### PR TITLE
feat(chart): ship CRDs as templates so helm upgrade reapplies them

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -3,11 +3,20 @@ include $(REPO_HACK_DIR)/tools.mk
 
 .DEFAULT_GOAL := generate
 
+CRD_TEMPLATES := ../charts/snapshot/templates/crd
+
 .PHONY: generate fmt lint tidy test
 
 generate: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) object:headerFile=../hack/boilerplate.go.txt paths=./...
-	$(CONTROLLER_GEN) crd paths=./... output:crd:artifacts:config=../charts/snapshot/crds
+	$(CONTROLLER_GEN) crd paths=./... output:crd:artifacts:config=$(CRD_TEMPLATES)
+	@set -eu; for f in $(CRD_TEMPLATES)/*.yaml; do \
+		[ -e "$$f" ] || continue; \
+		{ echo '{{- if .Values.crds.enabled }}' && \
+		  awk '/^  name:/ && !l {print "  labels:"; print "    {{- include \"snapshot.labels\" . | nindent 4 }}"; l=1} {print} /^  annotations:$$/ && !d {print "    {{- if .Values.crds.keep }}"; print "    helm.sh/resource-policy: keep"; print "    {{- end }}"; d=1} END {if (!d || !l) exit 3}' "$$f" && \
+		  echo '{{- end }}'; } > "$$f.tmp" || { rm -f "$$f.tmp"; exit 1; }; \
+		mv "$$f.tmp" "$$f"; \
+	done
 
 fmt:
 	gofmt -w .

--- a/charts/snapshot/README.md
+++ b/charts/snapshot/README.md
@@ -114,9 +114,51 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=snapshot -o wide
 | `rbac.create` | Create agent and operator RBAC | `true` |
 | `rbac.namespaceRestricted` | Namespace-scoped agent RBAC (required for PVC storage) | `true` |
 | `openshift.enabled` | OpenShift RBAC / SCC-related chart pieces | `false` |
+| `crds.enabled` | Render the CRDs as chart templates (set false to manage them out-of-band) | `true` |
+| `crds.keep` | Add `helm.sh/resource-policy: keep` so uninstall does not delete the CRDs (set false to cascade-delete CRDs and their CRs on uninstall) | `true` |
 
 Reserved `s3` and `oci` values remain chart-owned placeholders for future
 snapshot backends, but only `pvc` is implemented today.
+
+## CRDs
+
+The CRDs render as ordinary chart templates (under `templates/crd/`), so
+`helm upgrade` reapplies the current schema — unlike Helm's `crds/` directory,
+which installs CRDs only on the first `helm install`. By default each CRD carries
+`helm.sh/resource-policy: keep` (`crds.keep=true`), so `helm uninstall` leaves the
+CRDs (and their custom resources) in place rather than cascade-deleting them. Set
+`crds.keep=false` to let uninstall remove the CRDs — which cascade-deletes every
+`PodSnapshot` / `PodSnapshotContent` in the cluster (objects that still hold
+finalizers may sit in `Terminating` until their controller releases them).
+
+They are single-version (`nvidia.com/v1alpha1`) with no conversion webhook, so
+schema changes must stay backward-compatible — the new schema is applied in place
+over the existing one.
+
+Set `crds.enabled=false` to manage the CRDs out-of-band. ArgoCD and similar GitOps
+controllers ignore `helm.sh/resource-policy` and apply/prune CRDs on their own, so
+those users should set `crds.enabled=false` and manage the CRDs in the GitOps tool.
+
+### Upgrading from a build that installed CRDs via `crds/`
+
+If a cluster already has these CRDs — from an earlier chart version that shipped
+them under `crds/`, or from another installer — the first templated `helm upgrade`
+fails with `invalid ownership metadata` because the existing CRDs are not owned by
+this release. Adopt them once before upgrading (or use `helm upgrade --take-ownership`
+where supported):
+
+```bash
+REL=snapshot; NS=<release-namespace>
+for c in podsnapshots.nvidia.com podsnapshotcontents.nvidia.com; do
+  kubectl label  crd "$c" app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl annotate crd "$c" \
+    meta.helm.sh/release-name="$REL" \
+    meta.helm.sh/release-namespace="$NS" --overwrite
+done
+```
+
+Fresh clusters need none of this. The same step applies if you later reinstall
+under a different release name (the kept CRD is again unowned by the new release).
 
 See [values.yaml](./values.yaml) for the full configuration surface.
 

--- a/charts/snapshot/templates/crd/nvidia.com_podsnapshotcontents.yaml
+++ b/charts/snapshot/templates/crd/nvidia.com_podsnapshotcontents.yaml
@@ -1,25 +1,35 @@
+{{- if .Values.crds.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
-  name: podsnapshots.nvidia.com
+  labels:
+    {{- include "snapshot.labels" . | nindent 4 }}
+  name: podsnapshotcontents.nvidia.com
 spec:
   group: nvidia.com
   names:
-    kind: PodSnapshot
-    listKind: PodSnapshotList
-    plural: podsnapshots
+    kind: PodSnapshotContent
+    listKind: PodSnapshotContentList
+    plural: podsnapshotcontents
     shortNames:
-    - podsnap
-    singular: podsnapshot
-  scope: Namespaced
+    - podsnapcontent
+    singular: podsnapshotcontent
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: Bound PodSnapshotContent
-      jsonPath: .status.boundSnapshotContentName
-      name: Content
+    - description: Bound PodSnapshot
+      jsonPath: .spec.snapshotRef.name
+      name: PodSnapshot
+      type: string
+    - description: PodSnapshot namespace
+      jsonPath: .spec.snapshotRef.namespace
+      name: Namespace
       type: string
     - description: Ready condition
       jsonPath: .status.conditions[?(@.type=='Ready')].status
@@ -32,8 +42,8 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          PodSnapshot is the Schema for the snapshots API. It is the namespaced binding
-          for a captured container checkpoint and is consumed by restore paths.
+          PodSnapshotContent is the Schema for the snapshotcontents API. It is the
+          cluster-scoped artifact-of-record for a captured container checkpoint.
 
           No conversion: this type exists only in v1alpha1 (no other API version), so it
           is not part of any conversion scheme.
@@ -56,18 +66,46 @@ spec:
           metadata:
             type: object
           spec:
-            description: PodSnapshotSpec defines the desired state of PodSnapshot.
+            description: |-
+              PodSnapshotContentSpec defines the desired state of PodSnapshotContent. It is
+              populated by the PodSnapshotReconciler (operator) at creation time and is
+              immutable thereafter.
             properties:
-              source:
+              snapshotRef:
                 description: |-
-                  Source identifies the captured workload. It is a struct (rather than an
-                  inlined reference) so future source variants can be added additively.
+                  PodSnapshotRef is the back-pointer to the bound PodSnapshot. It may span
+                  namespaces because PodSnapshotContent is cluster-scoped.
                 properties:
+                  name:
+                    description: Name of the referenced PodSnapshot.
+                    type: string
+                  namespace:
+                    description: Namespace of the referenced PodSnapshot.
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referenced PodSnapshot, recorded at binding time to detect a
+                      stale reference after a delete and recreate.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              source:
+                description: 'Source describes what to capture: the source pod and
+                  the node it runs on.'
+                properties:
+                  nodeName:
+                    description: |-
+                      NodeName is the node the source pod runs on, denormalized from the live
+                      pod so it travels with PodRef as one immutable unit and selects the node
+                      agent that performs the dump.
+                    minLength: 1
+                    type: string
                   podRef:
                     description: |-
-                      PodRef references the pod, in the PodSnapshot's namespace, that is captured.
-                      The operator prepares the pod (control volume, target-container annotation,
-                      checkpoint storage mount) before creating the PodSnapshot.
+                      PodRef identifies the pod to dump. Its UID guards against dumping a
+                      same-named recreation of the pod.
                     properties:
                       name:
                         description: Name of the source pod.
@@ -82,23 +120,19 @@ spec:
                     - name
                     type: object
                 required:
+                - nodeName
                 - podRef
                 type: object
             required:
+            - snapshotRef
             - source
             type: object
           status:
-            description: PodSnapshotStatus defines the observed state of PodSnapshot.
+            description: PodSnapshotContentStatus defines the observed state of PodSnapshotContent.
             properties:
-              boundSnapshotContentName:
-                description: |-
-                  BoundPodSnapshotContentName is the name of the cluster-scoped PodSnapshotContent
-                  this PodSnapshot is bound to. It is nil until the agent has created the
-                  content and recorded the binding.
-                type: string
               conditions:
                 description: |-
-                  Conditions reflect the latest observations of the PodSnapshot's state.
+                  Conditions reflect the latest observations of the PodSnapshotContent's state.
                   Standard types are Ready and Failed.
                 items:
                   description: Condition contains details for one aspect of the current
@@ -164,3 +198,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/snapshot/templates/crd/nvidia.com_podsnapshots.yaml
+++ b/charts/snapshot/templates/crd/nvidia.com_podsnapshots.yaml
@@ -1,29 +1,31 @@
+{{- if .Values.crds.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.19.0
-  name: podsnapshotcontents.nvidia.com
+  labels:
+    {{- include "snapshot.labels" . | nindent 4 }}
+  name: podsnapshots.nvidia.com
 spec:
   group: nvidia.com
   names:
-    kind: PodSnapshotContent
-    listKind: PodSnapshotContentList
-    plural: podsnapshotcontents
+    kind: PodSnapshot
+    listKind: PodSnapshotList
+    plural: podsnapshots
     shortNames:
-    - podsnapcontent
-    singular: podsnapshotcontent
-  scope: Cluster
+    - podsnap
+    singular: podsnapshot
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Bound PodSnapshot
-      jsonPath: .spec.snapshotRef.name
-      name: PodSnapshot
-      type: string
-    - description: PodSnapshot namespace
-      jsonPath: .spec.snapshotRef.namespace
-      name: Namespace
+    - description: Bound PodSnapshotContent
+      jsonPath: .status.boundSnapshotContentName
+      name: Content
       type: string
     - description: Ready condition
       jsonPath: .status.conditions[?(@.type=='Ready')].status
@@ -36,8 +38,8 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          PodSnapshotContent is the Schema for the snapshotcontents API. It is the
-          cluster-scoped artifact-of-record for a captured container checkpoint.
+          PodSnapshot is the Schema for the snapshots API. It is the namespaced binding
+          for a captured container checkpoint and is consumed by restore paths.
 
           No conversion: this type exists only in v1alpha1 (no other API version), so it
           is not part of any conversion scheme.
@@ -60,46 +62,18 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              PodSnapshotContentSpec defines the desired state of PodSnapshotContent. It is
-              populated by the PodSnapshotReconciler (operator) at creation time and is
-              immutable thereafter.
+            description: PodSnapshotSpec defines the desired state of PodSnapshot.
             properties:
-              snapshotRef:
-                description: |-
-                  PodSnapshotRef is the back-pointer to the bound PodSnapshot. It may span
-                  namespaces because PodSnapshotContent is cluster-scoped.
-                properties:
-                  name:
-                    description: Name of the referenced PodSnapshot.
-                    type: string
-                  namespace:
-                    description: Namespace of the referenced PodSnapshot.
-                    type: string
-                  uid:
-                    description: |-
-                      UID of the referenced PodSnapshot, recorded at binding time to detect a
-                      stale reference after a delete and recreate.
-                    type: string
-                required:
-                - name
-                - namespace
-                type: object
               source:
-                description: 'Source describes what to capture: the source pod and
-                  the node it runs on.'
+                description: |-
+                  Source identifies the captured workload. It is a struct (rather than an
+                  inlined reference) so future source variants can be added additively.
                 properties:
-                  nodeName:
-                    description: |-
-                      NodeName is the node the source pod runs on, denormalized from the live
-                      pod so it travels with PodRef as one immutable unit and selects the node
-                      agent that performs the dump.
-                    minLength: 1
-                    type: string
                   podRef:
                     description: |-
-                      PodRef identifies the pod to dump. Its UID guards against dumping a
-                      same-named recreation of the pod.
+                      PodRef references the pod, in the PodSnapshot's namespace, that is captured.
+                      The operator prepares the pod (control volume, target-container annotation,
+                      checkpoint storage mount) before creating the PodSnapshot.
                     properties:
                       name:
                         description: Name of the source pod.
@@ -114,19 +88,23 @@ spec:
                     - name
                     type: object
                 required:
-                - nodeName
                 - podRef
                 type: object
             required:
-            - snapshotRef
             - source
             type: object
           status:
-            description: PodSnapshotContentStatus defines the observed state of PodSnapshotContent.
+            description: PodSnapshotStatus defines the observed state of PodSnapshot.
             properties:
+              boundSnapshotContentName:
+                description: |-
+                  BoundPodSnapshotContentName is the name of the cluster-scoped PodSnapshotContent
+                  this PodSnapshot is bound to. It is nil until the agent has created the
+                  content and recorded the binding.
+                type: string
               conditions:
                 description: |-
-                  Conditions reflect the latest observations of the PodSnapshotContent's state.
+                  Conditions reflect the latest observations of the PodSnapshot's state.
                   Standard types are Ready and Failed.
                 items:
                   description: Condition contains details for one aspect of the current
@@ -192,3 +170,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -146,6 +146,18 @@ rbac:
   # Note: PVC storage requires namespace-scoped mode (true) as PVCs are namespace-scoped
   namespaceRestricted: true
 
+# CRD lifecycle. The CRDs render as chart templates (under templates/crd/) so
+# `helm upgrade` reapplies the current schema; Helm's crds/ directory would only
+# install them on first install.
+crds:
+  # Render the CRDs with the chart. Set false to manage them out-of-band (e.g. a
+  # GitOps controller applies the CRDs itself).
+  enabled: true
+  # Add helm.sh/resource-policy: keep so `helm uninstall` leaves the CRDs (and the
+  # custom resources) in place. Set false to let uninstall delete the CRDs, which
+  # cascade-deletes every PodSnapshot / PodSnapshotContent in the cluster.
+  keep: true
+
 # Static agent configuration (loaded from ConfigMap)
 # Dynamic values (NODE_NAME, RESTRICTED_NAMESPACE, etc.) come from environment variables
 config:


### PR DESCRIPTION
## What

Helm installs CRDs from the special `crds/` directory only on the first `helm install` and never reapplies them on `helm upgrade`. This renders the two CRDs (`podsnapshots.nvidia.com`, `podsnapshotcontents.nvidia.com`) as **ordinary chart templates** under `templates/crd/`, so `helm upgrade` reapplies the current schema natively — the pattern used by cert-manager, Argo CD, Kubeflow Trainer, and Istio.

Supersedes the earlier pre-hook kubectl Job approach (removed): no more Job, ConfigMap, ClusterRole, or in-cluster kubectl image.

## How

- CRDs live in `charts/snapshot/templates/crd/`. controller-gen (in `api/Makefile`'s `generate`) writes them there; a wrap step guards each with `{{- if .Values.crds.enabled }}` and injects a conditional `helm.sh/resource-policy: keep` annotation. The wrap is deterministic (`make generate` stays diff-clean).
- New values:
  - `crds.enabled` (default `true`) — render the CRDs with the chart; set `false` to manage them out-of-band (GitOps).
  - `crds.keep` (default `true`) — add `helm.sh/resource-policy: keep` so uninstall does not cascade-delete the CRDs and their CRs; set `false` to let uninstall remove them.

## ⚠️ Breaking values change

The pre-hook Job's values are removed: **`crds.upgrade.*`** and **`image.kubectl`** no longer exist. New surface is `crds.enabled` / `crds.keep`.

## Migration

On a cluster that already has these CRDs (an earlier `crds/`-based build, or another installer), the first templated `helm upgrade` fails with `invalid ownership metadata` until the CRDs are adopted into the release. One-time fix (or `helm upgrade --take-ownership`), documented in the chart README:

```bash
REL=snapshot; NS=<release-namespace>
for c in podsnapshots.nvidia.com podsnapshotcontents.nvidia.com; do
  kubectl label  crd "$c" app.kubernetes.io/managed-by=Helm --overwrite
  kubectl annotate crd "$c" meta.helm.sh/release-name="$REL" meta.helm.sh/release-namespace="$NS" --overwrite
done
```

Fresh clusters need nothing.

## Testing

`make generate` (deterministic, clean tree), `make helm-lint` (pinned v3.17.3) + `helm template` assertions. Multi-version kind e2e on **v1.28.15 / v1.31.6 / v1.33.1**:
- install → both CRDs Established, `keep` annotation present, CEL `x-kubernetes-validations` survived (across all three versions)
- `helm upgrade` with an evolved schema → CRD reflects the change (native reapply)
- `crds.keep=true` → uninstall keeps CRDs; `crds.keep=false` → uninstall deletes them
- `crds.enabled=false` → no CRDs rendered
- adoption: pre-existing unowned CRD → install fails with the ownership error → annotate/label → install succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `crds.enabled` to control whether CRDs are rendered by the chart during `helm upgrade`.
  * Added `crds.keep` to optionally mark CRDs with `helm.sh/resource-policy: keep`, preventing deletion on uninstall.
* **Documentation**
  * Expanded the chart README with CRD configuration details and an adoption/migration procedure for installations that already have CRDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->