### PR TITLE
style: gofmt operator manager main.go

### DIFF
--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -34,8 +34,8 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		HealthProbeBindAddress: ":8081",
+		Scheme:                        scheme,
+		HealthProbeBindAddress:        ":8081",
 		LeaderElection:                true,
 		LeaderElectionID:              "snapshot-operator.nvidia.com",
 		LeaderElectionReleaseOnCancel: true,


### PR DESCRIPTION
`make check` (`gofmt -w`) reformats `operator/cmd/manager/main.go` on `main`, leaving the tree dirty and failing the `check` job on every PR's merge-check.

The leader-election fields added in #28 introduced a longer struct key (`LeaderElectionReleaseOnCancel`) without re-aligning the existing `Scheme` / `HealthProbeBindAddress` values. This applies the gofmt alignment (Go 1.26.5).

Whitespace-only; no behavior change. Unblocks `check` for all open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and alignment of manager initialization settings.
  * No changes to runtime behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->