### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Snapshot exposes checkpoint and restore as Kubernetes resources.
 #### Capture
 
 To create a snapshot, a caller identifies the pod to checkpoint. Snapshot pauses the running process and captures its complete execution state, including both CPU memory and GPU memory, into a persistent artifact.
-This artifact is not a container image,a filesystem snapshot, or a volume snapshot. Instead, it represents the complete in-memory state of a live, fully initialized GPU worker.
+This artifact is not a container image, a filesystem snapshot, or a volume snapshot. Instead, it represents the complete in-memory state of a live, fully initialized GPU worker.
 
 #### Restore
 
@@ -37,7 +37,7 @@ Snapshots are portable across compatible machines and can be restored on any nod
 | Resource | Scope | Role |
 |----------|-------|------|
 | `PodSnapshot` | Namespaced | Created by callers to request a capture or reference an artifact for restore. |
-| `PodSnapshotContent` | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapashot operator, never by the caller. |
+| `PodSnapshotContent` | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapshot operator, never by the caller. |
 | `nvidia.com/restore-from` | Namespaced | Added as a pod annotation to trigger restore from a named `PodSnapshot` in the same namespace. |
 
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,90 @@
 
 > **This project is under construction.**
 
-Snapshot is a Kubernetes operator that checkpoints and restores NVIDIA GPU workload pods.
 
-## The cold-start problem
+Snapshot is a Kubernetes-native checkpoint and restore system for NVIDIA GPU workloads.
+It enables AI frameworks and platforms to capture a fully initialized GPU worker and restore that state on any compatible node, allowing new pods to become ready in seconds instead of minutes.
 
-GPU inference workers are expensive to start. Before a worker can serve a single request, it must load large model weights onto GPU memory, warm up execution kernels, and compile computation graphs. On large models this can take several minutes. Every new replica, every pod restart, and every scale-up event pays that initialization cost from scratch.
+Snapshot focuses on one responsibility: reliably capturing and restoring running GPU workloads. Higher-level decisions - such as which workloads to checkpoint, when to create snapshots, or when to restore them - are left to the systems integrating with Snapshot.
 
-## How Snapshot addresses it
 
-Snapshot captures a running GPU pod at its initialized, ready state, saving both CPU process memory and GPU memory to persistent storage. When a new pod is needed, the Snapshot agent replays that artifact directly, bypassing initialization entirely. What took minutes takes seconds. The checkpoint can be restored on any node with a matching GPU architecture and CUDA environment, so replicas are not bound to the node where the original pod ran.
+## Why Snapshot?
 
-## How it works
+GPU inference workers are expensive to start. Before serving a single request, a worker typically needs to load large model weights into GPU memory, initialize CUDA and other runtime libraries, warm up execution kernels, and compile or optimize computation graphs.
 
-Snapshot deploys as two components. A cluster-wide operator manages the checkpoint lifecycle: it coordinates when to capture a pod, tracks the artifact as it is written, and marks the result ready for restore. A per-node agent DaemonSet performs the actual capture and restore work on each GPU node, using CRIU (Checkpoint/Restore in Userspace) and NVIDIA's `cuda-checkpoint` to dump and replay both CPU process state and GPU memory.
+For large models, this initialization can take several minutes. Every new replica, pod restart, reschedule, or scale-up event repeats the entire process, paying that cost from scratch.
+Snapshot eliminates most of this overhead by restoring a previously initialized worker instead of starting a new one.
+
+## How it Works
+
+Snapshot exposes checkpoint and restore as Kubernetes resources.
+
+#### Capture
+
+To create a snapshot, a caller identifies the pod to checkpoint. Snapshot pauses the running process and captures its complete execution state, including both CPU memory and GPU memory, into a persistent artifact.
+This artifact is not a container image,a filesystem snapshot, or a volume snapshot. Instead, it represents the complete in-memory state of a live, fully initialized GPU worker.
+
+#### Restore
+
+To restore a worker, a new pod references a previously captured snapshot artifact. During pod startup, Snapshot restores the captured process state directly into the container, bypassing model loading, kernel warm-up, and other initialization steps. The restored process resumes execution from the exact point where it was captured.
+Snapshots are portable across compatible machines and can be restored on any node with matching GPU hardware and driver versions. They are not tied to the node where they were originally created.
+
+
+
+
+## APIs
+| Resource | Scope | Role |
+|----------|-------|------|
+| `PodSnapshot` | Namespaced | Created by callers to request a capture or reference an artifact for restore. |
+| `PodSnapshotContent` | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapashot operator, never by the caller. |
+| `nvidia.com/restore-from` | Namespaced | Added as a pod annotation to trigger restore from a named `PodSnapshot` in the same namespace. |
+
+
+
+## Architecture
+
+Snapshot consists of two main components.
+
+#### Operator
+
+The Kubernetes operator manages the control plane.
+
+It is responsible for:
+
+* Orchestrating checkpoint and restore operations.
+* Tracking snapshot lifecycle.
+* Exposing status through Kubernetes resources.
+* Managing cleanup.
+
+
+#### Node Agent
+
+A privileged node agent runs on every GPU node.
+
+It performs the actual checkpoint and restore operations by invoking CRIU and cuda-checkpoint against live processes.
+
+The node agent is intentionally an implementation detail. Clients never communicate with it directly.
+
+## Design Principles
+
+Snapshot owns the mechanics of checkpoint and restore—not the policy.
+
+Systems integrating with Snapshot decide:
+
+* Which workloads should be checkpointed.
+* When snapshots should be created.
+* When they should be restored.
+* How failures should be handled.
+
+Snapshot executes those requests and exposes the resulting state.
+
+Everything Snapshot manages is represented as Kubernetes resources. Snapshot metadata, capture progress, restore status, and lifecycle information are all observable through the Kubernetes API using standard Kubernetes tooling.
+
+Clients interact exclusively through the Kubernetes API. No platform-specific APIs, direct node communication, or custom protocols are required.
+
+
 
 ## Status
 
 The project is in early development. API types and control plane components are scaffolded but not yet feature-complete. Not ready for production use.
+

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ This artifact is not a container image, a filesystem snapshot, or a volume snaps
 To restore a worker, a new pod references a previously captured snapshot artifact. During pod startup, Snapshot restores the captured process state directly into the container, bypassing model loading, kernel warm-up, and other initialization steps. The restored process resumes execution from the exact point where it was captured.
 Snapshots are portable across compatible machines and can be restored on any node with matching GPU hardware and driver versions. They are not tied to the node where they were originally created.
 
-
-
+&nbsp;
 
 ## APIs
 | Resource | Scope | Role |
@@ -40,6 +39,7 @@ Snapshots are portable across compatible machines and can be restored on any nod
 | `PodSnapshotContent` | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapshot operator, never by the caller. |
 | `nvidia.com/restore-from` | Namespaced | Added as a pod annotation to trigger restore from a named `PodSnapshot` in the same namespace. |
 
+&nbsp;
 
 
 ## Architecture
@@ -66,6 +66,8 @@ It performs the actual checkpoint and restore operations by invoking CRIU and cu
 
 The node agent is intentionally an implementation detail. Clients never communicate with it directly.
 
+&nbsp;
+
 ## Design Principles
 
 Snapshot owns the mechanics of checkpoint and restore—not the policy.
@@ -83,7 +85,7 @@ Everything Snapshot manages is represented as Kubernetes resources. Snapshot met
 
 Clients interact exclusively through the Kubernetes API. No platform-specific APIs, direct node communication, or custom protocols are required.
 
-
+&nbsp;
 
 ## Status
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the README with a new “Snapshot” overview and “Why Snapshot?” section for Kubernetes-native checkpoint/restore of NVIDIA GPU workloads.
  * Restructured “How it Works” into “Capture” and “Restore,” clarifying that Capture records CPU/GPU in-memory state into a persistent artifact and Restore restores it during pod startup.
  * Added an “APIs” section covering `PodSnapshot`, `PodSnapshotContent`, and the `nvidia.com/restore-from` pod annotation for same-namespace restores.
  * Updated “Architecture” to describe Operator vs. Node Agent responsibilities and revised design principles/status messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->