### PR TITLE
fix: move NVIDIA copyright to top of LICENSE, restore APPENDIX placeholder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +188,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Add `Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.` as the first line of `LICENSE`, above the Apache License header
- Restore the APPENDIX example copyright to the generic placeholder `Copyright [yyyy] [name of copyright owner]`

Requested by OSRB compliance review (comment #10, 2026-07-20). All other compliance items (CONTRIBUTING.md, source headers, third-party handling) already passed.

## Test plan

- [ ] Verify `LICENSE` line 1 is the NVIDIA copyright
- [ ] Verify APPENDIX placeholder is the generic form