### PR TITLE
feat(agent): add ns-bind-mount C helper and Go mount package

### DIFF
--- a/agent/cmd/ns-bind-mount/main.c
+++ b/agent/cmd/ns-bind-mount/main.c
@@ -1,0 +1,437 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ns-bind-mount: bind-mount or unmount a directory in another process's mount namespace.
+ *
+ * Mount:      ns-bind-mount <pid> <src> <dst> [ro]
+ * Mount-fd:   ns-bind-mount mount-fd <ns_fd> <src> <dst> [ro]
+ * Unmount:    ns-bind-mount umount <pid> <dst>
+ * Unmount-fd: ns-bind-mount umount-fd <ns_fd> <dst> [created]
+ *
+ * mount-fd is the preferred form: the caller (Go) opens /proc/<pid>/ns/mnt
+ * before launching the helper and passes the fd through ExtraFiles, so the
+ * namespace is pinned at open time rather than re-resolved from the PID inside
+ * the helper.  Both mount paths apply mount_setattr(MOUNT_ATTR_RDONLY) to the
+ * cloned tree *before* attaching so the mount is never visible as writable
+ * inside the target namespace.  Unmount enters the namespace the same way and
+ * calls umount2(MNT_DETACH).  Both subcommands run as single-threaded C
+ * processes so setns(CLONE_NEWNS) is allowed (prohibited in multithreaded Go
+ * programs).
+ *
+ * Requires Linux 5.12+ (mount_setattr; open_tree/move_mount need only 5.2).
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef __NR_open_tree
+#define __NR_open_tree 428
+#endif
+#ifndef __NR_move_mount
+#define __NR_move_mount 429
+#endif
+#ifndef __NR_mount_setattr
+#define __NR_mount_setattr 442
+#endif
+
+#define OPEN_TREE_CLONE 1
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+
+#ifndef MOUNT_ATTR_RDONLY
+#define MOUNT_ATTR_RDONLY 0x00000001
+#define MOUNT_ATTR_NOSUID 0x00000002
+#define MOUNT_ATTR_NODEV 0x00000004
+struct mount_attr {
+  uint64_t attr_set;
+  uint64_t attr_clr;
+  uint64_t propagation;
+  uint64_t userns_fd;
+};
+#endif
+
+/* Paths the caller is allowed to pass as src and dst.  Both the Go layer and
+ * this binary enforce these prefixes so that a bug in the controller cannot
+ * cause arbitrary host paths to be mounted into (or unmounted from) a foreign
+ * namespace.
+ *
+ * These values mirror the Go constants in internal/nsmount/injector.go:
+ *   agentBinDir    = "/snapshot-binaries"       → ALLOWED_SRC_PREFIX
+ *   SnapshotBinDir = "/tmp/snapshot-binaries"   → ALLOWED_DST_PREFIX
+ * Keep them in sync when either changes. */
+#define ALLOWED_SRC_PREFIX "/snapshot-binaries"     /* = nsmount.agentBinDir */
+#define ALLOWED_DST_PREFIX "/tmp/snapshot-binaries" /* = nsmount.SnapshotBinDir */
+
+/* Returns 0 if path is absolute and begins with allowed_prefix, -1 otherwise. */
+static int
+check_path_prefix(const char* path, const char* allowed_prefix, const char* label)
+{
+  if (path[0] != '/') {
+    fprintf(stderr, "%s must be an absolute path: %s\n", label, path);
+    return -1;
+  }
+  size_t plen = strlen(allowed_prefix);
+  if (strncmp(path, allowed_prefix, plen) != 0 || (path[plen] != '\0' && path[plen] != '/')) {
+    fprintf(stderr, "%s must start with %s: %s\n", label, allowed_prefix, path);
+    return -1;
+  }
+  return 0;
+}
+
+/* Returns 1 if path contains a ".." path component, 0 otherwise. */
+static int
+has_dotdot_component(const char* path)
+{
+  for (const char* p = path; *p;) {
+    const char* seg = p;
+    while (*p && *p != '/') p++;
+    size_t len = (size_t)(p - seg);
+    if (len == 2 && seg[0] == '.' && seg[1] == '.')
+      return 1;
+    while (*p == '/') p++;
+  }
+  return 0;
+}
+
+static int
+sys_open_tree(int dfd, const char* path, unsigned flags)
+{
+  return (int)syscall(__NR_open_tree, dfd, path, flags);
+}
+
+static int
+sys_move_mount(int from_dfd, const char* from_path, int to_dfd, const char* to_path, unsigned flags)
+{
+  return (int)syscall(__NR_move_mount, from_dfd, from_path, to_dfd, to_path, flags);
+}
+
+/* Enter the mount namespace of the given pid.  Returns 0 on success. */
+static int
+enter_mnt_ns(int pid)
+{
+  char ns_path[256];
+  snprintf(ns_path, sizeof(ns_path), "/proc/%d/ns/mnt", pid);
+  int ns_fd = open(ns_path, O_RDONLY | O_CLOEXEC);
+  if (ns_fd < 0) {
+    fprintf(stderr, "open %s: %s\n", ns_path, strerror(errno));
+    return -1;
+  }
+  if (setns(ns_fd, CLONE_NEWNS) < 0) {
+    fprintf(stderr, "setns %s: %s\n", ns_path, strerror(errno));
+    close(ns_fd);
+    return -1;
+  }
+  close(ns_fd);
+  return 0;
+}
+
+/* Parse a positive pid from str.  Returns the pid on success, -1 on error. */
+static int
+parse_pid(const char* str)
+{
+  char* end;
+  long val = strtol(str, &end, 10);
+  if (*end != '\0' || val <= 0 || val > INT_MAX) {
+    fprintf(stderr, "invalid pid: %s\n", str);
+    return -1;
+  }
+  return (int)val;
+}
+
+/* Apply read-only attributes to tree_fd before attaching it so the mount is
+ * never visible as writable inside the target namespace. */
+static int
+apply_rdonly_attrs(int tree_fd)
+{
+  struct mount_attr attr = {
+      .attr_set = MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV,
+  };
+  if (syscall(__NR_mount_setattr, tree_fd, "", AT_EMPTY_PATH, &attr, sizeof attr) < 0) {
+    fprintf(stderr, "mount_setattr ro: %s\n", strerror(errno));
+    return -1;
+  }
+  return 0;
+}
+
+/* Create or verify the target directory.  Returns 1 if this call created it,
+ * 0 if it already existed as a plain directory, -1 on error. */
+static int
+ensure_dst_dir(const char* dst)
+{
+  if (mkdir(dst, 0700) == 0)
+    return 1;
+  if (errno != EEXIST) {
+    fprintf(stderr, "mkdir %s: %s\n", dst, strerror(errno));
+    return -1;
+  }
+  /* dst already existed — verify it is a plain directory, not a symlink,
+   * so a process inside the namespace cannot redirect the mount. */
+  struct stat st;
+  if (lstat(dst, &st) < 0) {
+    fprintf(stderr, "lstat %s: %s\n", dst, strerror(errno));
+    return -1;
+  }
+  if (!S_ISDIR(st.st_mode)) {
+    fprintf(stderr, "dst %s exists but is not a plain directory\n", dst);
+    return -1;
+  }
+  return 0;
+}
+
+static int
+do_umount(int argc, char* argv[])
+{
+  if (argc < 4) {
+    fprintf(stderr, "usage: ns-bind-mount umount <pid> <dst>\n");
+    return 1;
+  }
+  int pid = parse_pid(argv[2]);
+  if (pid < 0)
+    return 1;
+  const char* dst = argv[3];
+
+  if (has_dotdot_component(dst)) {
+    fprintf(stderr, "dst must not contain '..' components: %s\n", dst);
+    return 1;
+  }
+  if (check_path_prefix(dst, ALLOWED_DST_PREFIX, "dst") < 0)
+    return 1;
+
+  if (enter_mnt_ns(pid) < 0)
+    return 1;
+
+  /* MNT_DETACH: lazy unmount — succeeds even if the path is busy. */
+  if (umount2(dst, MNT_DETACH) < 0) {
+    if (errno != ENOENT && errno != EINVAL) {
+      fprintf(stderr, "umount2 %s: %s\n", dst, strerror(errno));
+      return 1;
+    }
+    /* Already gone (CRIU removed it during namespace restore).
+     * Fall through to rmdir so we don't leave the directory behind. */
+  }
+
+  /* Remove the directory we created at mount time. Ignore errors — the
+   * directory may be non-empty or already gone, neither is fatal. */
+  rmdir(dst);
+  return 0;
+}
+
+/* Unmount via an open namespace fd rather than a pid.  The caller (Go) passes
+ * an already-open /proc/<pid>/ns/mnt fd inherited through ExtraFiles; using
+ * the fd avoids the PID-reuse window between mount time and cleanup.
+ * The optional "created" argument instructs the helper to remove dst — only
+ * set when the mount subcommand reported that it created the directory. */
+static int
+do_umount_fd(int argc, char* argv[])
+{
+  if (argc < 4) {
+    fprintf(stderr, "usage: ns-bind-mount umount-fd <ns_fd> <dst> [created]\n");
+    return 1;
+  }
+  char* end;
+  long fd_val = strtol(argv[2], &end, 10);
+  if (*end != '\0' || fd_val < 0 || fd_val > INT_MAX) {
+    fprintf(stderr, "invalid fd: %s\n", argv[2]);
+    return 1;
+  }
+  int ns_fd = (int)fd_val;
+  const char* dst = argv[3];
+  int created_dst = (argc >= 5 && strcmp(argv[4], "created") == 0);
+
+  if (has_dotdot_component(dst)) {
+    fprintf(stderr, "dst must not contain '..' components: %s\n", dst);
+    return 1;
+  }
+  if (check_path_prefix(dst, ALLOWED_DST_PREFIX, "dst") < 0)
+    return 1;
+
+  if (setns(ns_fd, CLONE_NEWNS) < 0) {
+    fprintf(stderr, "setns fd %d: %s\n", ns_fd, strerror(errno));
+    return 1;
+  }
+
+  if (umount2(dst, MNT_DETACH) < 0) {
+    if (errno != ENOENT && errno != EINVAL) {
+      fprintf(stderr, "umount2 %s: %s\n", dst, strerror(errno));
+      return 1;
+    }
+    /* Already gone (CRIU removed it during namespace restore).
+     * Fall through so we clean up the directory if we created it. */
+  }
+
+  /* Only remove the directory if the mount subcommand created it. */
+  if (created_dst)
+    rmdir(dst);
+  return 0;
+}
+
+/* Mount via an already-open namespace fd.  The caller (Go) opens
+ * /proc/<pid>/ns/mnt before launching the helper and passes the fd through
+ * ExtraFiles, so the namespace is pinned at Go-side open time rather than
+ * re-resolved from the PID — eliminating the PID-reuse window. */
+static int
+do_mount_fd(int argc, char* argv[])
+{
+  if (argc < 5) {
+    fprintf(stderr, "usage: ns-bind-mount mount-fd <ns_fd> <src> <dst> [ro]\n");
+    return 1;
+  }
+  char* end;
+  long fd_val = strtol(argv[2], &end, 10);
+  if (*end != '\0' || fd_val < 0 || fd_val > INT_MAX) {
+    fprintf(stderr, "invalid fd: %s\n", argv[2]);
+    return 1;
+  }
+  int ns_fd = (int)fd_val;
+  const char* src = argv[3];
+  const char* dst = argv[4];
+  int readonly = (argc >= 6 && strcmp(argv[5], "ro") == 0);
+
+  if (has_dotdot_component(src)) {
+    fprintf(stderr, "src must not contain '..' components: %s\n", src);
+    return 1;
+  }
+  if (check_path_prefix(src, ALLOWED_SRC_PREFIX, "src") < 0)
+    return 1;
+  if (has_dotdot_component(dst)) {
+    fprintf(stderr, "dst must not contain '..' components: %s\n", dst);
+    return 1;
+  }
+  if (check_path_prefix(dst, ALLOWED_DST_PREFIX, "dst") < 0)
+    return 1;
+
+  /* Clone the source mount tree before entering the target namespace. */
+  int tree_fd = sys_open_tree(AT_FDCWD, src, OPEN_TREE_CLONE | O_CLOEXEC);
+  if (tree_fd < 0) {
+    fprintf(stderr, "open_tree %s: %s\n", src, strerror(errno));
+    return 1;
+  }
+
+  /* Apply read-only attributes before attaching so the mount is never
+   * visible as writable inside the target namespace. */
+  if (readonly) {
+    if (apply_rdonly_attrs(tree_fd) < 0) {
+      close(tree_fd);
+      return 1;
+    }
+  }
+
+  /* Enter the target namespace via the inherited fd. */
+  if (setns(ns_fd, CLONE_NEWNS) < 0) {
+    fprintf(stderr, "setns fd %d: %s\n", ns_fd, strerror(errno));
+    close(tree_fd);
+    return 1;
+  }
+
+  int created_dst = ensure_dst_dir(dst);
+  if (created_dst < 0) {
+    close(tree_fd);
+    return 1;
+  }
+
+  /* Move the cloned mount into the target namespace at dst. */
+  if (sys_move_mount(tree_fd, "", AT_FDCWD, dst, MOVE_MOUNT_F_EMPTY_PATH) < 0) {
+    fprintf(stderr, "move_mount -> %s: %s\n", dst, strerror(errno));
+    close(tree_fd);
+    if (created_dst)
+      rmdir(dst);
+    return 1;
+  }
+  close(tree_fd);
+
+  printf("created_dst=%d\n", created_dst);
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  if (argc >= 2 && strcmp(argv[1], "mount-fd") == 0)
+    return do_mount_fd(argc, argv);
+  if (argc >= 2 && strcmp(argv[1], "umount-fd") == 0)
+    return do_umount_fd(argc, argv);
+  if (argc >= 2 && strcmp(argv[1], "umount") == 0)
+    return do_umount(argc, argv);
+
+  if (argc < 4) {
+    fprintf(
+        stderr,
+        "usage: ns-bind-mount <pid> <src> <dst> [ro]\n"
+        "       ns-bind-mount mount-fd <ns_fd> <src> <dst> [ro]\n"
+        "       ns-bind-mount umount <pid> <dst>\n"
+        "       ns-bind-mount umount-fd <ns_fd> <dst> [created]\n");
+    return 1;
+  }
+
+  int pid = parse_pid(argv[1]);
+  if (pid < 0)
+    return 1;
+  const char* src = argv[2];
+  const char* dst = argv[3];
+  int readonly = (argc >= 5 && strcmp(argv[4], "ro") == 0);
+
+  if (has_dotdot_component(src)) {
+    fprintf(stderr, "src must not contain '..' components: %s\n", src);
+    return 1;
+  }
+  if (check_path_prefix(src, ALLOWED_SRC_PREFIX, "src") < 0)
+    return 1;
+  if (has_dotdot_component(dst)) {
+    fprintf(stderr, "dst must not contain '..' components: %s\n", dst);
+    return 1;
+  }
+  if (check_path_prefix(dst, ALLOWED_DST_PREFIX, "dst") < 0)
+    return 1;
+
+  /* Clone the source mount tree before entering the target namespace. */
+  int tree_fd = sys_open_tree(AT_FDCWD, src, OPEN_TREE_CLONE | O_CLOEXEC);
+  if (tree_fd < 0) {
+    fprintf(stderr, "open_tree %s: %s\n", src, strerror(errno));
+    return 1;
+  }
+
+  /* Apply read-only attributes before attaching so the mount is never
+   * visible as writable inside the target namespace. */
+  if (readonly) {
+    if (apply_rdonly_attrs(tree_fd) < 0) {
+      close(tree_fd);
+      return 1;
+    }
+  }
+
+  /* Enter the target process's mount namespace. */
+  if (enter_mnt_ns(pid) < 0) {
+    close(tree_fd);
+    return 1;
+  }
+
+  int created_dst = ensure_dst_dir(dst);
+  if (created_dst < 0) {
+    close(tree_fd);
+    return 1;
+  }
+
+  /* Move the cloned mount into the target namespace at dst. */
+  if (sys_move_mount(tree_fd, "", AT_FDCWD, dst, MOVE_MOUNT_F_EMPTY_PATH) < 0) {
+    fprintf(stderr, "move_mount -> %s: %s\n", dst, strerror(errno));
+    close(tree_fd);
+    if (created_dst)
+      rmdir(dst);
+    return 1;
+  }
+  close(tree_fd);
+
+  printf("created_dst=%d\n", created_dst);
+  return 0;
+}

--- a/agent/internal/nsmount/injector.go
+++ b/agent/internal/nsmount/injector.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nsmount bind-mounts a directory into a foreign process's mount
+// namespace via the ns-bind-mount C helper (cmd/ns-bind-mount).
+package nsmount
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+// MountPoint represents an active bind-mount of a directory inside a foreign
+// namespace. The caller must call Unmount when done.
+type MountPoint interface {
+	// Path returns the in-namespace absolute path to the named binary.
+	// name must be a single path element with no separators or dot-dot components.
+	// Example: mp.Path("nsrestore") → "/tmp/snapshot-binaries/nsrestore", nil
+	Path(name string) (string, error)
+
+	// Unmount removes the bind-mount from the target namespace.
+	// Idempotent — safe to call from a defer even if Mount partially failed.
+	// A non-nil error means the mount may still be active; callers must treat
+	// this as fatal and exit so Kubernetes restarts into a clean namespace.
+	Unmount(ctx context.Context) error
+}
+
+// NSMounter mounts a source directory into a placeholder container's mount
+// namespace and returns a MountPoint for later cleanup.
+type NSMounter struct {
+	src     string
+	dst     string
+	mounter mounter
+	log     logr.Logger
+}
+
+// New returns an NSMounter backed by the ns-bind-mount binary at its default
+// location. It errors if the helper binary is missing, so a misconfigured
+// node fails at startup rather than at the first mount.
+// Requires Linux 5.12+ (mount_setattr; open_tree/move_mount need only 5.2).
+func New(src, dst string, log logr.Logger) (*NSMounter, error) {
+	m, err := newExecMounter(defaultBinaryPath, log)
+	if err != nil {
+		return nil, err
+	}
+	return newWithMounter(src, dst, m, log)
+}
+
+// newWithMounter is the test seam: it takes an arbitrary mounter so tests can
+// exercise Mount without the ns-bind-mount subprocess.
+func newWithMounter(src, dst string, m mounter, log logr.Logger) (*NSMounter, error) {
+	return &NSMounter{src: src, dst: dst, mounter: m, log: log}, nil
+}
+
+// Mount bind-mounts src into dst inside the mount namespace of pid.
+// The caller must call MountPoint.Unmount when done.
+func (nsm *NSMounter) Mount(ctx context.Context, pid int) (MountPoint, error) {
+	nsm.log.Info("mounting agent bundle into placeholder namespace", "pid", pid, "src", nsm.src, "dst", nsm.dst)
+
+	ref, err := nsm.mounter.Mount(ctx, pid, nsm.src, nsm.dst, MountOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+
+	nsm.log.Info("agent bundle mounted", "pid", pid, "dst", ref.TargetPath())
+	return &mountPoint{mount: ref}, nil
+}
+
+// mountPoint wraps a mountRef to expose the MountPoint surface:
+// Path resolves binary names relative to the mounted directory,
+// and Unmount delegates to the underlying mount's Unmount.
+type mountPoint struct {
+	mount mountRef
+}
+
+// Path returns the in-namespace absolute path to the named binary.
+// name must be a single path element: callers pass literals, and anything
+// else could redirect a privileged exec outside the mounted bundle.
+func (h *mountPoint) Path(name string) (string, error) {
+	if name == "" || name == "." || name == ".." || strings.ContainsRune(name, os.PathSeparator) {
+		return "", fmt.Errorf("nsmount: invalid binary name %q", name)
+	}
+	return filepath.Join(h.mount.TargetPath(), name), nil
+}
+
+func (h *mountPoint) Unmount(ctx context.Context) error {
+	return h.mount.Unmount(ctx)
+}

--- a/agent/internal/nsmount/injector_test.go
+++ b/agent/internal/nsmount/injector_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nsmount
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	testSrc = "/snapshot-binaries"
+	testDst = "/tmp/snapshot-binaries"
+)
+
+// fakemountRef implements mountRef for tests.
+type fakemountRef struct {
+	dst        string
+	unmountLog *[]string
+}
+
+func (h *fakemountRef) TargetPath() string { return h.dst }
+
+func (h *fakemountRef) Unmount(_ context.Context) error {
+	*h.unmountLog = append(*h.unmountLog, h.dst)
+	return nil
+}
+
+// mountCall records a single Mount invocation.
+type mountCall struct {
+	pid      int
+	src, dst string
+	opts     MountOptions
+}
+
+// mockMounter lets tests control per-call Mount results and record call order.
+type mockMounter struct {
+	// results[i] is returned for the i-th Mount call (in order).
+	results    []error
+	calls      []mountCall
+	unmountLog []string
+}
+
+func (m *mockMounter) Mount(_ context.Context, pid int, src, dst string, opts MountOptions) (mountRef, error) {
+	i := len(m.calls)
+	m.calls = append(m.calls, mountCall{pid: pid, src: src, dst: dst, opts: opts})
+	if i < len(m.results) && m.results[i] != nil {
+		return nil, m.results[i]
+	}
+	return &fakemountRef{dst: dst, unmountLog: &m.unmountLog}, nil
+}
+
+const testPID = 42
+
+func newMounter(t *testing.T, m *mockMounter) *NSMounter {
+	t.Helper()
+	nsm, err := newWithMounter(testSrc, testDst, m, logr.Discard())
+	if err != nil {
+		t.Fatalf("newWithMounter: %v", err)
+	}
+	return nsm
+}
+
+func TestMount_MountsAgentBundle(t *testing.T) {
+	m := &mockMounter{}
+	_, err := newMounter(t, m).Mount(context.Background(), testPID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []mountCall{
+		{pid: testPID, src: testSrc, dst: testDst, opts: MountOptions{ReadOnly: true}},
+	}
+	if len(m.calls) != len(want) {
+		t.Fatalf("got %d mount calls, want %d", len(m.calls), len(want))
+	}
+	if m.calls[0] != want[0] {
+		t.Errorf("call[0]: got %+v, want %+v", m.calls[0], want[0])
+	}
+}
+
+func TestMount_Path(t *testing.T) {
+	m := &mockMounter{}
+	mp, err := newMounter(t, m).Mount(context.Background(), testPID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := mp.Path("nsrestore")
+	if err != nil {
+		t.Fatalf("Path: unexpected error: %v", err)
+	}
+	want := filepath.Join(testDst, "nsrestore")
+	if got != want {
+		t.Errorf("Path: got %q, want %q", got, want)
+	}
+}
+
+func TestMount_Unmounts(t *testing.T) {
+	m := &mockMounter{}
+	mp, err := newMounter(t, m).Mount(context.Background(), testPID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mp.Unmount(context.Background()); err != nil {
+		t.Fatalf("unexpected unmount error: %v", err)
+	}
+
+	if len(m.unmountLog) != 1 || m.unmountLog[0] != testDst {
+		t.Errorf("expected unmount of %q, got %v", testDst, m.unmountLog)
+	}
+}
+
+func TestMount_Fails(t *testing.T) {
+	mountErr := errors.New("mount failed")
+	m := &mockMounter{results: []error{mountErr}}
+
+	_, err := newMounter(t, m).Mount(context.Background(), testPID)
+	if !errors.Is(err, mountErr) {
+		t.Fatalf("got %v, want %v", err, mountErr)
+	}
+	if len(m.unmountLog) != 0 {
+		t.Errorf("expected no unmounts, got %v", m.unmountLog)
+	}
+}
+
+func TestPath_RejectsInvalidNames(t *testing.T) {
+	m := &mockMounter{}
+	mp, err := newMounter(t, m).Mount(context.Background(), testPID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	invalid := []string{"", ".", "..", "foo/bar", "../../etc/passwd"}
+	for _, name := range invalid {
+		_, err := mp.Path(name)
+		if err == nil {
+			t.Errorf("Path(%q): expected error, got nil", name)
+		}
+	}
+}

--- a/agent/internal/nsmount/mount.go
+++ b/agent/internal/nsmount/mount.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nsmount
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	binaryName        = "ns-bind-mount"
+	defaultBinaryPath = "/usr/local/sbin/" + binaryName
+	nsMntNsPathFmt    = "/proc/%d/ns/mnt"
+
+	// nsFdChildNum is the fd number that the ns/mnt file descriptor will have
+	// inside the child process. Go's exec package maps ExtraFiles[i] to fd
+	// (3+i) — after stdin(0), stdout(1), stderr(2). nsFd is the only entry in
+	// ExtraFiles, so it lands at fd 3. If ExtraFiles ever gains additional
+	// entries before nsFd, this constant must be updated to match.
+	nsFdChildNum = 3
+
+	// unmountTimeout bounds a single ns-bind-mount cleanup invocation so a hung
+	// umount cannot block the caller indefinitely.
+	unmountTimeout = 10 * time.Second
+)
+
+// MountOptions configures a single namespace-aware mount operation.
+type MountOptions struct {
+	ReadOnly bool // mount with MS_RDONLY
+}
+
+// mountRef represents an active mount inside a foreign namespace.
+// The owner must call Unmount when the mount is no longer needed.
+type mountRef interface {
+	// Unmount detaches the mount from the target namespace.
+	// Idempotent — safe to call multiple times.
+	Unmount(ctx context.Context) error
+
+	// TargetPath returns the dst path as seen inside the target namespace.
+	TargetPath() string
+}
+
+// mounter mounts src at dst inside the mount namespace identified by pid.
+// It exists so tests can substitute the ns-bind-mount subprocess; production
+// callers get an execMounter via New and never name this type.
+type mounter interface {
+	Mount(ctx context.Context, pid int, src, dst string, opts MountOptions) (mountRef, error)
+}
+
+// execMounter implements mounter by invoking the ns-bind-mount C helper as a
+// subprocess. The helper performs cross-namespace bind mounts using
+// open_tree(2)/move_mount(2) after entering the target process's mount
+// namespace via setns(CLONE_NEWNS); it is a separate binary because Go's
+// multithreaded runtime cannot call setns(CLONE_NEWNS) directly.
+type execMounter struct {
+	binaryPath string
+	log        logr.Logger
+}
+
+// newExecMounter returns an execMounter for the ns-bind-mount binary at path.
+// It errors if the binary is absent so callers fail at startup rather than at
+// the first mount operation.
+func newExecMounter(path string, log logr.Logger) (*execMounter, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("%s binary not found at %s: %w", binaryName, path, err)
+	}
+	return &execMounter{binaryPath: path, log: log}, nil
+}
+
+// execMountRef is the concrete mountRef returned by execMounter.Mount.
+type execMountRef struct {
+	binaryPath string
+	nsFd       *os.File // /proc/<pid>/ns/mnt pinned before the subprocess runs; held so Unmount re-enters the same namespace without relying on the PID
+	dst        string
+	createdDst bool // true if the mount helper created dst; controls rmdir on cleanup
+	log        logr.Logger
+	once       sync.Once
+	unmountErr error
+}
+
+func (h *execMountRef) TargetPath() string { return h.dst }
+
+func (h *execMountRef) Unmount(_ context.Context) error {
+	h.once.Do(func() {
+		defer h.nsFd.Close()
+		// Fresh context with a hard timeout. The parent context is intentionally
+		// not forwarded: cleanup must complete even if the caller's context is
+		// already cancelled.
+		ctx, cancel := context.WithTimeout(context.Background(), unmountTimeout)
+		defer cancel()
+		// Pass the ns fd via ExtraFiles; it lands at fd nsFdChildNum in the child.
+		args := []string{"umount-fd", strconv.Itoa(nsFdChildNum), h.dst}
+		if h.createdDst {
+			args = append(args, "created")
+		}
+		cmd := exec.CommandContext(ctx, h.binaryPath, args...)
+		cmd.ExtraFiles = []*os.File{h.nsFd}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			h.log.Error(err, "failed to unmount from namespace", "dst", h.dst, "output", strings.TrimSpace(string(out)))
+			h.unmountErr = fmt.Errorf("ns-bind-mount umount-fd %s: %w\noutput: %s", h.dst, err, strings.TrimSpace(string(out)))
+			return
+		}
+		h.log.Info("unmounted from namespace", "dst", h.dst)
+	})
+	return h.unmountErr
+}
+
+// Mount bind-mounts src (in the current namespace) to dst inside the mount
+// namespace of pid. It opens /proc/<pid>/ns/mnt *before* launching the helper
+// so the namespace is pinned against PID reuse, then passes the fd to the
+// mount-fd subcommand via ExtraFiles. The fd is retained in the returned handle
+// so Unmount can re-enter the namespace without relying on the PID.
+func (m *execMounter) Mount(ctx context.Context, pid int, src, dst string, opts MountOptions) (mountRef, error) {
+	// Pin the namespace fd before calling the helper so mount and cleanup
+	// provably act on the same namespace regardless of PID reuse.
+	nsFdPath := fmt.Sprintf(nsMntNsPathFmt, pid)
+	nsFd, err := os.Open(nsFdPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", nsFdPath, err)
+	}
+
+	args := []string{"mount-fd", strconv.Itoa(nsFdChildNum), src, dst}
+	if opts.ReadOnly {
+		args = append(args, "ro")
+	}
+
+	cmd := exec.CommandContext(ctx, m.binaryPath, args...)
+	cmd.ExtraFiles = []*os.File{nsFd}
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		nsFd.Close()
+		return nil, fmt.Errorf("ns-bind-mount mount-fd %s -> %s: %w\noutput: %s", src, dst, err, strings.TrimSpace(stderr.String()))
+	}
+	m.log.Info("mounted into namespace", "src", src, "dst", dst, "readonly", opts.ReadOnly, "pid", pid)
+
+	createdDst := strings.Contains(stdout.String(), "created_dst=1")
+
+	return &execMountRef{
+		binaryPath: m.binaryPath,
+		nsFd:       nsFd,
+		dst:        dst,
+		createdDst: createdDst,
+		log:        m.log,
+	}, nil
+}

--- a/agent/internal/nsmount/mount_test.go
+++ b/agent/internal/nsmount/mount_test.go
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package nsmount
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// writeFakeBinary writes a shell script at a temp path and returns the path.
+// The script is passed to sh -c, so $@ refers to the arguments passed by execMounter.
+func writeFakeBinary(t *testing.T, script string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "ns-bind-mount")
+	content := "#!/bin/sh\n" + script + "\n"
+	if err := os.WriteFile(p, []byte(content), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func newMounterForTest(t *testing.T, bin string) *execMounter {
+	t.Helper()
+	m, err := newExecMounter(bin, logr.Discard())
+	if err != nil {
+		t.Fatalf("newExecMounter: %v", err)
+	}
+	return m
+}
+
+// readLines reads a file and splits it into non-empty lines.
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readLines: %v", err)
+	}
+	var lines []string
+	for _, l := range strings.Split(string(data), "\n") {
+		if l != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines
+}
+
+func TestExecMounter_Mount_Args(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "args.log")
+	// Print each argument on its own line so we can parse them individually.
+	// The Go caller now uses "mount-fd <nsFdChildNum> <src> <dst>" so $@ logs
+	// those four tokens.
+	bin := writeFakeBinary(t, `printf '%s\n' "$@" >> `+logFile)
+
+	m := newMounterForTest(t, bin)
+	pid := os.Getpid()
+	_, err := m.Mount(context.Background(), pid, "/src", "/dst", MountOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readLines(t, logFile)
+	want := []string{"mount-fd", fmt.Sprintf("%d", nsFdChildNum), "/src", "/dst"}
+	if len(got) != len(want) {
+		t.Fatalf("args: got %v want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("arg[%d]: got %q want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestExecMounter_Mount_ReadOnly(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "args.log")
+	bin := writeFakeBinary(t, `printf '%s\n' "$@" >> `+logFile)
+
+	m := newMounterForTest(t, bin)
+	pid := os.Getpid()
+	_, err := m.Mount(context.Background(), pid, "/src", "/dst", MountOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readLines(t, logFile)
+	want := []string{"mount-fd", fmt.Sprintf("%d", nsFdChildNum), "/src", "/dst", "ro"}
+	if len(got) != len(want) {
+		t.Fatalf("args: got %v want %v", got, want)
+	}
+	if got[4] != "ro" {
+		t.Errorf("expected 'ro' flag at index 4, got %q", got[4])
+	}
+}
+
+func TestExecMounter_Mount_ErrorWrapped(t *testing.T) {
+	bin := writeFakeBinary(t, `echo "subprocess boom" >&2; exit 1`)
+	m := newMounterForTest(t, bin)
+
+	// Use current pid so the ns fd open succeeds; the helper itself then fails.
+	_, err := m.Mount(context.Background(), os.Getpid(), "/src", "/dst", MountOptions{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	s := err.Error()
+	for _, want := range []string{"/src", "/dst", "subprocess boom"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("error missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestExecMounter_Mount_NsFdOpenFailure(t *testing.T) {
+	// The ns fd is now opened BEFORE the helper runs. A dead PID (MaxInt32)
+	// causes os.Open("/proc/<pid>/ns/mnt") to fail before the binary is called.
+	bin := writeFakeBinary(t, `exit 0`)
+	m := newMounterForTest(t, bin)
+
+	_, err := m.Mount(context.Background(), math.MaxInt32, "/src", "/dst", MountOptions{})
+	if err == nil {
+		t.Fatal("expected error when ns fd cannot be opened, got nil")
+	}
+	if !strings.Contains(err.Error(), "ns/mnt") {
+		t.Errorf("error should mention ns/mnt path, got: %v", err)
+	}
+}
+
+func TestExecMounter_Unmount_Error(t *testing.T) {
+	bin := writeFakeBinary(t, `if [ "$1" = "umount-fd" ]; then echo "boom" >&2; exit 1; fi`)
+	m := newMounterForTest(t, bin)
+	handle, err := m.Mount(context.Background(), os.Getpid(), "/src", "/dst", MountOptions{})
+	if err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+
+	err = handle.Unmount(context.Background())
+	if err == nil {
+		t.Fatal("expected error from umount-fd, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error should contain subprocess output, got: %v", err)
+	}
+
+	// Second call must return the same stored error without invoking the binary again.
+	err2 := handle.Unmount(context.Background())
+	if err2 != err {
+		t.Errorf("second Unmount returned different error: %v", err2)
+	}
+}
+
+func TestExecMounter_Unmount_Idempotent(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	// Record the first argument of each invocation (subcommand name).
+	bin := writeFakeBinary(t, `printf '%s\n' "$1" >> `+callLog)
+
+	m := newMounterForTest(t, bin)
+	handle, err := m.Mount(context.Background(), os.Getpid(), "/src", "/dst", MountOptions{})
+	if err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+
+	if err := handle.Unmount(context.Background()); err != nil {
+		t.Fatalf("first Unmount: %v", err)
+	}
+	if err := handle.Unmount(context.Background()); err != nil {
+		t.Fatalf("second Unmount: %v", err)
+	}
+
+	calls := readLines(t, callLog)
+	umountFdCalls := 0
+	for _, c := range calls {
+		if c == "umount-fd" {
+			umountFdCalls++
+		}
+	}
+	if umountFdCalls != 1 {
+		t.Errorf("expected exactly 1 umount-fd call, got %d (all calls: %v)", umountFdCalls, calls)
+	}
+}


### PR DESCRIPTION
Sync upstream https://github.com/ai-dynamo/dynamo/commit/cb5082f6 (#12542).


Signed-off-by: Oleg Kushniriov **[okushniriov@nvidia.com](mailto:okushniriov@nvidia.com)**

Add foundational packages for cross-namespace bind mounting, required to stage the agent binary bundle inside a placeholder
container's mount namespace before CRIU restore runs.

Go's multithreaded runtime prohibits setns(CLONE_NEWNS), so the implementation is split across a C helper binary and two thin Go
packages. This PR is additive only — no existing files are modified and the new packages are not yet wired into the restore path.

Details
Three layers are introduced:

cmd/ns-bind-mount/main.c — C helper that performs bind mount (open_tree(OPEN_TREE_CLONE) + move_mount) and lazy unmount
(umount2(MNT_DETACH)) across mount namespaces. Requires Linux 5.2+.
internal/nsbindmount/nsbindmount.go — Go Mounter interface backed by ExecMounter, which shells out to the C helper and
returns a cleanup func.
internal/injection/injector.go + paths.go — Injector struct that uses Mounter to bind-mount the agent binary bundle
read-only into a target namespace given a PID.
internal/injection/injector_test.go — unit tests via mockMounter; no cluster or Linux privileges required.
The Dockerfile build stage for the C binary and the wiring of Injector into executor/restore.go are intentionally deferred to a
follow-up PR.

Where should the reviewer start?
1. cmd/ns-bind-mount/main.c
Most security-sensitive code. Verify open_tree/move_mount ordering, enter_mnt_ns, and error paths (fd cleanup on failure, rmdir
on move_mount failure).

2. internal/nsbindmount/nsbindmount.go
Check the Mounter interface contract and cleanup closure (exec.Command without context is intentional — cleanup must complete even
after the parent context is cancelled).

3. internal/injection/injector.go
Straightforward once the above two are understood.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for securely mounting read-only directories into another process’s mount namespace.
  * Supports targeting processes by PID and provides safe path resolution within mounted content.
  * Added reliable cleanup, including idempotent unmounting and removal of created directories.
  * Added validation for paths, namespace references, and mount parameters.

* **Bug Fixes**
  * Improved error handling and reporting for failed mounts, unmounts, and namespace access.

* **Tests**
  * Added comprehensive coverage for mounting, cleanup, validation, read-only behavior, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->