### PR TITLE
fix(agent): guard restores against pod replacement

### DIFF
--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -358,7 +358,7 @@ func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string 
 	return ""
 }
 
-func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName string) (*corev1.Pod, bool) {
+func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName, checkpointID string) (*corev1.Pod, bool) {
 	livePod, err := w.clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -374,6 +374,9 @@ func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *cor
 		)
 		return nil, false
 	}
+	if w.maybeSkipRestore(pod, livePod, podKey, containerName, checkpointID) {
+		return nil, false
+	}
 	if livePod.DeletionTimestamp != nil ||
 		(livePod.Status.Phase != corev1.PodPending && livePod.Status.Phase != corev1.PodRunning) {
 		w.log.V(1).Info("Skipping restore; pod became ineligible while polling runtime",
@@ -384,6 +387,58 @@ func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *cor
 		return nil, false
 	}
 	return livePod, true
+}
+
+func (w *NodeController) maybeSkipRestore(observedPod, livePod *corev1.Pod, podKey, containerName, checkpointID string) bool {
+	if observedPod.UID == "" || livePod.UID != observedPod.UID {
+		w.log.Info("Skipping restore; pod identity changed while polling runtime",
+			"pod", podKey,
+			"container", containerName,
+			"observed_uid", observedPod.UID,
+			"live_uid", livePod.UID,
+		)
+		return true
+	}
+	if livePod.Spec.NodeName != w.config.NodeName {
+		w.log.Info("Skipping restore; pod is no longer assigned to this node",
+			"pod", podKey,
+			"container", containerName,
+			"node", livePod.Spec.NodeName,
+		)
+		return true
+	}
+	if livePod.Labels[snapshotv1alpha1.CheckpointIDLabel] != checkpointID {
+		w.log.Info("Skipping restore; pod checkpoint identity changed while polling runtime",
+			"pod", podKey,
+			"container", containerName,
+			"checkpoint_id", checkpointID,
+			"live_checkpoint_id", livePod.Labels[snapshotv1alpha1.CheckpointIDLabel],
+		)
+		return true
+	}
+	targets, err := snapshotv1alpha1.TargetContainersFromAnnotations(livePod.Annotations, 1, 0)
+	if err != nil {
+		w.log.Error(err, "Skipping restore; live pod has invalid target-container metadata",
+			"pod", podKey,
+			"container", containerName,
+		)
+		return true
+	}
+	stillTargeted := false
+	for _, target := range targets {
+		if target == containerName {
+			stillTargeted = true
+			break
+		}
+	}
+	if !stillTargeted {
+		w.log.Info("Skipping restore; container is no longer a restore target",
+			"pod", podKey,
+			"container", containerName,
+		)
+		return true
+	}
+	return false
 }
 
 func (w *NodeController) pollForContainerID(
@@ -402,7 +457,7 @@ func (w *NodeController) pollForContainerID(
 		containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
 		cancel()
 		if err == nil && containerID != "" {
-			livePod, ok := w.refreshRestorePodForStart(ctx, pod, podKey, containerName)
+			livePod, ok := w.refreshRestorePodForStart(ctx, pod, podKey, containerName, checkpointID)
 			if !ok {
 				return
 			}

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -115,6 +115,7 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
+			UID:         "test-pod-uid",
 			Labels:      labels,
 			Annotations: merged,
 		},
@@ -132,6 +133,51 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 			},
 		},
 	}
+}
+
+func TestAnnotatePodUsesUIDPrecondition(t *testing.T) {
+	statusKey := snapshotv1alpha1.RestoreStatusAnnotationPrefix + "main"
+	annotations := map[string]string{statusKey: snapshotv1alpha1.RestoreStatusInProgress}
+
+	t.Run("matching UID updates only requested annotations", func(t *testing.T) {
+		pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, nil, nil)
+		clientset := fake.NewClientset(pod.DeepCopy())
+
+		if err := annotatePod(context.Background(), clientset, testr.New(t), pod, annotations); err != nil {
+			t.Fatalf("annotatePod() error = %v", err)
+		}
+
+		updated, err := clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get updated pod: %v", err)
+		}
+		if got := updated.Annotations[statusKey]; got != snapshotv1alpha1.RestoreStatusInProgress {
+			t.Fatalf("restore status annotation = %q, want %q", got, snapshotv1alpha1.RestoreStatusInProgress)
+		}
+		if got := updated.Annotations[snapshotv1alpha1.TargetContainersAnnotation]; got != "main" {
+			t.Fatalf("target-container annotation = %q, want main", got)
+		}
+	})
+
+	t.Run("recreated pod is not modified", func(t *testing.T) {
+		observed := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, nil, nil)
+		observed.UID = "observed-uid"
+		live := observed.DeepCopy()
+		live.UID = "replacement-uid"
+		clientset := fake.NewClientset(live)
+
+		if err := annotatePod(context.Background(), clientset, testr.New(t), observed, annotations); err == nil {
+			t.Fatal("annotatePod() succeeded for a same-named replacement pod")
+		}
+
+		unchanged, err := clientset.CoreV1().Pods(live.Namespace).Get(context.Background(), live.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get replacement pod: %v", err)
+		}
+		if _, ok := unchanged.Annotations[statusKey]; ok {
+			t.Fatalf("replacement pod received restore status: %#v", unchanged.Annotations)
+		}
+	})
 }
 
 func TestCheckpointLocationsFromPod(t *testing.T) {
@@ -638,6 +684,83 @@ func TestReconcileRestorePodPollsRuntimeBeforePodRunning(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("expected RestoreRequested event from runtime polling before PodRunning; actions=%#v", clientset.Actions())
+}
+
+func TestRefreshRestorePodForStartRevalidatesIdentityAndMetadata(t *testing.T) {
+	const checkpointID = "abc123"
+	tests := []struct {
+		name           string
+		mutateObserved func(*corev1.Pod)
+		mutateLive     func(*corev1.Pod)
+		wantEligible   bool
+	}{
+		{name: "unchanged pod", wantEligible: true},
+		{
+			name: "same-named replacement pod",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.UID = "replacement-uid"
+			},
+		},
+		{
+			name: "missing observed UID",
+			mutateObserved: func(pod *corev1.Pod) {
+				pod.UID = ""
+			},
+		},
+		{
+			name: "checkpoint identity changed",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.Labels[snapshotv1alpha1.CheckpointIDLabel] = "other-checkpoint"
+			},
+		},
+		{
+			name: "container no longer targeted",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.Annotations[snapshotv1alpha1.TargetContainersAnnotation] = "sidecar"
+			},
+		},
+		{
+			name: "pod moved off node",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.Spec.NodeName = "other-node"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := makePod(
+				"test-pod",
+				"default",
+				testNodeName,
+				corev1.PodRunning,
+				false,
+				map[string]string{snapshotv1alpha1.CheckpointIDLabel: checkpointID},
+				nil,
+			)
+			live := observed.DeepCopy()
+			if tc.mutateObserved != nil {
+				tc.mutateObserved(observed)
+			}
+			if tc.mutateLive != nil {
+				tc.mutateLive(live)
+			}
+			w := makeTestController(t, live)
+
+			got, eligible := w.refreshRestorePodForStart(
+				context.Background(), observed, "default/test-pod", "main", checkpointID,
+			)
+			if eligible != tc.wantEligible {
+				t.Fatalf("eligible = %v, want %v", eligible, tc.wantEligible)
+			}
+			if eligible && got == nil {
+				t.Fatal("eligible refresh returned a nil pod")
+			}
+			if !eligible && got != nil {
+				t.Fatalf("ineligible refresh returned pod UID %q", got.UID)
+			}
+		})
+	}
 }
 
 func TestPollForContainerIDSkipsTerminalLivePod(t *testing.T) {

--- a/agent/internal/controller/util.go
+++ b/agent/internal/controller/util.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -65,17 +67,40 @@ func isContainerReady(pod *corev1.Pod, containerName string) bool {
 }
 
 func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.Logger, pod *corev1.Pod, annotations map[string]string) error {
-	patchBytes, err := json.Marshal(map[string]any{
-		"metadata": map[string]any{
-			"annotations": annotations,
-		},
-	})
+	if pod.UID == "" {
+		return fmt.Errorf("pod %s/%s has no UID", pod.Namespace, pod.Name)
+	}
+	if pod.Annotations == nil {
+		return fmt.Errorf("pod %s/%s has no annotations map", pod.Namespace, pod.Name)
+	}
+
+	// Test the immutable UID in the same API request as the annotation writes. A
+	// namespace/name Get followed by a merge patch has a TOCTOU window where a
+	// deleted Pod can be replaced by a same-named Pod between the two requests.
+	patch := []map[string]any{{
+		"op":    "test",
+		"path":  "/metadata/uid",
+		"value": string(pod.UID),
+	}}
+	keys := make([]string, 0, len(annotations))
+	for key := range annotations {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		patch = append(patch, map[string]any{
+			"op":    "add",
+			"path":  "/metadata/annotations/" + escapeJSONPointerToken(key),
+			"value": annotations[key],
+		})
+	}
+	patchBytes, err := json.Marshal(patch)
 	if err != nil {
 		return fmt.Errorf("failed to build annotation patch payload: %w", err)
 	}
 
 	_, err = clientset.CoreV1().Pods(pod.Namespace).Patch(
-		ctx, pod.Name, ktypes.MergePatchType, patchBytes, metav1.PatchOptions{},
+		ctx, pod.Name, ktypes.JSONPatchType, patchBytes, metav1.PatchOptions{},
 	)
 	if err != nil {
 		log.Error(err, "Failed to annotate pod",
@@ -84,6 +109,10 @@ func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.L
 		)
 	}
 	return err
+}
+
+func escapeJSONPointerToken(value string) string {
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(value)
 }
 
 // checkpointLeaseName returns the Lease guarding the artifact identified by checkpointID. The

--- a/agent/internal/controller/util.go
+++ b/agent/internal/controller/util.go
@@ -66,12 +66,12 @@ func isContainerReady(pod *corev1.Pod, containerName string) bool {
 	return false
 }
 
-func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.Logger, pod *corev1.Pod, annotations map[string]string) error {
+func getPatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) ([]byte, error) {
 	if pod.UID == "" {
-		return fmt.Errorf("pod %s/%s has no UID", pod.Namespace, pod.Name)
+		return nil, fmt.Errorf("pod %s/%s has no UID", pod.Namespace, pod.Name)
 	}
 	if pod.Annotations == nil {
-		return fmt.Errorf("pod %s/%s has no annotations map", pod.Namespace, pod.Name)
+		return nil, fmt.Errorf("pod %s/%s has no annotations map", pod.Namespace, pod.Name)
 	}
 
 	// Test the immutable UID in the same API request as the annotation writes. A
@@ -96,9 +96,16 @@ func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.L
 	}
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		return fmt.Errorf("failed to build annotation patch payload: %w", err)
+		return nil, fmt.Errorf("failed to build annotation patch payload: %w", err)
 	}
+	return patchBytes, nil
+}
 
+func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.Logger, pod *corev1.Pod, annotations map[string]string) error {
+	patchBytes, err := getPatchPodAnnotations(pod, annotations)
+	if err != nil {
+		return err
+	}
 	_, err = clientset.CoreV1().Pods(pod.Namespace).Patch(
 		ctx, pod.Name, ktypes.JSONPatchType, patchBytes, metav1.PatchOptions{},
 	)


### PR DESCRIPTION
## Summary

- guard Pod annotation updates with an atomic UID precondition
- re-fetch and revalidate the Pod identity, node assignment, checkpoint label, and restore targets before starting a restore
- add regression coverage for same-named replacement Pods and changed restore metadata

## Why

The restore flow can retain a Pod object while polling for its container ID. If that Pod is deleted and recreated with the same namespace and name, the old flow could annotate or start a restore against the replacement Pod. Using the immutable Pod UID as a precondition and revalidating the live Pod closes that race.

## Impact

Restore work is skipped when the live Pod no longer matches the object that initiated it. Unchanged eligible Pods continue through the existing restore path.

## Validation

- `go test ./...` in the Linux agent container
- `go test ./internal/controller` in the Linux agent container after the helper extraction
- `GOOS=linux GOARCH=amd64 go vet ./...`
- `git diff --check`
