### PR TITLE
ci: add release pipeline for Docker images and Helm chart

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -119,14 +119,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # --platform=linux/amd64: Dockerfile exits 1 on other arches
-      # --build-context=api=./api: go-base stage needs the api module
       - name: Build and push agent image
         timeout-minutes: 45
         run: |
           make docker-build-agent \
             TAGS="${{ needs.version.outputs.tags }}" \
             DOCKER_BUILD_ARGS="--platform=linux/amd64 \
-              --build-context=api=./api \
               --push \
               --cache-from=type=gha,scope=agent \
               --cache-to=type=gha,scope=agent,mode=max"
@@ -161,5 +159,5 @@ jobs:
           VERSION="${{ needs.version.outputs.version }}"
           helm package ./charts/snapshot \
             --version "${VERSION#v}" \
-            --app-version "${VERSION#v}"
+            --app-version "${VERSION}"
           helm push "./snapshot-${VERSION#v}.tgz" oci://ghcr.io/ai-dynamo/snapshot

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -48,11 +48,11 @@ jobs:
       - name: Compute version and tags
         id: compute
         env:
+          INPUT: ${{ inputs.version }}
           # Use the CI run's head SHA for dev builds, not GITHUB_SHA which may
           # have advanced to a later commit by the time this workflow fires.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
-          INPUT="${{ inputs.version }}"
           if [ -n "${INPUT}" ]; then
             echo "${INPUT}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
               || { echo "Invalid version tag: ${INPUT}" >&2; exit 1; }

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Push Artifacts
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.1.0)'
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override (leave empty for dev build)'
+        required: false
+        type: string
+
+concurrency:
+  group: push-artifacts-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  # Gate: skip all jobs if triggered by a failed CI run.
+  # All other jobs depend on this one, so they cascade-skip automatically.
+  version:
+    name: Compute version
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+      tags: ${{ steps.compute.outputs.tags }}
+      head_sha: ${{ steps.compute.outputs.head_sha }}
+    steps:
+      - name: Compute version and tags
+        id: compute
+        env:
+          # Use the CI run's head SHA for dev builds, not GITHUB_SHA which may
+          # have advanced to a later commit by the time this workflow fires.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          INPUT="${{ inputs.version }}"
+          if [ -n "${INPUT}" ]; then
+            echo "${INPUT}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
+              || { echo "Invalid version tag: ${INPUT}" >&2; exit 1; }
+            echo "version=${INPUT}" >> "$GITHUB_OUTPUT"
+            # Keep the v prefix in Docker tags (e.g. v0.1.0 latest).
+            # Push 'latest' only on explicit release builds, not dev snapshots.
+            echo "tags=${INPUT} latest" >> "$GITHUB_OUTPUT"
+          else
+            # The 'g' prefix prevents all-numeric SHAs from forming invalid semver.
+            VERSION="v0.0.0-g${HEAD_SHA:0:8}"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "tags=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+  # ── Operator image ──────────────────────────────────────────────────────────
+  build-operator:
+    name: Build and push operator image
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the exact commit that passed CI, not whatever is at HEAD now.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push operator image
+        run: |
+          make docker-build-operator \
+            TAGS="${{ needs.version.outputs.tags }}" \
+            DOCKER_BUILD_ARGS="--push \
+              --cache-from=type=gha,scope=operator \
+              --cache-to=type=gha,scope=operator,mode=max"
+
+  # ── Agent image (slow: CRIU from source + CUDA base) ────────────────────────
+  build-agent:
+    name: Build and push agent image
+    needs: version
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # --platform=linux/amd64: Dockerfile exits 1 on other arches
+      # --build-context=api=./api: go-base stage needs the api module
+      - name: Build and push agent image
+        timeout-minutes: 45
+        run: |
+          make docker-build-agent \
+            TAGS="${{ needs.version.outputs.tags }}" \
+            DOCKER_BUILD_ARGS="--platform=linux/amd64 \
+              --build-context=api=./api \
+              --push \
+              --cache-from=type=gha,scope=agent \
+              --cache-to=type=gha,scope=agent,mode=max"
+
+  # ── Helm chart (OCI push to GHCR) ──────────────────────────────────────────
+  release-helm:
+    name: Package and push Helm chart
+    needs: [version, build-operator, build-agent]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.head_sha }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint chart before packaging
+        run: helm lint ./charts/snapshot
+
+      - name: Log in to GHCR (Helm OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io \
+              --username "${{ github.actor }}" \
+              --password-stdin
+
+      # Chart.yaml on disk stays at dev values. Version is injected at package
+      # time. The values.yaml `tag: ""` fields resolve to appVersion in templates.
+      - name: Package and push Helm chart
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          helm package ./charts/snapshot \
+            --version "${VERSION#v}" \
+            --app-version "${VERSION#v}"
+          helm push "./snapshot-${VERSION#v}.tgz" oci://ghcr.io/ai-dynamo/snapshot

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -22,12 +22,10 @@ on:
         type: string
 
 concurrency:
-  group: push-artifacts-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: push-artifacts-${{ inputs.version || github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 jobs:
 
@@ -68,22 +66,51 @@ jobs:
           fi
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
+  validate:
+    name: Validate release commit
+    needs: version
+    permissions:
+      # Required to check out the selected release commit.
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.version.outputs.head_sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26.5"
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            go.work.sum
+
+      - name: Run full validation gate
+        run: make check
+
   # ── Operator image ──────────────────────────────────────────────────────────
   build-operator:
     name: Build and push operator image
-    needs: version
+    needs: [version, validate]
+    permissions:
+      # Checkout the validated source and publish its image to GHCR.
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       # Check out the exact commit that passed CI, not whatever is at HEAD now.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -100,19 +127,24 @@ jobs:
   # ── Agent image (slow: CRIU from source + CUDA base) ────────────────────────
   build-agent:
     name: Build and push agent image
-    needs: version
+    needs: [version, validate]
+    permissions:
+      # Checkout the validated source and publish its image to GHCR.
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -132,15 +164,20 @@ jobs:
   # ── Helm chart (OCI push to GHCR) ──────────────────────────────────────────
   release-helm:
     name: Package and push Helm chart
-    needs: [version, build-operator, build-agent]
+    needs: [version, validate, build-operator, build-agent]
+    permissions:
+      # Checkout the validated chart and publish it to GHCR.
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Lint chart before packaging
         run: helm lint ./charts/snapshot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,17 +7,18 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
-  packages: write
+permissions: {}
 
 jobs:
   push-artifacts:
     name: Push release artifacts
+    permissions:
+      # Let the called workflow read source and publish release artifacts.
+      contents: read
+      packages: write
     uses: ./.github/workflows/push-artifacts.yaml
     with:
       version: ${{ github.event.release.tag_name }}
-    secrets: inherit
 
   # Go module proxy requires sub-path tags for modules not at the repo root.
   # Without api/v0.1.0, operator/v0.1.0, agent/v0.1.0 — `go get` of any
@@ -25,9 +26,12 @@ jobs:
   go-module-tags:
     name: Create Go module sub-path tags
     needs: push-artifacts
+    permissions:
+      # Required to push immutable Go module tags after artifacts succeed.
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  push-artifacts:
+    name: Push release artifacts
+    uses: ./.github/workflows/push-artifacts.yaml
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit
+
+  # Go module proxy requires sub-path tags for modules not at the repo root.
+  # Without api/v0.1.0, operator/v0.1.0, agent/v0.1.0 — `go get` of any
+  # sub-module by version fails.
+  go-module-tags:
+    name: Create Go module sub-path tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Force-overwrite local tags and push individual refs so this step is
+      # idempotent on retries or re-published releases.
+      - name: Push sub-path tags
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          git tag -f "api/${TAG}"
+          git tag -f "operator/${TAG}"
+          git tag -f "agent/${TAG}"
+          git push --force origin "api/${TAG}" "operator/${TAG}" "agent/${TAG}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
   # sub-module by version fails.
   go-module-tags:
     name: Create Go module sub-path tags
+    needs: push-artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,15 +34,51 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Force-overwrite local tags and push individual refs so this step is
-      # idempotent on retries or re-published releases.
+      # Validate every existing tag before creating anything, then atomically
+      # push only missing tags. Published module versions are immutable.
       - name: Push sub-path tags
         env:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
             || { echo "Invalid tag: ${TAG}" >&2; exit 1; }
-          git tag -f "api/${TAG}"
-          git tag -f "operator/${TAG}"
-          git tag -f "agent/${TAG}"
-          git push --force origin "api/${TAG}" "operator/${TAG}" "agent/${TAG}"
+
+          release_commit="$(git rev-parse HEAD^{commit})"
+          missing_tags=()
+
+          for module in api operator agent; do
+            module_tag="${module}/${TAG}"
+            remote_refs="$(
+              git ls-remote origin \
+                "refs/tags/${module_tag}" \
+                "refs/tags/${module_tag}^{}"
+            )"
+
+            if [ -z "${remote_refs}" ]; then
+              missing_tags+=("${module_tag}")
+              continue
+            fi
+
+            remote_commit="$(
+              printf '%s\n' "${remote_refs}" |
+                awk '
+                  NR == 1 { first = $1 }
+                  $2 ~ /\^\{\}$/ { print $1; peeled = 1 }
+                  END { if (!peeled) print first }
+                '
+            )"
+            if [ "${remote_commit}" != "${release_commit}" ]; then
+              echo "Tag ${module_tag} already points to ${remote_commit}, not ${release_commit}" >&2
+              exit 1
+            fi
+          done
+
+          if [ "${#missing_tags[@]}" -eq 0 ]; then
+            echo "All Go module tags already point to ${release_commit}"
+            exit 0
+          fi
+
+          for module_tag in "${missing_tags[@]}"; do
+            git tag "${module_tag}" "${release_commit}"
+          done
+          git push --atomic origin "${missing_tags[@]}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,8 +36,11 @@ jobs:
       # Force-overwrite local tags and push individual refs so this step is
       # idempotent on retries or re-published releases.
       - name: Push sub-path tags
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
+            || { echo "Invalid tag: ${TAG}" >&2; exit 1; }
           git tag -f "api/${TAG}"
           git tag -f "operator/${TAG}"
           git tag -f "agent/${TAG}"

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ helm-lint: $(HELM)
 
 docker-build-agent:
 	docker buildx build $(DOCKER_BUILD_ARGS) -f agent/Dockerfile \
-	  $(foreach t,$(TAGS),-t $(REGISTRY)/agent:$(t)) .
+	  --build-context=api=./api --target agent \
+	  $(foreach t,$(TAGS),-t $(REGISTRY)/agent:$(t)) agent/
 
 docker-build-operator:
 	docker buildx build $(DOCKER_BUILD_ARGS) -f operator/Dockerfile \


### PR DESCRIPTION
## Summary

Adds a two-file GitHub Actions release pipeline (Grove pattern):

- **`push-artifacts.yaml`** — reusable workflow that builds and pushes both Docker images and the Helm chart as an OCI artifact to GHCR. Triggered on CI success on `main` (dev snapshots) and via `workflow_call`/`workflow_dispatch`.
- **`release.yaml`** — fires on `release: published`, calls `push-artifacts.yaml` with the release tag, and creates Go module sub-path tags (`api/v*`, `operator/v*`, `agent/v*`).

### Artifacts produced per release

| Artifact | Location |
|----------|----------|
| Operator image | `ghcr.io/ai-dynamo/snapshot/operator:v<version>` |
| Agent image | `ghcr.io/ai-dynamo/snapshot/agent:v<version>` |
| Helm chart (OCI) | `ghcr.io/ai-dynamo/snapshot/snapshot:<version>` |
| Go module tags | `api/v<version>`, `operator/v<version>`, `agent/v<version>` |

### To trigger a release

```bash
gh release create v0.0.1-alpha.1 --prerelease --title "v0.0.1-alpha.1" --notes "Pipeline smoke test"
```

## Test plan

- [ ] Merge to `main` → confirm `Push Artifacts` workflow fires after CI passes and pushes dev snapshot images
- [ ] Create `v0.0.1-alpha.1` pre-release → confirm all four artifact types are published
- [ ] `docker pull ghcr.io/ai-dynamo/snapshot/operator:v0.0.1-alpha.1`
- [ ] `docker pull ghcr.io/ai-dynamo/snapshot/agent:v0.0.1-alpha.1`
- [ ] `helm pull oci://ghcr.io/ai-dynamo/snapshot/snapshot --version 0.0.1-alpha.1`
- [ ] `git tag -l | grep alpha` shows `api/v0.0.1-alpha.1`, `operator/v0.0.1-alpha.1`, `agent/v0.0.1-alpha.1`

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated “Push Artifacts” workflow to publish container images (operator and agent) and the snapshot Helm chart to GHCR after successful CI or via manual/reusable triggers, including version computation and optional `latest` tagging.
  * Added a “Release” workflow that validates release tags and ensures Go module tags (`api`, `operator`, `agent`) point to the release commit, creating missing tags as needed.
* **Chores**
  * Enabled weekly Dependabot updates for GitHub Actions dependencies.
  * Updated the agent Docker Buildx command with the correct build context and target stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->