### PR TITLE
feat: Sync/dynamo 12936

### DIFF
--- a/agent/internal/cuda/shim.go
+++ b/agent/internal/cuda/shim.go
@@ -5,10 +5,13 @@ package cuda
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -17,13 +20,16 @@ import (
 )
 
 const (
-	cudaCheckpointHelperBinary = "/usr/local/bin/cuda-checkpoint-helper"
+	defaultCUDAHelperBinary = "/usr/local/bin/cuda-checkpoint-helper"
+	helperWaitDelay         = 2 * time.Second
 
 	actionLock       = "lock"
 	actionCheckpoint = "checkpoint"
 	actionRestore    = "restore"
 	actionUnlock     = "unlock"
 )
+
+var cudaCheckpointHelperBinary = defaultCUDAHelperBinary
 
 func lock(ctx context.Context, pid int, log logr.Logger) error {
 	return runAction(ctx, pid, actionLock, "", log)
@@ -60,6 +66,11 @@ func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.
 		args = append(args, "--device-map", deviceMap)
 	}
 	cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return normalizeProcessGroupKillError(syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
+	}
+	cmd.WaitDelay = helperWaitDelay
 	details := snapshotruntime.ProcessDetails{
 		ObservedPID:   pid,
 		OutermostPID:  pid,
@@ -74,6 +85,9 @@ func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.
 	duration := time.Since(start)
 	out := strings.TrimSpace(string(output))
 	if err != nil {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
 		log.Error(err, "cuda-checkpoint-helper command failed",
 			"pid", pid,
 			"outermost_pid", details.OutermostPID,
@@ -95,4 +109,11 @@ func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.
 		"output", out,
 	)
 	return nil
+}
+
+func normalizeProcessGroupKillError(err error) error {
+	if errors.Is(err, syscall.ESRCH) {
+		return os.ErrProcessDone
+	}
+	return err
 }

--- a/agent/internal/cuda/shim_test.go
+++ b/agent/internal/cuda/shim_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func installFakeCUDAHelper(t *testing.T, script string) {
+	t.Helper()
+	helper := filepath.Join(t.TempDir(), "cuda-checkpoint-helper")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\n"+script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	originalHelper := cudaCheckpointHelperBinary
+	cudaCheckpointHelperBinary = helper
+	t.Cleanup(func() { cudaCheckpointHelperBinary = originalHelper })
+}
+
+func TestRunActionCancellationIsBounded(t *testing.T) {
+	installFakeCUDAHelper(t, "sleep 300 &\nwait\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	err := runAction(ctx, 11, actionRestore, "", logr.Discard())
+	duration := time.Since(started)
+	if err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("runAction() error = %v", err)
+	}
+	if duration > helperWaitDelay+time.Second {
+		t.Fatalf("runAction() took %s after cancellation", duration)
+	}
+}
+
+func TestNormalizeProcessGroupKillErrorReportsFinishedProcess(t *testing.T) {
+	if err := normalizeProcessGroupKillError(syscall.ESRCH); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("normalizeProcessGroupKillError() error = %v, want %v", err, os.ErrProcessDone)
+	}
+}


### PR DESCRIPTION
Sync upstream https://github.com/ai-dynamo/dynamo/commit/3aa5a19 (#12936).

Overview:
Bounds cancellation by killing the helper process group and limiting pipe cleanup waits.

Details:
Put the helper in its own process group.
Kill the group ^ on cancellation.
Bound inherited-pipe waits with WaitDelay.


Signed-off-by: Oleg Kushniriov [okushniriov@nvidia.com](mailto:okushniriov@nvidia.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation of CUDA helper operations by terminating associated processes more reliably.
  * Ensured cancelled operations return the appropriate context cancellation error.
  * Added bounded cleanup to prevent operations from hanging during shutdown.

* **Tests**
  * Added coverage for process cancellation, cleanup timing, and termination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->