### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @enoodle @dfeigin-nv @galletas1712 @julienmancuso
+* @shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @yoedgin @dfeigin-nv @galletas1712 @julienmancuso

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @enoodle @dfeigin-nv @galletas1712 @julienmancuso


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` assigning all team members as owners of the entire repository

## Reviewers
@shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @enoodle @dfeigin-nv @galletas1712 @julienmancuso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for a designated project path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->