### PR TITLE
fix(rbac): add events create+patch for operator and agent

### DIFF
--- a/charts/snapshot/templates/operator-rbac.yaml
+++ b/charts/snapshot/templates/operator-rbac.yaml
@@ -36,6 +36,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/snapshot/templates/role.yaml
+++ b/charts/snapshot/templates/role.yaml
@@ -23,7 +23,7 @@ rules:
   # Emit operational events on pod/restore lifecycle updates
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create"]
+    verbs: ["create", "patch"]
   # Resolve DRA GPU UUIDs via ResourceClaim allocation (namespace-scoped)
   - apiGroups: ["resource.k8s.io"]
     resources: ["resourceclaims"]
@@ -76,7 +76,7 @@ rules:
   # Emit operational events on pod/restore lifecycle updates
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create"]
+    verbs: ["create", "patch"]
   # Resolve DRA GPU UUIDs via ResourceClaim and ResourceSlice
   - apiGroups: ["resource.k8s.io"]
     resources: ["resourceclaims", "resourceslices"]

--- a/operator/internal/controller/podsnapshot_reconciler.go
+++ b/operator/internal/controller/podsnapshot_reconciler.go
@@ -61,6 +61,7 @@ type PodSnapshotReconciler struct {
 // +kubebuilder:rbac:groups=nvidia.com,resources=podsnapshotcontents,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=nvidia.com,resources=podsnapshotcontents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile drives a PodSnapshot through binding, status mirroring, and cascade deletion. It is a thin
 // orchestrator: each branch delegates to a helper that owns that path's detail.


### PR DESCRIPTION
## Summary
- Add `events: create, patch` to the operator ClusterRole and kubebuilder marker — the reconciler emits events on `PodSnapshot` objects across namespaces, which the leaderelection Role alone doesn't cover
- Add `patch` to agent events in both namespaced Role and ClusterRole — `patch` is required for Kubernetes event deduplication alongside `create`

## Test plan
- [ ] Deploy Helm chart and verify operator/agent start without RBAC errors
- [ ] Trigger a snapshot and confirm events appear on the `PodSnapshot` object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes event reporting by allowing the operator and agent to create and update event records.
  * Ensures status and operational events can be reliably recorded in both namespace-scoped and cluster-wide deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->