### PR TITLE
ci: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Docs: https://docs.coderabbit.ai/getting-started/configure-coderabbit/
+
+version: "2"
+language: "en-US"
+early_access: false
+
+tone_instructions: "Production infrastructure software. Be direct. Flag backward-incompatibility, security implications, resource leaks, and RBAC over-permissions without softening."
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  estimate_code_review_effort: true
+  abort_on_close: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    base_branches:
+      - main
+    ignore_title_keywords:
+      - "wip"
+      - "draft"
+      - "do not merge"
+      - "dnm"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"
+
+  suggested_labels: false
+  suggested_reviewers: false
+  sequence_diagrams: false
+  related_issues: false
+  related_prs: false
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+  pre_merge_checks:
+    title:
+      mode: "warning"
+      requirements: "Must follow conventional commits: feat/fix/chore/docs/refactor/test/ci. First line under 72 chars."
+    custom_checks:
+      - name: "Breaking API Changes"
+        mode: "error"
+        instructions: "Fail if api/** removes, renames, or changes the type of any existing exported field without an API version bump."
+      - name: "RBAC Least Privilege"
+        mode: "warning"
+        instructions: "Warn if any kubebuilder RBAC marker or Helm RBAC manifest grants wildcard verbs ('*') or resources ('*') without an explicit justification comment."
+
+  path_filters:
+    - "!**/zz_generated*.go"
+    - "!charts/snapshot/crds/**"
+    - "!**/vendor/**"
+    - "!**/go.sum"
+    - "!**/*.pb.go"
+
+  path_instructions:
+    - path: "api/**"
+      instructions: "Review against .ai/api-contract-guidelines.md and .ai/go-guidelines.md"
+    - path: "operator/**"
+      instructions: "Review against .ai/k8s-operator-guidelines.md and .ai/go-guidelines.md"
+    - path: "agent/**"
+      instructions: "Review against .ai/agent-guidelines.md and .ai/go-guidelines.md"
+    - path: "charts/**"
+      instructions: "Review against .ai/k8s-operator-guidelines.md (Helm chart section). Flag missing resource limits/requests, wildcard RBAC verbs or resources, and missing standard app.kubernetes.io/* labels."
+    - path: ".github/workflows/**"
+      instructions: "Flag any job that skips the full 'make check' gate or bypasses golangci-lint/govulncheck. Flag new secrets not stored in GitHub Actions secrets."
+    - path: "**/*_test.go"
+      instructions: "Review against .ai/go-guidelines.md (testing section). Flag constants used in test assertions — must be string literals."
+
+tools:
+  golangci-lint:
+    enabled: true
+  semgrep:
+    enabled: true
+  gitleaks:
+    enabled: true
+  checkov:
+    enabled: true
+  trivy:
+    enabled: true
+  yamllint:
+    enabled: true
+  shellcheck:
+    enabled: true
+  hadolint:
+    enabled: true
+  actionlint:
+    enabled: true
+  markdownlint:
+    enabled: true
+  checkmake:
+    enabled: true
+  osvScanner:
+    enabled: true
+  helm:
+    enabled: true
+  buf:
+    enabled: false
+  eslint:
+    enabled: false
+  ruff:
+    enabled: false
+  pylint:
+    enabled: false
+  flake8:
+    enabled: false
+  rubocop:
+    enabled: false
+  phpstan:
+    enabled: false
+  clippy:
+    enabled: false
+  detekt:
+    enabled: false
+  swiftlint:
+    enabled: false
+
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - ".ai/**/*.md"
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -51,13 +51,14 @@ reviews:
       enabled: false
 
   pre_merge_checks:
+    override_requested_reviewers_only: true
     title:
       mode: "warning"
       requirements: "Must follow conventional commits: feat/fix/chore/docs/refactor/test/ci. First line under 72 chars."
     custom_checks:
       - name: "Breaking API Changes"
         mode: "warning"
-        instructions: "Warn if api/** removes, renames, changes the Go type of, or renames the json tag on any existing exported field. Also flag new fields missing // +optional or a CEL default — required fields break existing stored CRs. Flag changes to XValidation immutability markers on PodSnapshotSpec or PodSnapshotContentSpec."
+        instructions: "Warn if api/** removes, renames, changes the Go type of, or adds/renames/removes the json tag on any existing exported field. Flag new fields missing // +optional or a +kubebuilder:default marker — required fields without a default break existing stored CRs. Flag changes to XValidation immutability markers on PodSnapshotSpec or PodSnapshotContentSpec."
       - name: "RBAC Least Privilege"
         mode: "warning"
         instructions: "Warn if any kubebuilder RBAC marker or Helm RBAC manifest grants wildcard verbs ('*') or resources ('*') without an explicit justification comment."

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -51,7 +51,7 @@ reviews:
       enabled: false
 
   pre_merge_checks:
-    override_requested_reviewers_only: true
+    override_requested_reviewers_only: false
     title:
       mode: "warning"
       requirements: "Must follow conventional commits: feat/fix/chore/docs/refactor/test/ci. First line under 72 chars."

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,7 +24,7 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 10
+    auto_pause_after_reviewed_commits: 0
     base_branches:
       - main
     ignore_title_keywords:
@@ -57,7 +57,7 @@ reviews:
     custom_checks:
       - name: "Breaking API Changes"
         mode: "warning"
-        instructions: "Fail if api/** removes, renames, or changes the type of any existing exported field without an API version bump."
+        instructions: "Warn if api/** removes, renames, changes the Go type of, or renames the json tag on any existing exported field. Also flag new fields missing // +optional or a CEL default — required fields break existing stored CRs. Flag changes to XValidation immutability markers on PodSnapshotSpec or PodSnapshotContentSpec."
       - name: "RBAC Least Privilege"
         mode: "warning"
         instructions: "Warn if any kubebuilder RBAC marker or Helm RBAC manifest grants wildcard verbs ('*') or resources ('*') without an explicit justification comment."

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -40,7 +40,7 @@ reviews:
 
   suggested_labels: false
   suggested_reviewers: false
-  sequence_diagrams: false
+  sequence_diagrams: true
   related_issues: false
   related_prs: false
 
@@ -56,7 +56,7 @@ reviews:
       requirements: "Must follow conventional commits: feat/fix/chore/docs/refactor/test/ci. First line under 72 chars."
     custom_checks:
       - name: "Breaking API Changes"
-        mode: "error"
+        mode: "warning"
         instructions: "Fail if api/** removes, renames, or changes the type of any existing exported field without an API version bump."
       - name: "RBAC Least Privilege"
         mode: "warning"
@@ -70,18 +70,10 @@ reviews:
     - "!**/*.pb.go"
 
   path_instructions:
-    - path: "api/**"
-      instructions: "Review against .ai/api-contract-guidelines.md and .ai/go-guidelines.md"
-    - path: "operator/**"
-      instructions: "Review against .ai/k8s-operator-guidelines.md and .ai/go-guidelines.md"
-    - path: "agent/**"
-      instructions: "Review against .ai/agent-guidelines.md and .ai/go-guidelines.md"
     - path: "charts/**"
-      instructions: "Review against .ai/k8s-operator-guidelines.md (Helm chart section). Flag missing resource limits/requests, wildcard RBAC verbs or resources, and missing standard app.kubernetes.io/* labels."
+      instructions: "Flag missing resource limits/requests on containers, wildcard RBAC verbs or resources, and missing standard app.kubernetes.io/* labels."
     - path: ".github/workflows/**"
       instructions: "Flag any job that skips the full 'make check' gate or bypasses golangci-lint/govulncheck. Flag new secrets not stored in GitHub Actions secrets."
-    - path: "**/*_test.go"
-      instructions: "Review against .ai/go-guidelines.md (testing section). Flag constants used in test assertions — must be string literals."
 
 tools:
   golangci-lint:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,7 +24,7 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 5
+    auto_pause_after_reviewed_commits: 10
     base_branches:
       - main
     ignore_title_keywords:


### PR DESCRIPTION
## Summary

Adds `.coderabbit.yaml` to enable automated CodeRabbit review on all PRs targeting `main`.

**Key choices:**
- `profile: assertive` — full coverage, no softening
- `auto_incremental_review: true` — re-reviews on each push
- Path-specific instructions per module (api, operator, agent, charts, CI, tests)
- Explicit tool enablement: golangci-lint, semgrep, gitleaks, checkov, trivy, yamllint, shellcheck, hadolint, actionlint, helm, markdownlint, checkmake, osvScanner
- `pre_merge_checks` with custom rules for breaking API changes and wildcard RBAC
- Generated files excluded from review (`zz_generated*.go`, CRD YAML)

Knowledge-base guideline files (`.ai/*.md`) will follow in a separate PR once content is verified against the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a complete automated review configuration to standardize review tone and behaviors (including incremental review handling and draft/WIP bypass rules).
  * Enabled production-focused pre-merge checks across Go, YAML, shell, and CI/security scanning, with exclusions for generated/vendor/protobuf-adjacent artifacts.
  * Introduced custom warnings to flag breaking API changes and RBAC least-privilege violations.
  * Applied targeted guidance for charts and workflow files, including required resource labeling and secret-handling/workflow gating rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->