### PR TITLE
fix: align agent Docker Go version

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -16,7 +16,7 @@
 # Build Arguments
 # =============================================================================
 ARG DOCKER_PROXY
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.5
 # Default to upstream CRIU development branch. Custom forks can override both
 # args at build time, for example:
 #   --build-arg CRIU_REPO=<git-remote-url>


### PR DESCRIPTION
## Summary

- update the agent Docker builder from Go 1.26.3 to Go 1.26.5
- align the image build with agent/go.mod, go.work, and CI
- fix the failed agent publication in Actions run 30249192898

## Root cause

The agent Docker build ran go mod download with Go 1.26.3 while agent/go.mod requires Go 1.26.5. GOTOOLCHAIN=local prevented an automatic toolchain upgrade.

## Validation

- focused linux/amd64 Docker build through the builder target passed
- go mod download passed inside golang:1.26.5
- snapshot-agent and nsrestore compiled successfully
- complete agent image build passed, including CRIU and CUDA stages
- local image smoke test confirmed required binaries and CRIU 4.2.1
- git diff --check passed

Failing job: https://github.com/ai-dynamo/snapshot/actions/runs/30249192898/job/89923615920

Signed-off-by: Ron Kahn <rkahn@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Go toolchain to version 1.26.5 for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->