### PR TITLE
docs: add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Snapshot
 
 > **This project is under construction.**
+
+Snapshot is a Kubernetes operator that checkpoints and restores NVIDIA GPU workload pods.
+
+## What problem it solves
+
+Starting a GPU inference workload from scratch takes time. Loading model weights, warming kernels, and compiling graphs can take minutes — even for moderate-sized models. Snapshot captures a pod at its initialized, ready state and replays that state on any compatible node. Subsequent pods start in seconds rather than starting over.
+
+## How it works
+
+Two components work together. A central operator manages the checkpoint lifecycle: scheduling captures, tracking artifacts, and coordinating restores. A per-node agent DaemonSet runs the actual work on each GPU node — it quiesces the target container, uses CRIU (Checkpoint/Restore in Userspace) and NVIDIA's `cuda-checkpoint` to dump process and GPU memory state to storage, and replays that state into a new pod on restore.
+
+## Status
+
+The project is in early development. API types and control plane components are scaffolded but not feature-complete. Not ready for production use.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Snapshot is a Kubernetes operator that checkpoints and restores NVIDIA GPU workl
 
 ## What problem it solves
 
-Starting a GPU inference workload from scratch takes time. Loading model weights, warming kernels, and compiling graphs can take minutes — even for moderate-sized models. Snapshot captures a pod at its initialized, ready state and replays that state on any compatible node. Subsequent pods start in seconds rather than starting over.
+Starting a GPU inference workload from scratch takes time. Loading model weights, warming kernels, and compiling graphs can take minutes, even for moderate-sized models. Snapshot captures a pod at its initialized, ready state and replays that state on any compatible node. Subsequent pods start in seconds rather than starting over.
 
 ## How it works
 
-Two components work together. A central operator manages the checkpoint lifecycle: scheduling captures, tracking artifacts, and coordinating restores. A per-node agent DaemonSet runs the actual work on each GPU node — it quiesces the target container, uses CRIU (Checkpoint/Restore in Userspace) and NVIDIA's `cuda-checkpoint` to dump process and GPU memory state to storage, and replays that state into a new pod on restore.
+Two components work together. A central operator manages the checkpoint lifecycle: scheduling captures, tracking artifacts, and coordinating restores. A per-node agent DaemonSet runs the actual work on each GPU node, quiescing the target container and using CRIU (Checkpoint/Restore in Userspace) and NVIDIA's `cuda-checkpoint` to dump process and GPU memory state to storage, then replaying that state into a new pod on restore.
 
 ## Status
 


### PR DESCRIPTION
Replaces the 3-line stub with a focused README covering what Snapshot is, the cold-start problem it solves, and how the operator and agent work together.

Still under construction notice is kept prominent at the top.