### PR TITLE
ci: allow arm64 e2e runner tooling

### DIFF
--- a/.github/actions/install-vcluster-cli/action.yml
+++ b/.github/actions/install-vcluster-cli/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: SHA256 for the linux amd64 vCluster CLI binary.
     required: false
     default: c3c16d9b425bf6a77b8cee0136c64a3f000b7440793c0f712564e1cb26d1f824
+  vcluster_sha256_arm64:
+    description: SHA256 for the linux arm64 vCluster CLI binary.
+    required: false
+    default: 7d81d6e59c0981bcd2010cddb554d95f85f6b856ccdc17550dd92f0071bd0dfb
 
 runs:
   using: composite
@@ -26,9 +30,14 @@ runs:
         arch="$(uname -m)"
         case "${arch}" in
           x86_64)
+            vcluster_arch="amd64"
             vcluster_sha256="${{ inputs.vcluster_sha256_amd64 }}"
             ;;
-          *) echo "::error::Snapshot e2e currently supports only x86_64 runners; got ${arch}"; exit 1 ;;
+          aarch64)
+            vcluster_arch="arm64"
+            vcluster_sha256="${{ inputs.vcluster_sha256_arm64 }}"
+            ;;
+          *) echo "::error::Unsupported runner architecture for vCluster CLI: ${arch}"; exit 1 ;;
         esac
 
         requested_version="${{ inputs.vcluster_version }}"
@@ -63,7 +72,7 @@ runs:
           --connect-timeout 10 --max-time 120 \
           --fail --show-error -sL \
           -o "${tmp_bin}" \
-          "https://github.com/loft-sh/vcluster/releases/download/${{ inputs.vcluster_version }}/vcluster-linux-amd64"
+          "https://github.com/loft-sh/vcluster/releases/download/${{ inputs.vcluster_version }}/vcluster-linux-${vcluster_arch}"
         echo "${vcluster_sha256}  ${tmp_bin}" | sha256sum -c -
         sudo install -m 0755 "${tmp_bin}" /usr/local/bin/vcluster
         rm -f "${tmp_bin}"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -85,14 +85,18 @@ jobs:
             kubectl delete namespace "${namespace}" --ignore-not-found --wait=false || true
           done
 
-      - name: Validate runner architecture
-        if: ${{ runner.arch != 'X64' }}
-        timeout-minutes: 1
-        run: |
-          echo "Snapshot e2e currently supports only X64 runners; got ${{ runner.arch }}" >&2
-          exit 1
+      - name: Install Python tooling (ARM64)
+        if: ${{ runner.arch == 'ARM64' }}
+        timeout-minutes: 3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.10.11"
+          checksum: "23003df007937dd607409c8ddf010baa82bad2673e60e254632ca5b04edcce13"
+          enable-cache: "false"
+          download-from-astral-mirror: "false"
 
-      - name: Install Python tooling
+      - name: Install Python tooling (X64)
+        if: ${{ runner.arch == 'X64' }}
         timeout-minutes: 3
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,12 +8,6 @@ on:
   schedule:
     # 23:00 Pacific Standard Time.
     - cron: "0 7 * * *"
-  pull_request:
-    paths:
-      - ".github/workflows/e2e.yaml"
-      - ".github/actions/install-vcluster-cli/**"
-      - "e2e/**"
-      - "charts/snapshot/**"
 
 concurrency:
   group: snapshot-e2e-vcluster-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,12 @@ on:
   schedule:
     # 23:00 Pacific Standard Time.
     - cron: "0 7 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/e2e.yaml"
+      - ".github/actions/install-vcluster-cli/**"
+      - "e2e/**"
+      - "charts/snapshot/**"
 
 concurrency:
   group: snapshot-e2e-vcluster-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
Allows the Snapshot e2e workflow to run on ARM64 GitHub runners while keeping the target GPU workload scheduling unchanged. The workflow now installs architecture-specific uv and vCluster CLI binaries with pinned checksums.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 runners when installing the CLI.
  * Architecture-specific CLI binaries and checksum validation are now selected automatically.
  * End-to-end testing tooling now supports both ARM64 and x64 runners.

* **Bug Fixes**
  * Removed the restriction preventing end-to-end workflows from running on non-x64 architectures.
  * Improved handling and reporting of unsupported runner architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->