### PR TITLE
feat(agent): restore ns mount

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -99,12 +99,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /workspace
 
 COPY cmd/cuda-checkpoint-helper/main.c ./cmd/cuda-checkpoint-helper/main.c
+COPY cmd/ns-bind-mount/main.c ./cmd/ns-bind-mount/main.c
 
 RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
     ./cmd/cuda-checkpoint-helper/main.c \
     -I/usr/local/cuda/include \
     -L/usr/local/cuda/lib64/stubs \
     -lcuda
+
+# ns-bind-mount bind-mounts the snapshot binaries into a target container's mount
+# namespace. It needs no CUDA headers, only mount_setattr (Linux 5.12+).
+RUN gcc -O2 -Wall -Wextra -o /ns-bind-mount ./cmd/ns-bind-mount/main.c
 
 # =============================================================================
 # Stage: CRIU Builder - Build CRIU with CUDA plugin
@@ -221,11 +226,73 @@ RUN criu --version
 COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /usr/local/sbin/cuda-checkpoint
 COPY --from=criu-builder /tmp/cuda-checkpoint/LICENSE /legal/cuda-checkpoint/LICENSE
 COPY --from=cuda-helper-builder /cuda-checkpoint-helper /usr/local/bin/cuda-checkpoint-helper
-RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-helper
+# nsmount resolves this helper at /usr/local/sbin/ns-bind-mount (see
+# agent/internal/nsmount/mount.go defaultBinaryPath).
+COPY --from=cuda-helper-builder /ns-bind-mount /usr/local/sbin/ns-bind-mount
+RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-helper \
+    /usr/local/sbin/ns-bind-mount
 
 # Copy the built binaries
 COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
-COPY --from=builder /nsrestore /usr/local/bin/nsrestore
+
+# Assemble the injection bundle: bind-mounted read-only into the placeholder's
+# mount namespace at /tmp/snapshot-binaries during restore (internal/nsmount).
+# The placeholder ships none of this. nsrestore redirects all three lookup
+# mechanisms into the mount: criu's libdir -> criu-plugins/ (criu.overrideLibDir),
+# LD_LIBRARY_PATH -> lib/, and PATH -> the bundle root.
+RUN mkdir -p /snapshot-binaries/lib /snapshot-binaries/criu-plugins
+COPY --from=builder /nsrestore /snapshot-binaries/nsrestore
+COPY --from=criu-builder /criu-install/usr/local/sbin/criu /snapshot-binaries/criu
+COPY --from=criu-builder /criu-install/usr/local/lib/snapshot/criu-plugins/ /snapshot-binaries/criu-plugins/
+COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /snapshot-binaries/cuda-checkpoint
+COPY --from=cuda-helper-builder /cuda-checkpoint-helper /snapshot-binaries/cuda-checkpoint-helper
+
+# Network binaries needed during restore:
+#   ip  — address/route restore (criu/net.c)
+#   tar — used by runtime.ApplyRootfsDiff
+# Network lock is set to SKIP (--network-lock skip) in BuildRestoreOpts, so
+# criu never forks iptables-restore/ip6tables-restore on this path and neither
+# binary needs to be in the bundle. See BuildRestoreOpts for why SKIP is safe
+# for restore specifically.
+# All resolve through PATH inside the namespace.
+RUN set -eu; \
+    cp -L "$(command -v ip)" "$(command -v tar)" /snapshot-binaries/; \
+    chmod +x /snapshot-binaries/criu /snapshot-binaries/nsrestore \
+             /snapshot-binaries/cuda-checkpoint /snapshot-binaries/cuda-checkpoint-helper \
+             /snapshot-binaries/ip /snapshot-binaries/tar
+
+# Shared-library closure of the bundled binaries and plugins.
+#
+# glibc (libc, libm, libpthread, libdl, librt, libresolv) and the loader are
+# deliberately excluded: the kernel reads PT_INTERP before LD_LIBRARY_PATH
+# applies, so the loader always comes from the placeholder, and glibc's loader
+# and libc are version-locked — pairing them across builds breaks at exec.
+# Also excluded: libmvec, libutil, libanl, libnsl, libthread_db — same glibc
+# version-lock; libm matches only when followed by '.' or '-', not libmvec.
+# libcuda/libnvidia are excluded because they are injected by the NVIDIA
+# container runtime and must match the host driver.
+RUN set -eu; \
+    command -v ldd >/dev/null || { echo "ERROR: ldd missing in builder" >&2; exit 1; }; \
+    for f in /snapshot-binaries/* /snapshot-binaries/criu-plugins/*.so; do \
+      [ -f "$f" ] || continue; \
+      ldd "$f" 2>/dev/null | awk '/=> \//{print $3}'; \
+    done | sort -u \
+    | grep -Ev '/(ld-linux|libc|libm|libmvec|libdl|libpthread|librt|libresolv|libutil|libanl|libnsl|libthread_db|libcuda|libnvidia)[.-]' \
+    | xargs -r -I{} cp -Ln {} /snapshot-binaries/lib/
+
+# Post-condition: verify each key binary resolves cleanly against the bundle's
+# lib/. The closure step above uses xargs -r which exits 0 on empty input, so
+# a silent ldd failure leaves lib/ empty; asserting here catches that.
+RUN set -eu; \
+    for f in /snapshot-binaries/criu /snapshot-binaries/ip \
+             /snapshot-binaries/tar /snapshot-binaries/criu-plugins/*.so; do \
+      [ -f "$f" ] || continue; \
+      if LD_LIBRARY_PATH=/snapshot-binaries/lib ldd "$f" 2>&1 | grep -q 'not found'; then \
+        echo "ERROR: unresolved shared libraries in $f:" >&2; \
+        LD_LIBRARY_PATH=/snapshot-binaries/lib ldd "$f" >&2; \
+        exit 1; \
+      fi; \
+    done
 
 COPY --from=sources /sources /legal/source
 
@@ -245,8 +312,34 @@ ENTRYPOINT ["/usr/local/bin/snapshot-agent"]
 
 # =============================================================================
 # Stage: Placeholder - Runtime-compatible restore image (requires BASE_IMAGE arg)
-# This image is a superset of the runtime image: same default execution contract
-# (entrypoint/cmd/user), plus CRIU/cuda-checkpoint tooling for external restore.
+#
+# This is the runtime image with the same default execution contract
+# (entrypoint/cmd), running as root so the agent can restore into it. It ships
+# NO checkpoint/restore tooling: criu, nsrestore, the cuda-checkpoint binaries,
+# their shared libraries, and the criu plugins are all bind-mounted on demand
+# from the agent's /snapshot-binaries bundle at restore time (internal/nsmount).
+# The mount destination is created by the ns-bind-mount helper inside this
+# namespace, so nothing needs pre-provisioning here.
+#
+# Three constraints follow from that and must hold for every BASE_IMAGE:
+#   - BASE_IMAGE must be glibc-compatible with AGENT_BASE_IMAGE, because the
+#     bundle's library closure is built from AGENT_BASE_IMAGE (ubuntu 24.04,
+#     glibc 2.39) and loaded ahead of the placeholder's own libraries via
+#     LD_LIBRARY_PATH. A 22.04-based BASE_IMAGE builds green but fails at
+#     restore with "version 'GLIBC_2.38' not found".
+#   - The node kernel must be >= 5.12 (mount_setattr, used by ns-bind-mount).
+#   - The placeholder pod must NOT set readOnlyRootFilesystem: true unless a
+#     writable volume is mounted at /tmp. The agent bind-mounts the binary
+#     bundle into the placeholder's /tmp at restore time; with a read-only
+#     root and nothing mounted at /tmp, creating the mount point fails with
+#     EROFS. An emptyDir at /tmp (either medium) makes it work again, since
+#     volume mounts stay writable independently of the root filesystem.
+#
+# cuda-checkpoint wrapping is opt-in (--cuda-checkpoint-wrap in snapshotctl).
+# When used, the source workload image must have cuda-checkpoint at the same
+# path as it runs from — CRIU restores file-backed mappings by path, not via
+# PATH search — and so must this placeholder image (same BASE_IMAGE).
+#
 # Backend entrypoints run a restore standby path when the operator
 # injects DYN_SNAPSHOT_RESTORE_STANDBY=1, then sleep while the
 # snapshot-agent restores into the container.
@@ -260,41 +353,9 @@ ENV ORIGINAL_BASE_IMAGE=${BASE_IMAGE}
 USER root
 
 RUN if [ "${TARGETARCH}" != "amd64" ]; then \
-      echo "ERROR: Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" >&2; exit 1; \
+      echo "ERROR: Snapshot requires x86_64" >&2; exit 1; \
     fi
 
-# Install minimal runtime dependencies for CRIU restore (nsrestore runs here via nsenter)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libbsd0 \
-    libcap2 \
-    libnet1 \
-    libnl-3-200 \
-    libnl-route-3-200 \
-    libprotobuf-c1 \
-    libgnutls30t64 \
-    libnftables1 \
-    iproute2 \
-    iptables \
-    procps \
-    uuid-runtime \
-    tar \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy CRIU from builder (needed by nsrestore running inside these namespaces)
-COPY --from=criu-builder /criu-install/usr/local /usr/local
-COPY --from=criu-builder /tmp/criu/COPYING /legal/CRIU/COPYING
-RUN criu --version && echo "CRIU installed successfully"
-
-# Copy CUDA checkpoint binaries
-COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /usr/local/sbin/cuda-checkpoint
-COPY --from=criu-builder /tmp/cuda-checkpoint/LICENSE /legal/cuda-checkpoint/LICENSE
-COPY --from=cuda-helper-builder /cuda-checkpoint-helper /usr/local/bin/cuda-checkpoint-helper
-RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-helper
-
-# Copy nsrestore binary (invoked by DaemonSet via nsenter)
-COPY --from=builder /nsrestore /usr/local/bin/nsrestore
-RUN chmod +x /usr/local/bin/nsrestore
-
-# Create directories
-RUN mkdir -p /checkpoints /var/run/criu /var/criu-work
+# Checkpoint volume mount point. This is a storage concern — no restore tooling
+# is provisioned here; see the stage comment above.
+RUN mkdir -p /checkpoints

--- a/agent/cmd/ns-bind-mount/main.c
+++ b/agent/cmd/ns-bind-mount/main.c
@@ -67,11 +67,11 @@ struct mount_attr {
  * namespace.
  *
  * These values mirror the Go constants in internal/nsmount/injector.go:
- *   agentBinDir    = "/snapshot-binaries"       → ALLOWED_SRC_PREFIX
- *   SnapshotBinDir = "/tmp/snapshot-binaries"   → ALLOWED_DST_PREFIX
+ *   SnapshotBinSrc = "/snapshot-binaries"       → ALLOWED_SRC_PREFIX
+ *   SnapshotBinDst = "/tmp/snapshot-binaries"   → ALLOWED_DST_PREFIX
  * Keep them in sync when either changes. */
-#define ALLOWED_SRC_PREFIX "/snapshot-binaries"     /* = nsmount.agentBinDir */
-#define ALLOWED_DST_PREFIX "/tmp/snapshot-binaries" /* = nsmount.SnapshotBinDir */
+#define ALLOWED_SRC_PREFIX "/snapshot-binaries"     /* = nsmount.SnapshotBinSrc */
+#define ALLOWED_DST_PREFIX "/tmp/snapshot-binaries" /* = nsmount.SnapshotBinDst */
 
 /* Returns 0 if path is absolute and begins with allowed_prefix, -1 otherwise. */
 static int

--- a/agent/cmd/nsrestore/main.go
+++ b/agent/cmd/nsrestore/main.go
@@ -8,11 +8,13 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 
 	"github.com/ai-dynamo/snapshot/agent/internal/executor"
 	"github.com/ai-dynamo/snapshot/agent/internal/logging"
+	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 )
 
 func main() {
@@ -23,10 +25,15 @@ func main() {
 	cudaDeviceMap := flag.String("cuda-device-map", "", "CUDA device map for cuda-checkpoint-helper restore")
 	cgroupRoot := flag.String("cgroup-root", "", "CRIU cgroup root remap path")
 	targetPodIP := flag.String("target-pod-ip", "", "Restore pod IP for CRIU TCP socket remapping")
+	bundleDir := flag.String("bundle-dir", nsmount.SnapshotBinDst, "Path where the agent binary bundle is mounted in this namespace")
 	flag.Parse()
 
 	if *checkpointPath == "" {
 		fatal(log, nil, "--checkpoint-path is required")
+	}
+
+	if err := useInjectedBundle(*bundleDir); err != nil {
+		fatal(log, err, "failed to point lookups at the injected bundle")
 	}
 
 	opts := executor.RestoreOptions{
@@ -34,6 +41,7 @@ func main() {
 		CUDADeviceMap:  *cudaDeviceMap,
 		CgroupRoot:     *cgroupRoot,
 		TargetPodIP:    *targetPodIP,
+		BundleDir:      *bundleDir,
 	}
 
 	result, err := executor.RestoreInNamespace(context.Background(), opts, log)
@@ -45,11 +53,42 @@ func main() {
 	}
 }
 
-func fatal(log logr.Logger, err error, msg string, keysAndValues ...interface{}) {
+func fatal(log logr.Logger, err error, msg string) {
 	if err != nil {
-		log.Error(err, msg, keysAndValues...)
+		log.Error(err, msg)
 	} else {
-		log.Info(msg, keysAndValues...)
+		log.Info(msg)
 	}
 	os.Exit(1)
+}
+
+// useInjectedBundle points every binary and library lookup at the agent bundle
+// mounted into this namespace. The placeholder ships no restore tooling, so
+// criu, its shared libraries, and the binaries criu forks (ip, iptables-restore)
+// must all resolve from the bundle.
+//
+// These are set on nsrestore's own environment rather than per-command: criu is
+// launched by go-criu, and criu in turn forks ip/iptables-restore, so neither
+// child is reachable through an exec.Cmd we control. Both inherit this environment.
+// nsrestore itself is a static binary, so LD_LIBRARY_PATH does not affect it.
+//
+// The inherited PATH and LD_LIBRARY_PATH are read from the process environment
+// directly — they arrive via the inherited env from the agent (execNSRestore sets
+// cmd.Env = os.Environ()), so no flags are needed to pass them through argv.
+func useInjectedBundle(bundleDir string) error {
+	libDir := filepath.Join(bundleDir, "lib")
+	if inherited := os.Getenv("LD_LIBRARY_PATH"); inherited != "" {
+		libDir += ":" + inherited
+	}
+	if err := os.Setenv("LD_LIBRARY_PATH", libDir); err != nil {
+		return err
+	}
+	newPATH := bundleDir
+	if inherited := os.Getenv("PATH"); inherited != "" {
+		newPATH = bundleDir + ":" + inherited
+	}
+	if err := os.Setenv("PATH", newPATH); err != nil {
+		return err
+	}
+	return nil
 }

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ai-dynamo/snapshot/agent/internal/executor"
+	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
@@ -52,6 +53,7 @@ type NodeController struct {
 	client       client.Client
 	dynClient    dynamic.Interface
 	runtime      snapshotruntime.Runtime
+	injector     executor.Mounter
 	log          logr.Logger
 	holderID     string
 	checkpointFn func(ctx context.Context, params CheckpointParams) error
@@ -114,12 +116,18 @@ func NewNodeController(
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
+	injector, err := nsmount.New(nsmount.SnapshotBinSrc, nsmount.SnapshotBinDst, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create binary injector: %w", err)
+	}
+
 	w := &NodeController{
 		config:    cfg,
 		clientset: clientset,
 		client:    typedClient,
 		dynClient: dynClient,
 		runtime:   rt,
+		injector:  injector,
 		log:       log,
 		holderID:  "snapshot-agent/" + uuid.NewString(),
 		inFlight:  make(map[string]struct{}),
@@ -572,21 +580,20 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
 
-	// Run the restore orchestrator (inspect + nsrestore).
+	// Run the restore orchestrator (inspect + mount agent bundle + nsrestore).
 	req := executor.RestoreRequest{
 		CheckpointID:                checkpointID,
 		CheckpointLocation:          checkpointLocation.HostPath,
 		ContainerCheckpointLocation: checkpointLocation.ContainerPath,
 		ContainerID:                 containerID,
 		StartedAt:                   startedAt,
-		NSRestorePath:               w.config.Restore.NSRestorePath,
 		PodName:                     pod.Name,
 		PodNamespace:                pod.Namespace,
 		TargetPodIP:                 pod.Status.PodIP,
 		ContainerName:               containerName,
 		Clientset:                   w.clientset,
 	}
-	placeholderHostPID, err := executor.Restore(restoreCtx, w.runtime, log, req)
+	placeholderHostPID, err := executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
 	if err != nil {
 		log.Error(err, "External restore failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
+	"github.com/ai-dynamo/snapshot/agent/internal/executor"
+	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
@@ -58,6 +61,31 @@ func (r *fakeRuntime) ResolveContainerByPod(ctx context.Context, pod, ns, ctr st
 }
 func (r *fakeRuntime) Close() error { return nil }
 
+// noopInjector is a no-op Mounter used in tests that do not exercise
+// the injection path. It prevents a nil-pointer panic if runRestore is ever
+// reached by a test that was previously relying on Phase 1 failing first.
+type noopInjector struct{}
+
+func (noopInjector) Mount(_ context.Context, _ int) (nsmount.MountPoint, error) {
+	return noopMountPoint{}, nil
+}
+
+type noopMountPoint struct{}
+
+func (noopMountPoint) Path(name string) (string, error) { return "/noop/" + name, nil }
+func (noopMountPoint) Unmount(_ context.Context) error  { return nil }
+func (noopMountPoint) NsFd() *os.File                   { return nil }
+
+// errorInjector always returns the wrapped error from Mount.
+type errorInjector struct{ err error }
+
+func (e errorInjector) Mount(_ context.Context, _ int) (nsmount.MountPoint, error) {
+	return nil, e.err
+}
+
+var _ executor.Mounter = noopInjector{}
+var _ executor.Mounter = errorInjector{}
+
 // makeTestController creates a NodeController with a fake k8s client and nil executors.
 // The fake clientset is empty so any goroutine launched by the restore path will fail on
 // the first annotatePod call and exit cleanly.
@@ -73,6 +101,7 @@ func makeTestController(t *testing.T, objs ...runtime.Object) *NodeController {
 		},
 		clientset: fake.NewClientset(objs...),
 		runtime:   &fakeRuntime{},
+		injector:  noopInjector{},
 		log:       testr.New(t),
 		holderID:  "test-holder",
 		inFlight:  make(map[string]struct{}),
@@ -714,5 +743,38 @@ func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {
 		if ok && event.Reason == "RestoreRequested" {
 			t.Fatalf("stale resolver should not start restore while attempt key is held; actions=%#v", clientset.Actions())
 		}
+	}
+}
+
+func TestRunRestoreEmitsRestoreFailedEventOnInjectError(t *testing.T) {
+	checkpointID := "test-checkpoint"
+	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, true,
+		map[string]string{snapshotv1alpha1.CheckpointIDLabel: checkpointID}, nil)
+
+	// Write a minimal manifest so inspectRestore can load it.
+	checkpointDir := filepath.Join(t.TempDir(), checkpointID)
+	if err := os.MkdirAll(checkpointDir, 0o755); err != nil {
+		t.Fatalf("create checkpoint dir: %v", err)
+	}
+	if err := types.WriteManifest(checkpointDir, &types.CheckpointManifest{CheckpointID: checkpointID}); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	injectErr := errors.New("injector unavailable")
+	w := makeTestController(t, pod)
+	// math.MaxInt32 is above any real kernel pid_max (≤4194304) so SendSignalToPID
+	// returns ESRCH instead of killing the test process.
+	w.runtime = &fakeRuntime{resolveContainerPID: math.MaxInt32}
+	w.injector = errorInjector{err: injectErr}
+
+	_ = w.runRestore(
+		context.Background(), pod, "main", "ctr-abc", checkpointID,
+		checkpointLocations{HostPath: checkpointDir, ContainerPath: checkpointDir},
+		"default/test-pod/main/ctr-abc",
+		time.Time{},
+	)
+
+	if !sawEventReason(w.clientset.(*fake.Clientset), "RestoreFailed") {
+		t.Fatal("expected RestoreFailed event when injector returns an error")
 	}
 }

--- a/agent/internal/criu/restore.go
+++ b/agent/internal/criu/restore.go
@@ -32,6 +32,7 @@ func ExecuteRestore(
 	criuOpts *criurpc.CriuOpts,
 	m *types.CheckpointManifest,
 	checkpointPath string,
+	bundleDir string,
 	log logr.Logger,
 ) (int32, func(), error) {
 	settings := m.CRIUDump.CRIU
@@ -41,9 +42,13 @@ func ExecuteRestore(
 	// and unlock. That keeps the window where the restored process runs with CUDA
 	// still locked as short as possible. cleanup is called on the error paths below.
 	var openFiles, inheritedFiles []*os.File
+	var confTmpDir string
 	cleanup := func() {
 		closeFiles(inheritedFiles)
 		closeFiles(openFiles)
+		if err := os.RemoveAll(confTmpDir); err != nil {
+			log.Error(err, "failed to remove criu config temp dir", "path", confTmpDir)
+		}
 	}
 
 	// Open image dir FD
@@ -69,12 +74,20 @@ func ExecuteRestore(
 		criuOpts.WorkDirFd = proto.Int32(workDirFD)
 	}
 
-	c := criulib.MakeCriu()
-	if _, err := os.Stat(settings.BinaryPath); err != nil {
+	overridePath, confTmpDir, err := rewriteCRIULibDir(criuOpts.ConfigFile, settings.WorkDir, bundleDir)
+	if err != nil {
 		cleanup()
-		return 0, nil, fmt.Errorf("criu binary not found at %s: %w", settings.BinaryPath, err)
+		return 0, nil, err
 	}
-	c.SetCriuPath(settings.BinaryPath)
+	criuOpts.ConfigFile = proto.String(overridePath)
+
+	criuBin, err := bundledCRIUPath(bundleDir)
+	if err != nil {
+		cleanup()
+		return 0, nil, err
+	}
+	c := criulib.MakeCriu()
+	c.SetCriuPath(criuBin)
 
 	netNsFile, err := os.Open(netNsPath)
 	if err != nil {
@@ -122,6 +135,18 @@ func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroup
 	criuOpts.MntnsCompatMode = proto.Bool(settings.MntnsCompatMode)
 	criuOpts.EvasiveDevices = proto.Bool(settings.EvasiveDevices)
 	criuOpts.ForceIrmap = proto.Bool(settings.ForceIrmap)
+
+	// Skip network locking on restore. CRIU only locks the network on this
+	// path via unlock_connection_info (criu/sk-tcp.c) and, under --empty-ns
+	// net, network_lock_internal (criu/cr-restore.c:2176) — neither applies
+	// here: the net namespace is external (see dump.go) and the restore target
+	// is a fresh placeholder netns with no dump-time DROP rules in it. SKIP is
+	// therefore inert, and it keeps criu from forking iptables-restore, which
+	// the injected bundle does not carry.
+	//
+	// Do NOT mirror this into BuildDumpOpts. Dump is where lock_connection
+	// actually protects the C/R window for tcpEstablished connections.
+	criuOpts.NetworkLock = criurpc.CriuNetworkLockMethod_SKIP.Enum()
 
 	if cgroupRoot != "" && shouldSetCgroupRoot(criuOpts.GetManageCgroupsMode()) {
 		criuOpts.CgRoot = []*criurpc.CgroupRoot{
@@ -180,6 +205,77 @@ func registerInheritFDs(c *criulib.Criu, stdioFDs []string, log logr.Logger) []*
 
 	log.V(1).Info("Registered inherited stdio pipes", "count", len(openFiles))
 	return openFiles
+}
+
+// rewriteCRIULibDir writes a criu.conf override that redirects the plugin libdir
+// to the injected bundle. The dump-time libdir points to the agent filesystem and
+// is unreachable inside the placeholder namespace; the override replaces it.
+// existingConfigFile is nil when the checkpoint was dumped without a criu.conf;
+// in that case the override is written from an empty base so CRIU always finds
+// its plugins at the injected path.
+// Returns (overridePath, tmpDir, err). tmpDir is non-empty only when workDir was
+// empty and a temporary directory was created; the caller must os.RemoveAll(tmpDir).
+func rewriteCRIULibDir(existingConfigFile *string, workDir, criuBundleDir string) (string, string, error) {
+	var tmpDir string
+	if workDir == "" {
+		// Older checkpoints may not have a WorkDir in their manifest. Fall back
+		// to a temp dir so the libdir override can still be written.
+		tmp, err := os.MkdirTemp("", "criu-restore-conf-*")
+		if err != nil {
+			return "", "", fmt.Errorf("rewriteCRIULibDir: no workDir and failed to create temp dir: %w", err)
+		}
+		workDir = tmp
+		tmpDir = tmp
+	}
+
+	var baseConf string
+	if existingConfigFile != nil {
+		data, err := os.ReadFile(*existingConfigFile)
+		if err != nil {
+			return "", tmpDir, fmt.Errorf("read criu config %s: %w", *existingConfigFile, err)
+		}
+		baseConf = string(data)
+	}
+
+	overridePath := filepath.Join(workDir, "criu-restore.conf")
+	conf := overrideLibDir(baseConf, filepath.Join(criuBundleDir, "criu-plugins"))
+	if err := os.WriteFile(overridePath, []byte(conf), 0644); err != nil {
+		return "", tmpDir, fmt.Errorf("write criu libdir override to %s: %w", overridePath, err)
+	}
+	return overridePath, tmpDir, nil
+}
+
+// bundledCRIUPath returns the path to the criu binary inside bundleDir.
+// BinaryPath in the checkpoint manifest refers to the agent filesystem and is
+// unusable inside the placeholder namespace; criu must always come from the injected bundle.
+func bundledCRIUPath(bundleDir string) (string, error) {
+	path := filepath.Join(bundleDir, "criu")
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("criu binary not found in injected bundle at %s: %w", path, err)
+	}
+	return path, nil
+}
+
+func overrideLibDir(conf, libDir string) string {
+	lines := strings.Split(conf, "\n")
+	replaced := false
+	for i, line := range lines {
+		if isLibDirLine(line) {
+			lines[i] = "libdir " + libDir
+			replaced = true
+		}
+	}
+	if !replaced {
+		lines = append(lines, "libdir "+libDir)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func isLibDirLine(line string) bool {
+	// CRIU's config parser (criu/config.c) accepts both space and tab as the
+	// key/value separator, so match both to avoid a duplicate libdir directive.
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "libdir ") || strings.HasPrefix(trimmed, "libdir\t")
 }
 
 func closeFiles(files []*os.File) {

--- a/agent/internal/criu/util_test.go
+++ b/agent/internal/criu/util_test.go
@@ -188,6 +188,34 @@ func TestApplyCommonSettings(t *testing.T) {
 	})
 }
 
+func TestOverrideLibDir(t *testing.T) {
+	t.Run("replaces existing libdir line", func(t *testing.T) {
+		conf := "log-level 4\nlibdir /usr/local/lib/snapshot/criu-plugins\nshell-job\n"
+		got := overrideLibDir(conf, "/tmp/snapshot-binaries/criu-plugins")
+		if strings.Contains(got, "/usr/local/lib/snapshot/criu-plugins") {
+			t.Error("old libdir should have been replaced")
+		}
+		if !strings.Contains(got, "libdir /tmp/snapshot-binaries/criu-plugins") {
+			t.Errorf("new libdir not found in output: %q", got)
+		}
+	})
+
+	t.Run("appends libdir when absent", func(t *testing.T) {
+		conf := "log-level 4\nshell-job\n"
+		got := overrideLibDir(conf, "/tmp/snapshot-binaries/criu-plugins")
+		if !strings.Contains(got, "libdir /tmp/snapshot-binaries/criu-plugins") {
+			t.Errorf("libdir not appended: %q", got)
+		}
+	})
+
+	t.Run("handles empty config", func(t *testing.T) {
+		got := overrideLibDir("", "/tmp/snapshot-binaries/criu-plugins")
+		if !strings.Contains(got, "libdir /tmp/snapshot-binaries/criu-plugins") {
+			t.Errorf("libdir not appended to empty config: %q", got)
+		}
+	})
+}
+
 func TestBuildRestoreExtMounts(t *testing.T) {
 	t.Run("normal manifest with ExtMnt", func(t *testing.T) {
 		m := &types.CheckpointManifest{

--- a/agent/internal/cuda/cuda.go
+++ b/agent/internal/cuda/cuda.go
@@ -24,6 +24,12 @@ import (
 const (
 	nvidiaGPUResource  = "nvidia.com/gpu"
 	nvidiaGPUDRADriver = "gpu.nvidia.com"
+
+	// HelperBinaryName is the cuda-checkpoint-helper executable name.
+	HelperBinaryName = "cuda-checkpoint-helper"
+	// DefaultHelperBinaryPath is the agent-side cuda-checkpoint-helper absolute path.
+	// In the placeholder namespace pass filepath.Join(bundleDir, HelperBinaryName) instead.
+	DefaultHelperBinaryPath = "/usr/local/bin/" + HelperBinaryName
 )
 
 var podResourcesSocketPath = "/var/lib/kubelet/pod-resources/kubelet.sock"
@@ -243,7 +249,7 @@ func FilterProcesses(ctx context.Context, allPIDs []int, log logr.Logger) []int 
 		if pid <= 0 {
 			continue
 		}
-		cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, "--get-restore-tid", "--pid", strconv.Itoa(pid))
+		cmd := exec.CommandContext(ctx, DefaultHelperBinaryPath, "--get-restore-tid", "--pid", strconv.Itoa(pid))
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			if ctx.Err() != nil {
@@ -347,21 +353,23 @@ func LockAndCheckpointProcessTree(ctx context.Context, cudaPIDs []int, log logr.
 }
 
 // RestoreAndUnlockProcessTree restores and unlocks CUDA state for the given PIDs.
-func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap string, log logr.Logger) (RestorePhaseTimings, error) {
+// helperBinaryPath must be the absolute path to cuda-checkpoint-helper: DefaultHelperBinaryPath
+// on the agent, or filepath.Join(bundleDir, HelperBinaryName) inside the placeholder namespace.
+func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap, helperBinaryPath string, log logr.Logger) (RestorePhaseTimings, error) {
 	var timings RestorePhaseTimings
 
 	start := time.Now()
 	for _, pid := range cudaPIDs {
-		if err := restoreProcess(ctx, pid, deviceMap, log); err != nil {
+		if err := restoreProcess(ctx, pid, deviceMap, helperBinaryPath, log); err != nil {
 			timings.TotalDuration = time.Since(start)
 			return timings, err
 		}
 	}
 
 	for _, pid := range cudaPIDs {
-		if err := unlock(ctx, pid, log); err != nil {
+		if err := unlock(ctx, pid, helperBinaryPath, log); err != nil {
 			timings.TotalDuration = time.Since(start)
-			state, stateErr := getState(ctx, pid)
+			state, stateErr := getState(ctx, pid, helperBinaryPath)
 			if stateErr == nil && state == "running" {
 				log.Info("cuda-checkpoint-helper unlock returned error but process is already running", "pid", pid)
 				continue

--- a/agent/internal/cuda/shim.go
+++ b/agent/internal/cuda/shim.go
@@ -20,8 +20,7 @@ import (
 )
 
 const (
-	defaultCUDAHelperBinary = "/usr/local/bin/cuda-checkpoint-helper"
-	helperWaitDelay         = 2 * time.Second
+	helperWaitDelay = 2 * time.Second
 
 	actionLock       = "lock"
 	actionCheckpoint = "checkpoint"
@@ -29,26 +28,26 @@ const (
 	actionUnlock     = "unlock"
 )
 
-var cudaCheckpointHelperBinary = defaultCUDAHelperBinary
+var cudaCheckpointHelperBinary = DefaultHelperBinaryPath
 
 func lock(ctx context.Context, pid int, log logr.Logger) error {
-	return runAction(ctx, pid, actionLock, "", log)
+	return runAction(ctx, pid, actionLock, "", DefaultHelperBinaryPath, log)
 }
 
 func checkpoint(ctx context.Context, pid int, log logr.Logger) error {
-	return runAction(ctx, pid, actionCheckpoint, "", log)
+	return runAction(ctx, pid, actionCheckpoint, "", DefaultHelperBinaryPath, log)
 }
 
-func restoreProcess(ctx context.Context, pid int, deviceMap string, log logr.Logger) error {
-	return runAction(ctx, pid, actionRestore, deviceMap, log)
+func restoreProcess(ctx context.Context, pid int, deviceMap, helperBinaryPath string, log logr.Logger) error {
+	return runAction(ctx, pid, actionRestore, deviceMap, helperBinaryPath, log)
 }
 
-func unlock(ctx context.Context, pid int, log logr.Logger) error {
-	return runAction(ctx, pid, actionUnlock, "", log)
+func unlock(ctx context.Context, pid int, helperBinaryPath string, log logr.Logger) error {
+	return runAction(ctx, pid, actionUnlock, "", helperBinaryPath, log)
 }
 
-func getState(ctx context.Context, pid int) (string, error) {
-	cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, "--get-state", "--pid", strconv.Itoa(pid))
+func getState(ctx context.Context, pid int, helperBinaryPath string) (string, error) {
+	cmd := exec.CommandContext(ctx, helperBinaryPath, "--get-state", "--pid", strconv.Itoa(pid))
 	output, err := cmd.CombinedOutput()
 	state := strings.TrimSpace(string(output))
 	if err != nil {
@@ -60,12 +59,12 @@ func getState(ctx context.Context, pid int) (string, error) {
 	return state, nil
 }
 
-func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.Logger) error {
+func runAction(ctx context.Context, pid int, action, deviceMap, helperBinaryPath string, log logr.Logger) error {
 	args := []string{"--action", action, "--pid", strconv.Itoa(pid)}
 	if action == actionRestore && deviceMap != "" {
 		args = append(args, "--device-map", deviceMap)
 	}
-	cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, args...)
+	cmd := exec.CommandContext(ctx, helperBinaryPath, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		return normalizeProcessGroupKillError(syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))

--- a/agent/internal/cuda/shim_test.go
+++ b/agent/internal/cuda/shim_test.go
@@ -33,7 +33,7 @@ func TestRunActionCancellationIsBounded(t *testing.T) {
 	defer cancel()
 
 	started := time.Now()
-	err := runAction(ctx, 11, actionRestore, "", logr.Discard())
+	err := runAction(ctx, 11, actionRestore, "", cudaCheckpointHelperBinary, logr.Discard())
 	duration := time.Since(started)
 	if err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
 		t.Fatalf("runAction() error = %v", err)

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -6,6 +6,8 @@ package executor
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -24,6 +26,8 @@ type RestoreOptions struct {
 	CUDADeviceMap  string
 	CgroupRoot     string
 	TargetPodIP    string
+	// BundleDir is the path where the agent's binary bundle is mounted inside this namespace.
+	BundleDir string
 }
 
 type RestoreInNamespaceResult struct {
@@ -31,6 +35,11 @@ type RestoreInNamespaceResult struct {
 	NSRestoreSetupDuration time.Duration `json:"nsrestoreSetupDuration"`
 	CRIURestoreDuration    time.Duration `json:"criuRestoreDuration"`
 	CUDADuration           time.Duration `json:"cudaDuration"`
+}
+
+// TotalDuration returns the sum of all in-namespace restore phase durations.
+func (r RestoreInNamespaceResult) TotalDuration() time.Duration {
+	return r.NSRestoreSetupDuration + r.CRIURestoreDuration + r.CUDADuration
 }
 
 // RestoreInNamespace performs a full restore from inside the target container's namespaces.
@@ -123,9 +132,27 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 		}
 	}()
 
+	// Open the cuda-checkpoint-helper fd BEFORE CRIU runs. CRIU restores the
+	// original mount namespace of the checkpointed process, which did not include
+	// the bundle mount at /tmp/snapshot-binaries. The C helper's umount code
+	// tolerates ENOENT from umount2 with the comment "Already gone (CRIU removed
+	// it during namespace restore)" — confirming this is observed behaviour. By
+	// opening the binary now and exec'ing via /proc/self/fd/N after CRIU returns,
+	// the fd remains valid even if the mount is gone.
+	var cudaHelperFdPath string
+	if !m.CUDA.IsEmpty() {
+		helperPath := filepath.Join(opts.BundleDir, cuda.HelperBinaryName)
+		f, err := os.Open(helperPath)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to open cuda-checkpoint-helper before CRIU restore: %w", err)
+		}
+		defer f.Close()
+		cudaHelperFdPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
+	}
+
 	// CRIU restore
 	criuRestoreStart := time.Now()
-	restoredPID, cleanup, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, log)
+	restoredPID, cleanup, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, opts.BundleDir, log)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -169,7 +196,7 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 			"restored_cuda_pids", restorePIDs,
 			"criu_callback_pid", restoredPID,
 		)
-		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, log)
+		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, cudaHelperFdPath, log)
 		if err != nil {
 			return nil, 0, fmt.Errorf("CUDA restore failed: %w", err)
 		}

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -21,9 +21,15 @@ import (
 	"github.com/ai-dynamo/snapshot/agent/internal/criu"
 	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	"github.com/ai-dynamo/snapshot/agent/internal/logging"
+	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
+
+// Mounter mounts the agent binary bundle into a placeholder container's mount namespace.
+type Mounter interface {
+	Mount(ctx context.Context, pid int) (nsmount.MountPoint, error)
+}
 
 // RestoreRequest holds the parameters for a restore operation.
 type RestoreRequest struct {
@@ -32,7 +38,6 @@ type RestoreRequest struct {
 	ContainerCheckpointLocation string
 	ContainerID                 string
 	StartedAt                   time.Time
-	NSRestorePath               string
 	PodName                     string
 	PodNamespace                string
 	TargetPodIP                 string
@@ -48,7 +53,7 @@ type RestoreRequest struct {
 // Returns the placeholder container's host PID so callers can reach into the
 // container's mount namespace (e.g. to write sentinels under /snapshot-control)
 // without re-resolving via the runtime.
-func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req RestoreRequest) (int, error) {
+func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req RestoreRequest, mounter Mounter) (placeholderPID int, retErr error) {
 	restoreStart := time.Now()
 	log.Info("=== Starting external restore ===",
 		"checkpoint_id", req.CheckpointID,
@@ -57,7 +62,7 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		"container", req.ContainerName,
 	)
 
-	// Phase 1: Host inspect — resolve placeholder, discover target GPUs, build device map
+	// Phase 1: Host inspect — resolve placeholder, discover target GPUs, build device map.
 	hostInspectStart := time.Now()
 	snap, err := inspectRestore(ctx, rt, log, req)
 	if err != nil {
@@ -65,17 +70,37 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 	}
 	hostInspectDuration := time.Since(hostInspectStart)
 
-	// Phase 2: Execute — nsrestore handles rootfs, CRIU restore, and CUDA restore inside namespace
-	result, err := execNSRestore(ctx, log, req, snap)
+	// Phase 2: Mount agent binaries into the placeholder's namespace so nsrestore is reachable.
+	injectStart := time.Now()
+	mp, err := mountBundle(ctx, mounter, snap.PlaceholderPID)
+	if err != nil {
+		return 0, err
+	}
+	injectDuration := time.Since(injectStart)
+	defer func() {
+		// Pass a background context: mp.Unmount has its own internal timeout
+		// (nsmount.unmountTimeout) around the ns-bind-mount subprocess.
+		if cleanupErr := mp.Unmount(context.Background()); cleanupErr != nil {
+			// Deliberately not promoted to retErr. The controller treats any
+			// error from Restore as a failed restore and SIGKILLs the placeholder,
+			// so surfacing a cleanup failure here would destroy a workload that
+			// already restored successfully. Log it and let the pod continue.
+			log.Error(cleanupErr, "failed to unmount agent bundle from placeholder namespace")
+		}
+	}()
+
+	// Phase 3: Execute — nsrestore handles rootfs, CRIU restore, and CUDA restore inside namespace.
+	result, err := execNSRestore(ctx, log, req, snap, mp)
 	if err != nil {
 		return 0, fmt.Errorf("nsrestore failed: %w", err)
 	}
-	restoreDuration := hostInspectDuration + result.NSRestoreSetupDuration + result.CRIURestoreDuration + result.CUDADuration
+	restoreDuration := hostInspectDuration + injectDuration + result.TotalDuration()
 	log.Info("Restore timing summary",
 		"restore", map[string]any{
 			"duration": restoreDuration.String(),
 			"phases": map[string]string{
 				"host_inspect_duration":    hostInspectDuration.String(),
+				"inject_duration":          injectDuration.String(),
 				"nsrestore_setup_duration": result.NSRestoreSetupDuration.String(),
 				"criu_restore_duration":    result.CRIURestoreDuration.String(),
 				"cuda_duration":            result.CUDADuration.String(),
@@ -88,13 +113,9 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		)
 	}
 
-	// Validate restored process from the host side
 	validationStart := time.Now()
-	procRoot := filepath.Join(snap.TargetRoot, "proc")
-	if err := snapshotruntime.ValidateProcessState(procRoot, result.RestoredPID); err != nil {
-		restoreLogPath := filepath.Join(snap.TargetRoot, "var", "criu-work", criu.RestoreLogFilename)
-		logging.LogProcessDiagnostics(procRoot, result.RestoredPID, restoreLogPath, log)
-		return 0, fmt.Errorf("restored process failed post-restore validation: %w", err)
+	if err := validateRestoredProcess(snap.TargetRoot, result.RestoredPID, log); err != nil {
+		return 0, err
 	}
 
 	log.Info("=== External restore completed ===",
@@ -105,6 +126,24 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 	)
 
 	return snap.PlaceholderPID, nil
+}
+
+func mountBundle(ctx context.Context, mounter Mounter, pid int) (nsmount.MountPoint, error) {
+	mp, err := mounter.Mount(ctx, pid)
+	if err != nil {
+		return nil, fmt.Errorf("mount agent bundle into placeholder: %w", err)
+	}
+	return mp, nil
+}
+
+func validateRestoredProcess(targetRoot string, restoredPID int, log logr.Logger) error {
+	procRoot := filepath.Join(targetRoot, "proc")
+	if err := snapshotruntime.ValidateProcessState(procRoot, restoredPID); err != nil {
+		restoreLogPath := filepath.Join(targetRoot, "var", "criu-work", criu.RestoreLogFilename)
+		logging.LogProcessDiagnostics(procRoot, restoredPID, restoreLogPath, log)
+		return fmt.Errorf("restored process failed post-restore validation: %w", err)
+	}
+	return nil
 }
 
 func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req RestoreRequest) (*types.RestoreContainerSnapshot, error) {
@@ -195,7 +234,21 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 
 // execNSRestore launches the nsrestore binary inside the placeholder container's
 // namespaces via nsenter and parses the restored PID from stdout JSON.
-func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, snap *types.RestoreContainerSnapshot) (*RestoreInNamespaceResult, error) {
+//
+// Security hardening in place:
+//
+//  1. Mount-namespace pinning: mp.NsFd() is the /proc/<pid>/ns/mnt fd opened at
+//     mount time. Passing it via --mount=/proc/self/fd/N to nsenter pins the mount
+//     namespace against PID reuse. The remaining four namespaces (uts, ipc, net,
+//     pid) are still resolved via -t <pid> and are not protected against reuse.
+//
+//  2. nsrestore binary fd: we open nsrestore from the agent host side (SnapshotBinSrc)
+//     before entering any namespace and exec it via /proc/self/fd/N. This protects
+//     the nsrestore binary itself against path-based substitution inside the
+//     container. Binaries that nsrestore subsequently loads (criu, ip, tar, .so
+//     files) are still resolved by PATH/LD_LIBRARY_PATH inside the container's
+//     mount namespace.
+func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, snap *types.RestoreContainerSnapshot, mp nsmount.MountPoint) (*RestoreInNamespaceResult, error) {
 	checkpointPath := req.ContainerCheckpointLocation
 	if checkpointPath != "" && !filepath.IsAbs(checkpointPath) {
 		return nil, fmt.Errorf("container checkpoint location must be absolute: %q", checkpointPath)
@@ -203,14 +256,45 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	if checkpointPath == "" {
 		checkpointPath = snap.CheckpointPath
 	}
-	args := []string{
-		"-t", strconv.Itoa(snap.PlaceholderPID),
-		// Intentionally exclude cgroup namespace (-C): CRIU must manage cgroups
-		// from the host-visible hierarchy so --cgroup-root remap works.
-		"-m", "-u", "-i", "-n", "-p",
-		"--", req.NSRestorePath,
-		"--checkpoint-path", checkpointPath,
+
+	// Open nsrestore from the agent host side before entering the container
+	// namespace, so the binary fd is immune to rename attacks inside the container.
+	binaryFile, err := os.Open(filepath.Join(nsmount.SnapshotBinSrc, "nsrestore"))
+	if err != nil {
+		return nil, fmt.Errorf("open nsrestore from agent bundle: %w", err)
 	}
+	defer binaryFile.Close()
+
+	// ExtraFiles[0] → child fd 3, ExtraFiles[1] → child fd 4.
+	// These constants mirror nsFdChildNum in mount.go (ExtraFiles[0] = fd 3).
+	const (
+		nsFdChild     = 3 // mp.NsFd() passed as ExtraFiles[0]
+		binaryFdChild = 4 // binaryFile passed as ExtraFiles[1]
+	)
+
+	bundleDir := nsmount.SnapshotBinDst // bundle root as seen inside the container
+	var args []string
+
+	nsFd := mp.NsFd()
+	if nsFd != nil {
+		// Use the pinned ns fd for the mount namespace; keep -t for the other
+		// namespaces (user, ipc, net, pid). This decouples mount-ns entry from
+		// PID liveness.
+		args = []string{
+			fmt.Sprintf("--mount=/proc/self/fd/%d", nsFdChild),
+			"-t", strconv.Itoa(snap.PlaceholderPID),
+			// Intentionally exclude cgroup namespace (-C): CRIU must manage cgroups
+			// from the host-visible hierarchy so --cgroup-root remap works.
+			"-u", "-i", "-n", "-p",
+			"--", fmt.Sprintf("/proc/self/fd/%d", binaryFdChild),
+		}
+	} else {
+		return nil, fmt.Errorf("execNSRestore: mp.NsFd() is nil; mount point was not properly initialized")
+	}
+	args = append(args,
+		"--checkpoint-path", checkpointPath,
+		"--bundle-dir", bundleDir,
+	)
 	if snap.CUDADeviceMap != "" {
 		args = append(args, "--cuda-device-map", snap.CUDADeviceMap)
 	}
@@ -224,6 +308,7 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	cmd := exec.CommandContext(ctx, "nsenter", args...)
 	// Inherit the agent environment so nsrestore uses the same logger settings.
 	cmd.Env = os.Environ()
+	cmd.ExtraFiles = []*os.File{nsFd, binaryFile}
 	log.V(1).Info("Executing nsenter + nsrestore", "cmd", cmd.String())
 
 	var stdout bytes.Buffer

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -6,14 +6,25 @@ package executor
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
+
+// testMountPoint satisfies nsmount.MountPoint for executor unit tests.
+type testMountPoint struct{ dst string }
+
+func (m testMountPoint) Path(name string) (string, error) { return m.dst + "/" + name, nil }
+func (m testMountPoint) Unmount(_ context.Context) error  { return nil }
+func (m testMountPoint) NsFd() *os.File                   { return nil }
+
+var _ nsmount.MountPoint = testMountPoint{}
 
 type restoreFakeRuntime struct {
 	resolvedID      string
@@ -42,12 +53,12 @@ func TestExecNSRestoreRejectsRelativeContainerCheckpointLocation(t *testing.T) {
 		testr.New(t),
 		RestoreRequest{
 			ContainerCheckpointLocation: "relative/checkpoint",
-			NSRestorePath:               "/usr/local/bin/nsrestore",
 		},
 		&types.RestoreContainerSnapshot{
 			CheckpointPath: "/host/checkpoints/abc123",
 			PlaceholderPID: 1,
 		},
+		testMountPoint{dst: "/tmp/snapshot-binaries"},
 	)
 	if err == nil {
 		t.Fatal("expected relative container checkpoint location to be rejected")

--- a/agent/internal/nsmount/injector.go
+++ b/agent/internal/nsmount/injector.go
@@ -7,12 +7,22 @@ package nsmount
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// SnapshotBinSrc is the agent-side directory containing the binary bundle.
+	SnapshotBinSrc = "/snapshot-binaries"
+	// SnapshotBinDst is the mount destination inside the placeholder namespace.
+	SnapshotBinDst = "/tmp/snapshot-binaries"
 )
 
 // MountPoint represents an active bind-mount of a directory inside a foreign
@@ -28,6 +38,12 @@ type MountPoint interface {
 	// A non-nil error means the mount may still be active; callers must treat
 	// this as fatal and exit so Kubernetes restarts into a clean namespace.
 	Unmount(ctx context.Context) error
+
+	// NsFd returns the pinned mount-namespace fd opened at Mount time.
+	// Use /proc/self/fd/<Fd()> as the --mount= argument to nsenter so the
+	// correct namespace is entered even if the original PID is recycled.
+	// Valid until Unmount is called. Test mocks may return nil.
+	NsFd() *os.File
 }
 
 // NSMounter mounts a source directory into a placeholder container's mount
@@ -39,11 +55,25 @@ type NSMounter struct {
 	log     logr.Logger
 }
 
+// probeKernelMountAPI verifies that mount_setattr (Linux 5.12) is available.
+// Called with a NULL attr, so a kernel that implements the syscall fails in
+// copy_struct_from_user with EFAULT; ENOSYS means the kernel is too old.
+func probeKernelMountAPI() error {
+	err := unix.MountSetattr(-1, "", 0, nil)
+	if errors.Is(err, syscall.ENOSYS) {
+		return fmt.Errorf("ns-bind-mount requires Linux 5.12+ (mount_setattr): kernel does not support it")
+	}
+	return nil
+}
+
 // New returns an NSMounter backed by the ns-bind-mount binary at its default
-// location. It errors if the helper binary is missing, so a misconfigured
-// node fails at startup rather than at the first mount.
-// Requires Linux 5.12+ (mount_setattr; open_tree/move_mount need only 5.2).
+// location. It errors if the helper binary is missing or if the kernel does not
+// support mount_setattr (Linux 5.12+), so a misconfigured node fails at agent
+// startup rather than at first restore.
 func New(src, dst string, log logr.Logger) (*NSMounter, error) {
+	if err := probeKernelMountAPI(); err != nil {
+		return nil, err
+	}
 	m, err := newExecMounter(defaultBinaryPath, log)
 	if err != nil {
 		return nil, err
@@ -90,4 +120,8 @@ func (h *mountPoint) Path(name string) (string, error) {
 
 func (h *mountPoint) Unmount(ctx context.Context) error {
 	return h.mount.Unmount(ctx)
+}
+
+func (h *mountPoint) NsFd() *os.File {
+	return h.mount.NsFd()
 }

--- a/agent/internal/nsmount/injector_test.go
+++ b/agent/internal/nsmount/injector_test.go
@@ -6,6 +6,7 @@ package nsmount
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +25,7 @@ type fakemountRef struct {
 }
 
 func (h *fakemountRef) TargetPath() string { return h.dst }
+func (h *fakemountRef) NsFd() *os.File     { return nil }
 
 func (h *fakemountRef) Unmount(_ context.Context) error {
 	*h.unmountLog = append(*h.unmountLog, h.dst)

--- a/agent/internal/nsmount/mount.go
+++ b/agent/internal/nsmount/mount.go
@@ -47,6 +47,11 @@ type mountRef interface {
 
 	// TargetPath returns the dst path as seen inside the target namespace.
 	TargetPath() string
+
+	// NsFd returns the pinned /proc/<pid>/ns/mnt file descriptor opened at
+	// Mount time. The fd remains valid until Unmount is called. Test mocks
+	// may return nil.
+	NsFd() *os.File
 }
 
 // mounter mounts src at dst inside the mount namespace identified by pid.
@@ -88,6 +93,7 @@ type execMountRef struct {
 }
 
 func (h *execMountRef) TargetPath() string { return h.dst }
+func (h *execMountRef) NsFd() *os.File     { return h.nsFd }
 
 func (h *execMountRef) Unmount(_ context.Context) error {
 	h.once.Do(func() {

--- a/agent/internal/types/config.go
+++ b/agent/internal/types/config.go
@@ -95,8 +95,7 @@ type StorageSpec struct {
 
 // RestoreSpec holds settings for the CRIU restore process.
 type RestoreSpec struct {
-	NSRestorePath         string `yaml:"nsRestorePath"`
-	RestoreTimeoutSeconds int    `yaml:"restoreTimeoutSeconds"`
+	RestoreTimeoutSeconds int `yaml:"restoreTimeoutSeconds"`
 }
 
 func (c *RestoreSpec) RestoreTimeout() time.Duration {
@@ -107,9 +106,6 @@ func (c *RestoreSpec) RestoreTimeout() time.Duration {
 }
 
 func (c *RestoreSpec) Validate() error {
-	if c.NSRestorePath == "" {
-		return &ConfigError{Field: "nsRestorePath", Message: "nsRestorePath is required"}
-	}
 	if c.RestoreTimeoutSeconds <= 0 {
 		return &ConfigError{Field: "restoreTimeoutSeconds", Message: "restoreTimeoutSeconds must be greater than zero"}
 	}

--- a/agent/internal/types/config_test.go
+++ b/agent/internal/types/config_test.go
@@ -12,7 +12,6 @@ func validAgentConfig() *AgentConfig {
 			BasePath: "/checkpoints",
 		},
 		Restore: RestoreSpec{
-			NSRestorePath:         "/usr/local/bin/nsrestore",
 			RestoreTimeoutSeconds: 60,
 		},
 	}

--- a/charts/snapshot/templates/configmap.yaml
+++ b/charts/snapshot/templates/configmap.yaml
@@ -27,7 +27,6 @@ data:
       exclusions: {{ toYaml .Values.config.overlay.exclusions | nindent 8 }}
 
     restore:
-      nsRestorePath: {{ .Values.config.restore.nsRestorePath | quote }}
       restoreTimeoutSeconds: {{ .Values.config.restore.restoreTimeoutSeconds }}
 
     criu:

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -200,8 +200,6 @@ config:
       - "*.pyc"
 
   restore:
-    # Path to the nsrestore binary in the placeholder image
-    nsRestorePath: /usr/local/bin/nsrestore
     # Maximum seconds to allow a restore attempt before the agent marks it failed
     restoreTimeoutSeconds: 7200
 

--- a/operator/cmd/snapshotctl/checkpoint.go
+++ b/operator/cmd/snapshotctl/checkpoint.go
@@ -13,20 +13,21 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 	snapshotprotocol "github.com/ai-dynamo/snapshot/operator/internal/protocol"
+
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
 const defaultGeneratedCheckpointIDPrefix = "manual-snapshot"
 
 type checkpointOptions struct {
-	ManifestPath                 string
-	Namespace                    string
-	KubeContext                  string
-	CheckpointID                 string
-	Container                    string
-	DisableCudaCheckpointJobFile bool
-	Timeout                      time.Duration
+	ManifestPath       string
+	Namespace          string
+	KubeContext        string
+	CheckpointID       string
+	Container          string
+	CudaCheckpointWrap bool
+	Timeout            time.Duration
 }
 
 type result struct {
@@ -59,7 +60,7 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (_ *result, 
 		checkpointID = fmt.Sprintf("%s-%d", defaultGeneratedCheckpointIDPrefix, time.Now().UTC().UnixNano())
 	}
 	resolvedStorage, err := snapshotv1alpha1.ResolveCheckpointStorage(checkpointID, "", snapshotv1alpha1.Storage{
-		Type:     snapshotv1alpha1.StorageTypePVC,
+		Type:     snapshotprotocol.StorageTypePVC,
 		PVCName:  storage.PVCName,
 		BasePath: storage.BasePath,
 	})
@@ -83,10 +84,10 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (_ *result, 
 		Namespace:       namespace,
 		TargetContainer: containers[0],
 		CheckpointID:    checkpointID,
-		ArtifactVersion: snapshotv1alpha1.DefaultCheckpointArtifactVersion,
-		SeccompProfile:  snapshotv1alpha1.DefaultSeccompLocalhostProfile,
+		ArtifactVersion: snapshotprotocol.DefaultCheckpointArtifactVersion,
+		SeccompProfile:  snapshotprotocol.DefaultSeccompLocalhostProfile,
 		Name:            checkpointJobName,
-		WrapLaunchJob:   !opts.DisableCudaCheckpointJobFile,
+		WrapLaunchJob:   opts.CudaCheckpointWrap,
 	})
 	if err != nil {
 		return nil, err

--- a/operator/cmd/snapshotctl/main.go
+++ b/operator/cmd/snapshotctl/main.go
@@ -50,7 +50,7 @@ func runCheckpoint(args []string) error {
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Explicit checkpoint ID; defaults to a generated value")
 	container := flags.String("container", "", "Required. Name of the workload container inside the manifest to checkpoint. May be omitted if the manifest already sets the nvidia.com/snapshot-target-containers annotation")
-	disableCudaCheckpointJobFile := flags.Bool("disable-cuda-checkpoint-job-file", false, "Preserve the manifest command instead of wrapping it with cuda-checkpoint --launch-job")
+	cudaCheckpointWrap := flags.Bool("cuda-checkpoint-wrap", false, "Wrap the container command with cuda-checkpoint --launch-job (required for multi-GPU checkpoints; the placeholder image must have cuda-checkpoint at the same path as the source container)")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for checkpoint completion")
 
 	if err := flags.Parse(args); err != nil {
@@ -65,13 +65,13 @@ func runCheckpoint(args []string) error {
 
 	snapshotctlLog.Info("Running checkpoint", "manifest", *manifest, "namespace", *namespace)
 	result, err := runCheckpointFlow(context.Background(), checkpointOptions{
-		ManifestPath:                 *manifest,
-		Namespace:                    *namespace,
-		KubeContext:                  *kubeContext,
-		CheckpointID:                 *checkpointID,
-		Container:                    *container,
-		DisableCudaCheckpointJobFile: *disableCudaCheckpointJobFile,
-		Timeout:                      *timeout,
+		ManifestPath:       *manifest,
+		Namespace:          *namespace,
+		KubeContext:        *kubeContext,
+		CheckpointID:       *checkpointID,
+		Container:          *container,
+		CudaCheckpointWrap: *cudaCheckpointWrap,
+		Timeout:            *timeout,
 	})
 	if err != nil {
 		return err

--- a/operator/internal/protocol/checkpoint_job_test.go
+++ b/operator/internal/protocol/checkpoint_job_test.go
@@ -289,6 +289,48 @@ func TestNewCheckpointJobRejectsUnknownTarget(t *testing.T) {
 	}
 }
 
+// TestNewCheckpointJobNoWrapByDefault verifies that the container command is
+// preserved unchanged when WrapLaunchJob is false (the default). This guards
+// against accidentally re-introducing cuda-checkpoint wrapping as the default,
+// which would require cuda-checkpoint to be present in the placeholder image
+// at the exact path CRIU checkpointed it from.
+func TestNewCheckpointJobNoWrapByDefault(t *testing.T) {
+	originalCmd := []string{"python3", "-m", "dynamo.vllm"}
+	originalArgs := []string{"--model", "Qwen"}
+
+	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "main",
+				Image:   "test:latest",
+				Command: originalCmd,
+				Args:    originalArgs,
+			}},
+		},
+	}, CheckpointJobOptions{
+		Namespace:       "test-ns",
+		TargetContainer: "main",
+		CheckpointID:    "hash",
+		ArtifactVersion: "2",
+		Name:            "test-job",
+		WrapLaunchJob:   false, // explicit: this is the default from snapshotctl
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "main")
+	if strings.Join(main.Command, " ") != strings.Join(originalCmd, " ") {
+		t.Errorf("command must be unchanged without WrapLaunchJob: got %v, want %v", main.Command, originalCmd)
+	}
+	if strings.Join(main.Args, " ") != strings.Join(originalArgs, " ") {
+		t.Errorf("args must be unchanged without WrapLaunchJob: got %v, want %v", main.Args, originalArgs)
+	}
+	if len(main.Command) > 0 && main.Command[0] == "cuda-checkpoint" {
+		t.Errorf("command must not be wrapped with cuda-checkpoint by default")
+	}
+}
+
 func TestGetCheckpointJobName(t *testing.T) {
 	name := GetCheckpointJobName("abc123def4567890", "2")
 	if name != "checkpoint-job-abc123def4567890-2" {


### PR DESCRIPTION
Sync upstream ai-dynamo/dynamo@4ab1d696 (#12626).

Overview
Replaces the static nsRestorePath config field with on-demand injection, then takes it to its conclusion: the placeholder image now ships no checkpoint/restore tooling at all.

The agent bind-mounts its /snapshot-binaries bundle into the placeholder container's mount namespace immediately before launching nsrestore. criu, nsrestore, the cuda-checkpoint binaries, their shared libraries, and the criu plugins all arrive through that mount. The placeholder Dockerfile is left with zero snapshot-specific lines.

Signed-off-by: Oleg Kushniriov <okushniriov@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restore operations now dynamically provide required binaries, plugins, libraries, and CUDA checkpoint tools.
  * Added support for restoring workloads with bundled CUDA helper paths.
  * Added kernel capability checks and validation for restore dependencies.

* **Bug Fixes**
  * Improved restore startup, cleanup, timing, and failure reporting.
  * Fixed checkpoint job behavior so commands remain unchanged unless CUDA wrapping is enabled.

* **Documentation**
  * Documented compatibility, kernel, filesystem, and CUDA path requirements.

* **Breaking Changes**
  * Replaced `--disable-cuda-checkpoint-job-file` with `--cuda-checkpoint-wrap`.
  * Removed the `nsRestorePath` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->