### PR TITLE
Temporary debug workflow for prod-deploy-tester-v1

### DIFF
--- a/.github/workflows/debug-dynamo-runner.yml
+++ b/.github/workflows/debug-dynamo-runner.yml
@@ -15,7 +15,7 @@ jobs:
   tmate:
     name: tmate on prod-deploy-tester-v1
     runs-on: prod-deploy-tester-v1
-    timeout-minutes: 60
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/debug-dynamo-runner.yml
+++ b/.github/workflows/debug-dynamo-runner.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Debug Dynamo Runner
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  tmate:
+    name: tmate on prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Runner preflight
+        run: |
+          hostname
+          uname -a
+          id
+          pwd
+          df -h
+          command -v kubectl || true
+          kubectl config current-context || true
+          kubectl get nodes -o wide || true
+          nvidia-smi || true
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true


### PR DESCRIPTION
Temporary PR to verify whether Snapshot PR workflows can run on prod-deploy-tester-v1 and expose a tmate session for runner inspection. This should be closed/removed after debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new GitHub Actions workflow for pull requests targeting `main`.
  - Includes best-effort environment checks (host/system, Kubernetes, and NVIDIA status) before starting.
  - Launches a time-limited interactive debugging session with access restricted to the workflow actor.
  - Uses read-only repository permissions and runs for up to **180 minutes**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->