### PR TITLE
fix(agent): enter PID namespace for GPU UUID nvidia-smi probe

### DIFF
--- a/agent/internal/cuda/cuda.go
+++ b/agent/internal/cuda/cuda.go
@@ -82,15 +82,17 @@ func GetPodGPUUUIDs(ctx context.Context, podName, podNamespace, containerName st
 }
 
 // GetGPUUUIDsViaNvidiaSmi discovers GPU UUIDs by running nvidia-smi inside the
-// container's mount namespace. This is the fallback path when the kubelet
+// container's mount and PID namespaces. This is the fallback path when the kubelet
 // PodResources API does not report GPU devices (e.g. when GPUs are allocated
 // via DRA instead of the NVIDIA device plugin).
 func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) ([]string, error) {
 	mountPath := fmt.Sprintf("%s/%d/ns/mnt", strings.TrimRight(hostProcPath, "/"), pid)
+	pidPath := fmt.Sprintf("%s/%d/ns/pid", strings.TrimRight(hostProcPath, "/"), pid)
 	cmd := exec.CommandContext(
 		ctx,
 		"nsenter",
 		fmt.Sprintf("--mount=%s", mountPath),
+		fmt.Sprintf("--pid=%s", pidPath),
 		"--",
 		"nvidia-smi", "--query-gpu=gpu_uuid", "--format=csv,noheader",
 	)


### PR DESCRIPTION
Syncs upstream fix ai-dynamo/dynamo@506a0a50 (dynamo#12227).

## Summary

- `GetGPUUUIDsViaNvidiaSmi` now enters the container's **PID namespace** (`--pid=<ns>`) in addition to its mount namespace when invoking `nsenter`
- Fixes GPU UUID discovery via the DRA fallback path where device visibility can depend on the PID namespace
- Updates the function docstring to match

This fix was previously applied to the `agentinject-gpufix` image but was never committed here.

## Test plan

- [ ] `GOOS=linux GOARCH=amd64 go build ./internal/cuda/...` passes
- [ ] Deploy on a DRA-based GPU node and confirm `nvidia-smi` GPU UUID discovery succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU detection in containerized environments by running hardware discovery within the target container’s namespaces.
  * Enhanced fallback handling for GPUs allocated through device resource interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->