### PR TITLE
test: update e2e PodSnapshot spec

### DIFF
--- a/e2e/snapshot_e2e/lifecycle.py
+++ b/e2e/snapshot_e2e/lifecycle.py
@@ -14,6 +14,7 @@ from kubernetes.client import ApiException
 
 from snapshot_e2e import k8s
 from snapshot_e2e.workloads import CHECKPOINT_DIR
+from snapshot_e2e.workloads import CONTAINER
 from snapshot_e2e.workloads import FILE_TOKEN
 from snapshot_e2e.workloads import OBSERVATIONS
 from snapshot_e2e.workloads import RESTORE_DONE
@@ -57,12 +58,21 @@ def create_podsnapshot(
     name: str,
     pod_name: str,
     pod_uid: str,
+    container: str = CONTAINER,
 ) -> dict[str, Any]:
     body = {
         "apiVersion": f"{GROUP}/{VERSION}",
         "kind": "PodSnapshot",
         "metadata": {"name": name, "namespace": namespace},
-        "spec": {"source": {"podRef": {"name": pod_name, "uid": pod_uid}}},
+        "spec": {
+            "source": {
+                "podRef": {
+                    "name": pod_name,
+                    "uid": pod_uid,
+                    "containers": [container],
+                }
+            }
+        },
     }
     return client.CustomObjectsApi().create_namespaced_custom_object(
         GROUP,

--- a/e2e/snapshot_e2e/workloads.py
+++ b/e2e/snapshot_e2e/workloads.py
@@ -62,15 +62,19 @@ def source_pod(
     run: TestRun,
     gpu: bool,
     include_target_annotation: bool = True,
+    include_checkpoint_label: bool = True,
 ) -> dict[str, Any]:
+    labels = {
+        **run.labels,
+        "nvidia.com/snapshot-is-checkpoint-source": "true",
+    }
+    if include_checkpoint_label:
+        labels["nvidia.com/snapshot-checkpoint-id"] = run.checkpoint_id
+
     metadata = {
         "name": run.source_pod,
         "namespace": config.namespace,
-        "labels": {
-            **run.labels,
-            "nvidia.com/snapshot-checkpoint-id": run.checkpoint_id,
-            "nvidia.com/snapshot-is-checkpoint-source": "true",
-        },
+        "labels": labels,
         "annotations": {
             "nvidia.com/snapshot-storage-type": "pvc",
             "nvidia.com/snapshot-storage-base-path": CHECKPOINT_DIR,

--- a/e2e/tests/test_snapshot_lifecycle.py
+++ b/e2e/tests/test_snapshot_lifecycle.py
@@ -115,7 +115,7 @@ def test_successful_restore_recovers_cpu_gpu_and_fs_from_snapshot(
 
 
 @pytest.mark.snapshot_failure
-def test_failed_snapshot_missing_target_container_annotation(
+def test_failed_snapshot_missing_checkpoint_id_label(
     config: k8s.E2EConfig,
     run: snap.TestRun,
 ) -> None:
@@ -124,7 +124,7 @@ def test_failed_snapshot_missing_target_container_annotation(
             config,
             run,
             gpu=False,
-            include_target_annotation=False,
+            include_checkpoint_label=False,
         )
         snap.create_podsnapshot(
             config.namespace,
@@ -143,8 +143,8 @@ def test_failed_snapshot_missing_target_container_annotation(
         assert ready is None or ready.get("status") != "True"
         assert content is not None
         content_failed = snap.condition(content, "Failed")
-        assert content_failed and content_failed.get("reason") == "MissingTargetContainer"
-        assert "target" in content_failed.get("message", "").lower()
+        assert content_failed and content_failed.get("reason") == "MissingCheckpointID"
+        assert "checkpoint" in content_failed.get("message", "").lower()
     except Exception:
         snap.debug_dump(config, run)
         raise
@@ -210,6 +210,7 @@ def create_ready_source(
     *,
     gpu: bool,
     include_target_annotation: bool = True,
+    include_checkpoint_label: bool = True,
 ) -> tuple[object, str]:
     k8s.create_pod(
         snap.source_pod(
@@ -217,6 +218,7 @@ def create_ready_source(
             run=run,
             gpu=gpu,
             include_target_annotation=include_target_annotation,
+            include_checkpoint_label=include_checkpoint_label,
         )
     )
     pod = snap.wait_for_pod_ready(config.namespace, run.source_pod)
@@ -244,6 +246,7 @@ def assert_podsnapshot_ready(
 
     assert content["spec"]["source"]["podRef"]["name"] == source.metadata.name
     assert content["spec"]["source"]["podRef"]["uid"] == source.metadata.uid
+    assert content["spec"]["source"]["podRef"]["containers"] == [snap.CONTAINER]
     assert content["spec"]["source"]["nodeName"] == source_node
     assert content["metadata"].get("labels", {}).get("nvidia.com/snapshot-node") == source_node
 


### PR DESCRIPTION
## Summary
- set PodSnapshot source podRef containers in e2e tests
- update the snapshot failure case to use the current checkpoint-ID validation path
- assert the bound PodSnapshotContent preserves the source container list

## Validation
- uv run --locked --project e2e pytest --collect-only e2e/tests -q
- uv run --locked --project e2e python -m compileall -q e2e/snapshot_e2e e2e/tests
- local vCluster lifecycle run passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot lifecycle handling for workloads with multiple containers.
  * Snapshot creation now supports selecting the intended source container.
  * Updated validation to provide clearer failure results when required checkpoint metadata is missing.
* **Tests**
  * Expanded lifecycle coverage for container references, checkpoint labels, and snapshot readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->