### PR TITLE
build(operator): use NVIDIA-managed distroless base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,10 @@ fmt:
 	$(MAKE) -C agent fmt
 	$(MAKE) -C operator fmt
 
-# A license header on controller-gen output would be stripped by the next generate.
+# A license header on controller-gen output would be stripped by the next generate,
+# so both CRD copies are exempt. The rest of the chart carries SPDX headers.
 LICENSE_IGNORES := -ignore '**/zz_generated*.go' -ignore '**/.gitkeep' \
-                   -ignore 'charts/**' -ignore 'api/v1alpha1/crds/**'
+                   -ignore '$(CHART_CRD_DIR)/**' -ignore '$(CRD_SRC_DIR)/**'
 
 add-license-headers: $(ADDLICENSE)
 	$(ADDLICENSE) -f hack/boilerplate.addlicense.txt $(LICENSE_IGNORES) . .github/workflows

--- a/charts/snapshot/Chart.yaml
+++ b/charts/snapshot/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: snapshot
 description: Deploys the snapshot operator and node agent

--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/snapshot/templates/configmap.yaml
+++ b/charts/snapshot/templates/configmap.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ConfigMap
 {{- if ne .Values.storage.type "pvc" }}

--- a/charts/snapshot/templates/daemonset.yaml
+++ b/charts/snapshot/templates/daemonset.yaml
@@ -2,6 +2,9 @@
 {{- $socket := include "snapshot.runtimeSocket" . -}}
 {{- $socketDir := $socket | dir -}}
 {{- $storageDir := include "snapshot.runtimeStorageDir" . -}}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/snapshot/templates/openshift/rbac-privileged.yaml
+++ b/charts/snapshot/templates/openshift/rbac-privileged.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # OpenShift: namespace-scoped "use" grant on the built-in privileged SCC for
 # the agent DS ServiceAccount. CRIU needs every knob privileged exposes;
 # using the shipped SCC matches NTO/LSO/GPU-Operator.

--- a/charts/snapshot/templates/operator-deployment.yaml
+++ b/charts/snapshot/templates/operator-deployment.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/snapshot/templates/operator-rbac.yaml
+++ b/charts/snapshot/templates/operator-rbac.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.rbac.create }}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/snapshot/templates/pvc.yaml
+++ b/charts/snapshot/templates/pvc.yaml
@@ -1,4 +1,7 @@
 {{- if and (eq .Values.storage.type "pvc") (eq .Values.storage.accessMode "agentMount") .Values.storage.pvc.create }}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/snapshot/templates/role.yaml
+++ b/charts/snapshot/templates/role.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.namespaceRestricted }}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/snapshot/templates/rolebinding.yaml
+++ b/charts/snapshot/templates/rolebinding.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.rbac.create }}
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Bind agent to the cluster-scoped PodSnapshotContent ClusterRole (capture work orders).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/snapshot/templates/seccomp-configmap.yaml
+++ b/charts/snapshot/templates/seccomp-configmap.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.seccomp.deploy }}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/snapshot/templates/serviceaccount.yaml
+++ b/charts/snapshot/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.serviceAccount.create }}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 image:
   operator:
     repository: ghcr.io/ai-dynamo/snapshot/operator

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -13,12 +13,7 @@ WORKDIR /workspace/operator
 RUN CGO_ENABLED=0 go build -o bin/manager ./cmd/manager
 RUN CGO_ENABLED=0 go build -o bin/crd-installer ./cmd/crdinstaller
 
-# NVIDIA-managed distroless base, pulled from nvcr.io. OSRB requires approved
-# base containers to come from an NVIDIA-managed repository; gcr.io/distroless
-# does not qualify even though distroless itself is an approved base (OSRB bugs
-# 4176061 / 4489229). Same image the Dynamo operator uses
-# (deploy/operator/Dockerfile in ai-dynamo/dynamo, pinned there at v4.0.3).
-FROM nvcr.io/nvidia/distroless/go:v4.0.8
+FROM nvcr.io/nvidia/distroless/go:v4.0.8@sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178
 COPY --from=builder /workspace/operator/bin/manager /manager
 COPY --from=builder /workspace/operator/bin/crd-installer /crd-installer
 # The gcr.io distroless :nonroot tag set this implicitly; nvcr.io's does not.

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -8,10 +8,19 @@ WORKDIR /workspace
 COPY api/ api/
 COPY operator/ operator/
 WORKDIR /workspace/operator
-RUN go build -o bin/manager ./cmd/manager
-RUN go build -o bin/crd-installer ./cmd/crdinstaller
+# CGO_ENABLED=0 keeps the binaries free of any libc linkage, so the musl-based
+# builder can't produce something the glibc-based runtime below won't load.
+RUN CGO_ENABLED=0 go build -o bin/manager ./cmd/manager
+RUN CGO_ENABLED=0 go build -o bin/crd-installer ./cmd/crdinstaller
 
-FROM gcr.io/distroless/static:nonroot
+# NVIDIA-managed distroless base, pulled from nvcr.io. OSRB requires approved
+# base containers to come from an NVIDIA-managed repository; gcr.io/distroless
+# does not qualify even though distroless itself is an approved base (OSRB bugs
+# 4176061 / 4489229). Same image the Dynamo operator uses
+# (deploy/operator/Dockerfile in ai-dynamo/dynamo, pinned there at v4.0.3).
+FROM nvcr.io/nvidia/distroless/go:v4.0.8
 COPY --from=builder /workspace/operator/bin/manager /manager
 COPY --from=builder /workspace/operator/bin/crd-installer /crd-installer
+# The gcr.io distroless :nonroot tag set this implicitly; nvcr.io's does not.
+USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Why

The OSRB artifact review flagged the operator image: OSRB requires approved base containers to be **pulled from an NVIDIA-managed repository**. Distroless is on their approved list (bugs 4176061 / 4489229), but `gcr.io/distroless/static:nonroot` doesn't satisfy the registry rule, so the choice was "switch to an approved distroless container, or provide a full SBOM plus source code for every OSS component in it."

Switching is much cheaper than owning the SBOM, and it moves the base back to NGC's compliance boundary — we then only owe attribution for what we add on top (the `manager` binary and its Go modules).

## What

`FROM gcr.io/distroless/static:nonroot` → `FROM nvcr.io/nvidia/distroless/go:v4.0.8`

Same base the Dynamo operator uses ([`deploy/operator/Dockerfile`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/Dockerfile), pinned there at `v4.0.3`). I pinned `v4.0.8`, the latest patch of that line. The image is multi-arch (amd64 + arm64) and pulls anonymously from nvcr.io — no NGC credentials needed in CI.

Two adjustments come with the swap:

- **`USER 65532:65532` is now explicit.** The gcr.io `:nonroot` tag carried this implicitly; the nvcr.io image does not. Without it the operator would have silently started running as root.
- **`CGO_ENABLED=0` on the build.** The builder is musl-based Alpine and the new runtime is glibc-based. Today the build is pure Go so it works either way, but a future cgo dependency would produce a binary the runtime can't load. Disabling cgo removes the mismatch and matches how the agent binaries are built.

## Testing

Not built locally — no Docker daemon available in this environment. Relying on the `build-operator` job in `push-artifacts.yaml` to exercise it. Worth a manual `make docker-build-operator` before merge if you want confirmation ahead of CI.

Related: OSRB artifact request for the container images and Helm chart; source approval in nvbugs/6461151.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container runtime image for improved NVIDIA compatibility and reproducible builds.
  * Ensured the application runs as a non-root user for improved container security.
  * Disabled CGO to support more portable container binaries.
  * Standardized license and copyright notices across deployment resources.
  * Refined license-header checks to cover chart files while excluding generated snapshot custom resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->