### PR TITLE
fix: re-sync restore, overlay, and sidecar fixes from Dynamo

### DIFF
--- a/agent/internal/criu/restore.go
+++ b/agent/internal/criu/restore.go
@@ -33,55 +33,69 @@ func ExecuteRestore(
 	m *types.CheckpointManifest,
 	checkpointPath string,
 	log logr.Logger,
-) (int32, error) {
+) (int32, func(), error) {
 	settings := m.CRIUDump.CRIU
+
+	// Return the FD closers as cleanup() rather than deferring them here, so the
+	// caller can run them after cuda unlock instead of between the CRIU restore
+	// and unlock. That keeps the window where the restored process runs with CUDA
+	// still locked as short as possible. cleanup is called on the error paths below.
+	var openFiles, inheritedFiles []*os.File
+	cleanup := func() {
+		closeFiles(inheritedFiles)
+		closeFiles(openFiles)
+	}
 
 	// Open image dir FD
 	imageDir, imageDirFD, err := openPathForCRIU(checkpointPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open image directory: %w", err)
+		return 0, nil, fmt.Errorf("failed to open image directory: %w", err)
 	}
-	defer imageDir.Close()
+	openFiles = append(openFiles, imageDir)
 	criuOpts.ImagesDirFd = proto.Int32(imageDirFD)
 
 	// Open work dir FD
 	if settings.WorkDir != "" {
 		if err := os.MkdirAll(settings.WorkDir, 0755); err != nil {
-			return 0, fmt.Errorf("failed to create CRIU work directory: %w", err)
+			cleanup()
+			return 0, nil, fmt.Errorf("failed to create CRIU work directory: %w", err)
 		}
 		workDirFile, workDirFD, err := openPathForCRIU(settings.WorkDir)
 		if err != nil {
-			return 0, fmt.Errorf("failed to open CRIU work directory: %w", err)
+			cleanup()
+			return 0, nil, fmt.Errorf("failed to open CRIU work directory: %w", err)
 		}
-		defer workDirFile.Close()
+		openFiles = append(openFiles, workDirFile)
 		criuOpts.WorkDirFd = proto.Int32(workDirFD)
 	}
 
 	c := criulib.MakeCriu()
 	if _, err := os.Stat(settings.BinaryPath); err != nil {
-		return 0, fmt.Errorf("criu binary not found at %s: %w", settings.BinaryPath, err)
+		cleanup()
+		return 0, nil, fmt.Errorf("criu binary not found at %s: %w", settings.BinaryPath, err)
 	}
 	c.SetCriuPath(settings.BinaryPath)
 
 	netNsFile, err := os.Open(netNsPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open net NS at %s: %w", netNsPath, err)
+		cleanup()
+		return 0, nil, fmt.Errorf("failed to open net NS at %s: %w", netNsPath, err)
 	}
-	defer netNsFile.Close()
+	openFiles = append(openFiles, netNsFile)
 	c.AddInheritFd("extNetNs", netNsFile)
 
-	inheritedFiles := registerInheritFDs(c, m.K8s.StdioFDs, log)
-	defer closeFiles(inheritedFiles)
+	inheritedFiles = registerInheritFDs(c, m.K8s.StdioFDs, log)
 
 	notify := &restoreNotify{log: log}
 	log.V(1).Info("Executing go-criu Restore call")
 	if err := c.Restore(criuOpts, notify); err != nil {
 		log.Error(err, "go-criu Restore returned error")
 		logging.LogRestoreErrors(checkpointPath, settings.WorkDir, log)
-		return 0, fmt.Errorf("CRIU restore failed: %w", err)
+		cleanup()
+		return 0, nil, fmt.Errorf("CRIU restore failed: %w", err)
 	}
 
-	return notify.restoredPID, nil
+	return notify.restoredPID, cleanup, nil
 }
 
 // BuildRestoreOpts assembles CriuOpts for a CRIU restore from the checkpoint manifest.

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -125,10 +125,14 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 
 	// CRIU restore
 	criuRestoreStart := time.Now()
-	restoredPID, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, log)
+	restoredPID, cleanup, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, log)
 	if err != nil {
 		return nil, 0, err
 	}
+	// Run the restore's FD cleanup at return, after cuda unlock and the
+	// restore-complete sentinel below, so nothing but the required PID resolve
+	// sits between the CRIU restore and unlock. Runs on any return, incl. errors.
+	defer cleanup()
 	timings.criuRestoreDuration = time.Since(criuRestoreStart)
 
 	cudaStart := time.Now()

--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -53,12 +53,31 @@ func GetOverlayUpperDir(pid int) (string, error) {
 }
 
 // CaptureRootfsDiff captures the overlay upperdir to a tar file.
+//
+// The archive is written to a temporary file first and renamed atomically on
+// success, so a partial or failed capture never leaves a corrupt archive at the
+// final path.
 func CaptureRootfsDiff(upperDir, checkpointDir string, exclusions types.OverlaySettings, bindMountDests []string) (string, error) {
 	if upperDir == "" {
 		return "", fmt.Errorf("upperdir is empty")
 	}
 
 	rootfsDiffPath := filepath.Join(checkpointDir, rootfsDiffFilename)
+
+	tmpFile, err := os.CreateTemp(checkpointDir, rootfsDiffFilename+".*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary rootfs diff: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to close temporary rootfs diff: %w", err)
+	}
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
 	tarArgs := []string{"--xattrs"}
 	for _, excl := range buildExclusions(exclusions) {
@@ -67,13 +86,26 @@ func CaptureRootfsDiff(upperDir, checkpointDir string, exclusions types.OverlayS
 	for _, dest := range bindMountDests {
 		tarArgs = append(tarArgs, "--exclude=."+dest)
 	}
-	tarArgs = append(tarArgs, "-C", upperDir, "-cf", rootfsDiffPath, ".")
+	tarArgs = append(tarArgs, "-C", upperDir, "-cf", tmpPath, ".")
 
 	cmd := exec.Command("tar", tarArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("tar failed: %w (output: %s)", err, string(output))
 	}
+
+	info, err := os.Stat(tmpPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat temporary rootfs diff: %w", err)
+	}
+	if info.Size() == 0 {
+		return "", fmt.Errorf("tar produced empty rootfs diff")
+	}
+
+	if err := os.Rename(tmpPath, rootfsDiffPath); err != nil {
+		return "", fmt.Errorf("failed to publish rootfs diff: %w", err)
+	}
+	tmpPath = ""
 
 	return rootfsDiffPath, nil
 }
@@ -123,8 +155,16 @@ func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
 // ApplyRootfsDiff extracts rootfs-diff.tar into the target root.
 func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
-	if _, err := os.Stat(rootfsDiffPath); os.IsNotExist(err) {
+	info, err := os.Stat(rootfsDiffPath)
+	if os.IsNotExist(err) {
 		log.V(1).Info("No rootfs-diff.tar, skipping")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stat rootfs diff: %w", err)
+	}
+	if info.Size() == 0 {
+		log.V(1).Info("rootfs-diff.tar is empty, skipping")
 		return nil
 	}
 

--- a/agent/internal/runtime/overlay_test.go
+++ b/agent/internal/runtime/overlay_test.go
@@ -147,6 +147,111 @@ func TestFindWhiteoutFiles(t *testing.T) {
 	}
 }
 
+func TestCaptureRootfsDiff(t *testing.T) {
+	t.Run("writes valid archive atomically", func(t *testing.T) {
+		upperDir := t.TempDir()
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(upperDir, "generated.txt"), []byte("runtime data"), 0644); err != nil {
+			t.Fatalf("write upperdir file: %v", err)
+		}
+
+		got, err := CaptureRootfsDiff(upperDir, checkpointDir, types.OverlaySettings{}, nil)
+		if err != nil {
+			t.Fatalf("CaptureRootfsDiff: %v", err)
+		}
+		want := filepath.Join(checkpointDir, rootfsDiffFilename)
+		if got != want {
+			t.Fatalf("got path %q, want %q", got, want)
+		}
+		info, err := os.Stat(want)
+		if err != nil {
+			t.Fatalf("stat rootfs diff: %v", err)
+		}
+		if info.Size() == 0 {
+			t.Fatal("rootfs diff should not be empty")
+		}
+		matches, err := filepath.Glob(filepath.Join(checkpointDir, rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob temp files: %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("temporary rootfs diff files were not cleaned up: %v", matches)
+		}
+
+		targetRoot := t.TempDir()
+		if err := ApplyRootfsDiff(checkpointDir, targetRoot, testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(targetRoot, "generated.txt"))
+		if err != nil {
+			t.Fatalf("read extracted file: %v", err)
+		}
+		if string(data) != "runtime data" {
+			t.Fatalf("extracted data = %q, want %q", string(data), "runtime data")
+		}
+	})
+
+	t.Run("failed capture does not publish partial archive", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		missingUpperDir := filepath.Join(t.TempDir(), "missing")
+
+		if _, err := CaptureRootfsDiff(missingUpperDir, checkpointDir, types.OverlaySettings{}, nil); err == nil {
+			t.Fatal("CaptureRootfsDiff should fail for missing upperdir")
+		}
+		if _, err := os.Stat(filepath.Join(checkpointDir, rootfsDiffFilename)); !os.IsNotExist(err) {
+			t.Fatalf("rootfs diff should not be published after failure, stat error: %v", err)
+		}
+		matches, err := filepath.Glob(filepath.Join(checkpointDir, rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob temp files: %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("temporary rootfs diff files were not cleaned up: %v", matches)
+		}
+	})
+}
+
+func TestApplyRootfsDiff(t *testing.T) {
+	t.Run("missing archive is no-op", func(t *testing.T) {
+		if err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+	})
+
+	t.Run("empty archive is no-op", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), nil, 0644); err != nil {
+			t.Fatalf("write empty rootfs diff: %v", err)
+		}
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+	})
+
+	t.Run("non-empty invalid archive fails", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), []byte("not a tar archive"), 0644); err != nil {
+			t.Fatalf("write invalid rootfs diff: %v", err)
+		}
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err == nil {
+			t.Fatal("ApplyRootfsDiff should fail for invalid non-empty archive")
+		}
+	})
+
+	t.Run("non-ENOENT stat error is propagated", func(t *testing.T) {
+		// Pass a regular file as checkpointPath so stat of
+		// checkpointPath/rootfs-diff.tar returns ENOTDIR, not ENOENT.
+		f, err := os.CreateTemp(t.TempDir(), "not-a-dir")
+		if err != nil {
+			t.Fatalf("create temp file: %v", err)
+		}
+		f.Close()
+		if err := ApplyRootfsDiff(f.Name(), t.TempDir(), testr.New(t)); err == nil {
+			t.Fatal("ApplyRootfsDiff should propagate non-ENOENT stat error")
+		}
+	})
+}
+
 func TestCaptureDeletedFiles(t *testing.T) {
 	t.Run("dir with whiteouts writes JSON and returns true", func(t *testing.T) {
 		upperDir := t.TempDir()

--- a/operator/internal/protocol/checkpoint.go
+++ b/operator/internal/protocol/checkpoint.go
@@ -39,6 +39,7 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	if podTemplate.Annotations == nil {
 		podTemplate.Annotations = map[string]string{}
 	}
+	podTemplate.Annotations = DisableCheckpointJobSidecarInjection(podTemplate.Annotations)
 	snapshotv1alpha1.ApplyCheckpointSourceMetadata(podTemplate.Labels, podTemplate.Annotations, opts.CheckpointID, opts.ArtifactVersion)
 	podTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
 	if opts.SeccompProfile != "" {
@@ -130,6 +131,29 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 		Type:             corev1.SeccompProfileTypeLocalhost,
 		LocalhostProfile: &profile,
 	}
+}
+
+const (
+	linkerdInjectAnnotation      = "linkerd.io/inject"
+	linkerdInjectDisabled        = "disabled"
+	istioSidecarInjectAnnotation = "sidecar.istio.io/inject"
+	istioSidecarInjectDisabled   = "false"
+)
+
+// DisableCheckpointJobSidecarInjection stamps sidecar opt-out annotations on a
+// pod annotation map. Checkpoint Jobs must complete when the target container
+// exits; an injected sidecar that outlives the checkpoint keeps the pod alive,
+// preventing Kubernetes from marking the Job complete.
+//
+// Mutates and returns the passed-in map. Allocates a new map when annotations
+// is nil; callers must use the returned value.
+func DisableCheckpointJobSidecarInjection(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[linkerdInjectAnnotation] = linkerdInjectDisabled
+	annotations[istioSidecarInjectAnnotation] = istioSidecarInjectDisabled
+	return annotations
 }
 
 // wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the

--- a/operator/internal/protocol/checkpoint_job_test.go
+++ b/operator/internal/protocol/checkpoint_job_test.go
@@ -171,6 +171,95 @@ func TestNewCheckpointJobWrapsTargetContainer(t *testing.T) {
 	}
 }
 
+func TestNewCheckpointJobDisablesServiceMeshInjection(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+	}{
+		{
+			name:        "no user annotations",
+			annotations: nil,
+		},
+		{
+			name: "pre-existing enabled injection overwritten",
+			annotations: map[string]string{
+				linkerdInjectAnnotation:      "enabled",
+				istioSidecarInjectAnnotation: "true",
+				"example.com/keep":           "keep-value",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var originalAnnotations map[string]string
+			if tc.annotations != nil {
+				originalAnnotations = make(map[string]string, len(tc.annotations))
+				for k, v := range tc.annotations {
+					originalAnnotations[k] = v
+				}
+			}
+
+			source := &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "main",
+						Command: []string{"python3"},
+					}},
+				},
+			}
+			if source.Annotations == nil {
+				source.Annotations = map[string]string{}
+			}
+			source.Annotations[snapshotv1alpha1.TargetContainersAnnotation] = "main"
+
+			job, err := NewCheckpointJob(source, CheckpointJobOptions{
+				Namespace:    "test-ns",
+				CheckpointID: "hash",
+				Name:         "test-job",
+			})
+			if err != nil {
+				t.Fatalf("NewCheckpointJob() error = %v", err)
+			}
+
+			got := job.Spec.Template.Annotations
+			if got[linkerdInjectAnnotation] != linkerdInjectDisabled {
+				t.Errorf("linkerd annotation = %q, want %q", got[linkerdInjectAnnotation], linkerdInjectDisabled)
+			}
+			if got[istioSidecarInjectAnnotation] != istioSidecarInjectDisabled {
+				t.Errorf("istio annotation = %q, want %q", got[istioSidecarInjectAnnotation], istioSidecarInjectDisabled)
+			}
+			if tc.annotations != nil {
+				if v, ok := tc.annotations["example.com/keep"]; ok && got["example.com/keep"] != v {
+					t.Errorf("user annotation lost: got %q, want %q", got["example.com/keep"], v)
+				}
+				// Source template must not be mutated.
+				for k, origV := range originalAnnotations {
+					if tc.annotations[k] != origV {
+						t.Errorf("source template mutated: key %q changed from %q to %q", k, origV, tc.annotations[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDisableCheckpointJobSidecarInjectionNilMap(t *testing.T) {
+	got := DisableCheckpointJobSidecarInjection(nil)
+	if got == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if got[linkerdInjectAnnotation] != linkerdInjectDisabled {
+		t.Errorf("linkerd annotation = %q, want %q", got[linkerdInjectAnnotation], linkerdInjectDisabled)
+	}
+	if got[istioSidecarInjectAnnotation] != istioSidecarInjectDisabled {
+		t.Errorf("istio annotation = %q, want %q", got[istioSidecarInjectAnnotation], istioSidecarInjectDisabled)
+	}
+}
+
 func TestNewCheckpointJobRequiresTargetAnnotation(t *testing.T) {
 	_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
## Summary
Ports three snapshot fixes that landed on Dynamo `upstream/main` after the initial migration (#7). Each is transformed to the standalone layout (SPDX headers, `ai-dynamo/snapshot/{agent,operator,api}` import paths); the sidecar constants live in the operator `protocol` package since they are operator-only and not part of the agent↔operator contract.

| Dynamo PR | Change | Files |
|---|---|---|
| #11777 | `ExecuteRestore` returns a cleanup closure so FD close runs after CUDA unlock | `agent/internal/criu/restore.go`, `executor/nsrestore.go` |
| #11883 | rootfs-diff.tar written atomically (temp + rename); empty archive handled as no-op | `agent/internal/runtime/overlay.go` (+ test) |
| #11396 | checkpoint Job pods opt out of linkerd/istio sidecar injection | `operator/internal/protocol/checkpoint.go` (+ test) |

## Out of scope
- containerd-v2 usage in `oci_containerd.go` — snapshot is intentionally ahead of upstream.
- DynamoCheckpoint-coupled files (`checkpoint_podsnapshot.go`, `gms_snapshot_gate.go`).
- SBOM/license Dockerfile overhaul (#11533) — needs the Dynamo compliance harness.

## Testing
- `go build` + `go vet` clean for the agent module (cross-compiled linux/amd64; runtime tests execute on Linux in CI).
- `go build` + `go test ./internal/protocol/...` pass for the operator module.
- CodeRabbit self-review: no findings on the changed source files.

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkpoint jobs now automatically disable Linkerd and Istio sidecar injection while preserving existing pod annotations.
  * Restore operations now retain required resources until restoration completes.

* **Bug Fixes**
  * Root filesystem snapshots are published safely, preventing incomplete archives.
  * Empty or missing filesystem snapshots are skipped during restoration.

* **Tests**
  * Added coverage for snapshot integrity, cleanup, error handling, and service-mesh annotation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->