### PR TITLE
fix(ci): allow release artifact publishing

### DIFF
--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -35,8 +35,7 @@ jobs:
     name: Compute version
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_call' ||
-      github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     outputs:
       version: ${{ steps.compute.outputs.version }}


### PR DESCRIPTION
## Summary

- allow release-triggered reusable workflow calls to publish artifacts
- continue skipping artifact publication after unsuccessful CI workflow runs

## Root cause

Reusable workflows inherit the caller's GitHub context. A call from the release workflow therefore has `github.event_name == 'release'`, not `workflow_call`. The existing condition skipped the version job, which cascaded to all shipping and Go module tagging jobs.

## Validation

- parsed `.github/workflows/push-artifacts.yaml` as YAML
- ran `make verify-license-headers`
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow checks to run across more event types.
  * Continued requiring successful CI results for workflow-triggered runs.
  * Simplified event handling for more consistent artifact processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->