### PR TITLE
fix: preserve CUDA launch-job identity across restore

### DIFF
--- a/agent/cmd/cuda-checkpoint-helper/main.c
+++ b/agent/cmd/cuda-checkpoint-helper/main.c
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <ctype.h>
 #include <cuda.h>
@@ -14,10 +16,10 @@ print_usage(FILE* stream)
   return fprintf(
              stream,
              "Usage:\n"
-             "  cuda-checkpoint-helper --get-state --pid <pid>\n"
-             "  cuda-checkpoint-helper --get-restore-tid --pid <pid>\n"
+             "  cuda-checkpoint-helper --get-state --pid <pid> [--job-file <path>]\n"
+             "  cuda-checkpoint-helper --get-restore-tid --pid <pid> [--job-file <path>]\n"
              "  cuda-checkpoint-helper --action lock|checkpoint|restore|unlock --pid <pid> [--timeout <ms>] "
-             "[--device-map <uuids>]\n") < 0
+             "[--device-map <uuids>] [--job-file <path>]\n") < 0
              ? 1
              : 0;
 }
@@ -272,6 +274,7 @@ main(int argc, char** argv)
 {
   const char* action = NULL;
   const char* device_map = "";
+  const char* job_file = "";
   int pid = 0;
   int have_pid = 0;
   int do_get_state_flag = 0;
@@ -320,6 +323,13 @@ main(int argc, char** argv)
       device_map = argv[i];
       continue;
     }
+    if (strcmp(argv[i], "--job-file") == 0) {
+      if (++i >= argc || argv[i][0] == '\0') {
+        return print_usage(stderr);
+      }
+      job_file = argv[i];
+      continue;
+    }
     if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
       return print_usage(stdout);
     }
@@ -331,6 +341,11 @@ main(int argc, char** argv)
   }
   if (!have_pid) {
     return print_usage(stderr);
+  }
+
+  if (job_file[0] != '\0' && setenv("CUDA_CHECKPOINT_JOB_FILE", job_file, 1) != 0) {
+    perror("setenv CUDA_CHECKPOINT_JOB_FILE");
+    return 1;
   }
 
   if (do_get_state_flag) {

--- a/agent/internal/cuda/cuda.go
+++ b/agent/internal/cuda/cuda.go
@@ -328,24 +328,29 @@ func BuildDeviceMap(sourceUUIDs, targetUUIDs []string, log logr.Logger) (string,
 	return strings.Join(pairs, ","), nil
 }
 
-// LockAndCheckpointProcessTree locks and checkpoints CUDA state for all given PIDs.
+// CheckpointProcessTree locks and checkpoints CUDA state for all given PIDs,
+// then persists the launch-job state needed to restore them.
 // On failure, the caller is expected to fail the operation and terminate the workload.
-func LockAndCheckpointProcessTree(ctx context.Context, cudaPIDs []int, log logr.Logger) (CheckpointPhaseTimings, error) {
+func CheckpointProcessTree(ctx context.Context, cudaPIDs []int, jobFile, checkpointDir string, log logr.Logger) (CheckpointPhaseTimings, error) {
 	var timings CheckpointPhaseTimings
 
 	start := time.Now()
 	for _, pid := range cudaPIDs {
-		if err := lock(ctx, pid, log); err != nil {
+		if err := lockWithJobFile(ctx, pid, jobFile, log); err != nil {
 			timings.TotalDuration = time.Since(start)
 			return timings, err
 		}
 	}
 
 	for _, pid := range cudaPIDs {
-		if err := checkpoint(ctx, pid, log); err != nil {
+		if err := checkpointWithJobFile(ctx, pid, jobFile, log); err != nil {
 			timings.TotalDuration = time.Since(start)
 			return timings, err
 		}
+	}
+	if err := refreshJobFileArtifact(jobFile, checkpointDir); err != nil {
+		timings.TotalDuration = time.Since(start)
+		return timings, err
 	}
 	timings.TotalDuration = time.Since(start)
 

--- a/agent/internal/cuda/job.go
+++ b/agent/internal/cuda/job.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
+	"golang.org/x/sys/unix"
+)
+
+// JobFileEnv is the CUDA launch-job environment variable consumed by the driver.
+const JobFileEnv = "CUDA_CHECKPOINT_JOB_FILE"
+
+// StageJobFile copies a launch-job file into the checkpoint artifact and
+// returns the host-visible path to the source pod's live job file. Capture
+// helpers must use that live file so they join the same CUDA job as the target
+// processes; the artifact copy is only a seed for later restore pods. A process
+// may only name the job file created for this checkpoint; the privileged agent
+// must not copy an arbitrary container path into shared storage.
+func StageJobFile(hostProcPath string, cudaPIDs []int, checkpointDir string, sourceGPUCount int) (string, error) {
+	if len(cudaPIDs) == 0 {
+		return "", nil
+	}
+
+	jobFile := ""
+	jobFilePID := 0
+	missingPIDs := make([]int, 0, len(cudaPIDs))
+	for _, pid := range cudaPIDs {
+		value, err := processEnvironmentValue(hostProcPath, pid, JobFileEnv)
+		if err != nil {
+			return "", err
+		}
+		if value == "" {
+			missingPIDs = append(missingPIDs, pid)
+			continue
+		}
+		if jobFile == "" {
+			jobFile = value
+			jobFilePID = pid
+			continue
+		}
+		if value != jobFile {
+			return "", fmt.Errorf("CUDA processes do not share one %s: %q != %q", JobFileEnv, jobFile, value)
+		}
+	}
+	if jobFile == "" {
+		if sourceGPUCount > 1 {
+			return "", fmt.Errorf("multi-GPU CUDA processes are missing %s", JobFileEnv)
+		}
+		return "", nil
+	}
+	if len(missingPIDs) > 0 {
+		return "", fmt.Errorf("CUDA processes %v are missing %s while other CUDA processes use it", missingPIDs, JobFileEnv)
+	}
+	if !filepath.IsAbs(jobFile) || filepath.Clean(jobFile) != jobFile {
+		return "", fmt.Errorf("%s must be an absolute, clean path, got %q", JobFileEnv, jobFile)
+	}
+	if jobFile == "/proc" || strings.HasPrefix(jobFile, "/proc/") {
+		return "", fmt.Errorf("%s must be persisted outside procfs before checkpoint, got %q", JobFileEnv, jobFile)
+	}
+	if jobFile != snapshotv1alpha1.CUDAJobFilePath {
+		return "", fmt.Errorf("%s is %q, want checkpoint job file %q", JobFileEnv, jobFile, snapshotv1alpha1.CUDAJobFilePath)
+	}
+
+	sourcePath := filepath.Join(hostProcPath, strconv.Itoa(jobFilePID), "root", strings.TrimPrefix(jobFile, string(os.PathSeparator)))
+	destinationPath := filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)
+	if err := copyJobFile(sourcePath, destinationPath); err != nil {
+		return "", fmt.Errorf("stage CUDA checkpoint job file: %w", err)
+	}
+	return sourcePath, nil
+}
+
+// refreshJobFileArtifact captures the job state after every CUDA process has
+// reached CHECKPOINTED. CUDA mutates the launch-job file while checkpointing,
+// so the earlier validation copy is not a valid restore seed.
+func refreshJobFileArtifact(liveJobFile, checkpointDir string) error {
+	if liveJobFile == "" {
+		return nil
+	}
+	destinationPath := filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)
+	if err := prepareLiveJobFile(liveJobFile, destinationPath); err != nil {
+		return fmt.Errorf("refresh CUDA checkpoint job file: %w", err)
+	}
+	return nil
+}
+
+// PrepareLiveJobFile materializes the immutable capture-time launch-job state
+// at the stable path recorded in the checkpointed process environment. It runs
+// inside the restore container's namespaces before CRIU recreates processes.
+// The returned path is the per-restore working copy that CUDA helpers must use;
+// the staged artifact remains immutable so it can seed later restores.
+func PrepareLiveJobFile(stagedJobFile string) (string, error) {
+	if err := prepareLiveJobFile(stagedJobFile, snapshotv1alpha1.CUDAJobFilePath); err != nil {
+		return "", err
+	}
+	return snapshotv1alpha1.CUDAJobFilePath, nil
+}
+
+// JobFileFromCheckpoint returns the staged job file when an artifact contains one.
+func JobFileFromCheckpoint(checkpointDir string) (string, error) {
+	jobFile := filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)
+	info, err := os.Lstat(jobFile)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("stat CUDA checkpoint job file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("CUDA checkpoint job file %q is not a regular file", jobFile)
+	}
+	return jobFile, nil
+}
+
+func processEnvironmentValue(hostProcPath string, pid int, name string) (string, error) {
+	content, err := os.ReadFile(filepath.Join(hostProcPath, strconv.Itoa(pid), "environ"))
+	if err != nil {
+		return "", fmt.Errorf("read environment for CUDA process %d: %w", pid, err)
+	}
+	prefix := name + "="
+	for _, entry := range strings.Split(string(content), "\x00") {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), nil
+		}
+	}
+	return "", nil
+}
+
+func copyJobFile(sourcePath, destinationPath string) error {
+	return copyRegularFile(sourcePath, destinationPath, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL)
+}
+
+func prepareLiveJobFile(sourcePath, destinationPath string) error {
+	return copyRegularFile(sourcePath, destinationPath, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC)
+}
+
+func copyRegularFile(sourcePath, destinationPath string, destinationFlags int) (err error) {
+	fd, err := unix.Open(sourcePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	source := os.NewFile(uintptr(fd), sourcePath)
+	defer func() {
+		if closeErr := source.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close source %q: %w", sourcePath, closeErr)
+		}
+	}()
+
+	info, err := source.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source %q is not a regular file", sourcePath)
+	}
+
+	destinationFD, err := unix.Open(destinationPath, destinationFlags|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0600)
+	if err != nil {
+		return err
+	}
+	destination := os.NewFile(uintptr(destinationFD), destinationPath)
+	defer func() {
+		if closeErr := destination.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close destination %q: %w", destinationPath, closeErr)
+		}
+	}()
+
+	if err := destination.Chmod(0600); err != nil {
+		return err
+	}
+	if _, err := io.Copy(destination, source); err != nil {
+		return err
+	}
+	return destination.Sync()
+}
+
+// SetLiveJobFileOwner makes the restore-time working copy accessible to the
+// restored workload without following a replacement symlink.
+func SetLiveJobFileOwner(jobFile string, uid, gid int) error {
+	fd, err := unix.Open(jobFile, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open live CUDA checkpoint job file %q: %w", jobFile, err)
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("stat live CUDA checkpoint job file %q: %w", jobFile, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = unix.Close(fd)
+		return fmt.Errorf("live CUDA checkpoint job file %q is not a regular file", jobFile)
+	}
+	if err := unix.Fchown(fd, uid, gid); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("set live CUDA checkpoint job file %q owner to %d:%d: %w", jobFile, uid, gid, err)
+	}
+	if err := unix.Close(fd); err != nil {
+		return fmt.Errorf("close live CUDA checkpoint job file %q: %w", jobFile, err)
+	}
+	return nil
+}

--- a/agent/internal/cuda/job_test.go
+++ b/agent/internal/cuda/job_test.go
@@ -1,0 +1,358 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
+)
+
+func TestStageJobFile(t *testing.T) {
+	procRoot := t.TempDir()
+	checkpointDir := t.TempDir()
+	jobFile := snapshotv1alpha1.CUDAJobFilePath
+
+	for _, pid := range []string{"101", "202"} {
+		processRoot := filepath.Join(procRoot, pid, "root")
+		if err := os.MkdirAll(filepath.Join(processRoot, filepath.Dir(jobFile)), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(procRoot, pid, "environ"), []byte("OTHER=value\x00"+JobFileEnv+"="+jobFile+"\x00"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(procRoot, "101", "root", jobFile), []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	helperJobFile, err := StageJobFile(procRoot, []int{101, 202}, checkpointDir, 2)
+	if err != nil {
+		t.Fatalf("StageJobFile() error = %v", err)
+	}
+	wantHelperJobFile := filepath.Join(procRoot, "101", "root", jobFile)
+	if helperJobFile != wantHelperJobFile {
+		t.Fatalf("StageJobFile() = %q, want %q", helperJobFile, wantHelperJobFile)
+	}
+	artifact := filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)
+	content, err := os.ReadFile(artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "job-state" {
+		t.Fatalf("staged content = %q", content)
+	}
+}
+
+func TestStageJobFileRejectsTransientProcPath(t *testing.T) {
+	procRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(procRoot, "101"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procRoot, "101", "environ"), []byte(JobFileEnv+"=/proc/1/fd/3\x00"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := StageJobFile(procRoot, []int{101}, t.TempDir(), 1)
+	if err == nil || !strings.Contains(err.Error(), "persisted outside procfs") {
+		t.Fatalf("expected transient procfs error, got %v", err)
+	}
+}
+
+func TestStageJobFileRejectsUnexpectedContainerPath(t *testing.T) {
+	procRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(procRoot, "101"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procRoot, "101", "environ"), []byte(JobFileEnv+"=/etc/shadow\x00"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := StageJobFile(procRoot, []int{101}, t.TempDir(), 1)
+	if err == nil || !strings.Contains(err.Error(), "want checkpoint job file") {
+		t.Fatalf("expected unexpected-path error, got %v", err)
+	}
+}
+
+func TestStageJobFileRejectsSymlink(t *testing.T) {
+	procRoot := t.TempDir()
+	checkpointDir := t.TempDir()
+	jobFile := snapshotv1alpha1.CUDAJobFilePath
+	processRoot := filepath.Join(procRoot, "101", "root")
+	if err := os.MkdirAll(filepath.Join(processRoot, filepath.Dir(jobFile)), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procRoot, "101", "environ"), []byte(JobFileEnv+"="+jobFile+"\x00"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(processRoot, "secret")
+	if err := os.WriteFile(secret, []byte("must-not-copy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(processRoot, jobFile)
+	if err := os.Symlink(filepath.Join("..", "secret"), source); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := StageJobFile(procRoot, []int{101}, checkpointDir, 1)
+	if err == nil {
+		t.Fatal("expected symlink source to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("staged file exists after rejected symlink: %v", statErr)
+	}
+}
+
+func TestRefreshJobFileArtifactCapturesPostCheckpointState(t *testing.T) {
+	checkpointDir := t.TempDir()
+	live := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	artifact := filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)
+	if err := os.WriteFile(live, []byte("pre-checkpoint-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifact, []byte("validation-copy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(live, []byte("post-checkpoint-job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := refreshJobFileArtifact(live, checkpointDir); err != nil {
+		t.Fatalf("refreshJobFileArtifact() error = %v", err)
+	}
+	content, err := os.ReadFile(artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "post-checkpoint-job-state" {
+		t.Fatalf("artifact content = %q", content)
+	}
+}
+
+func TestStageJobFileRequiresLaunchJobStateForMultiGPU(t *testing.T) {
+	procRoot := t.TempDir()
+	for _, pid := range []string{"101", "202"} {
+		if err := os.MkdirAll(filepath.Join(procRoot, pid), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(procRoot, pid, "environ"), []byte("OTHER=value\x00"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	jobFile, err := StageJobFile(procRoot, []int{101}, t.TempDir(), 1)
+	if err != nil || jobFile != "" {
+		t.Fatalf("legacy single-GPU StageJobFile() = %q, %v", jobFile, err)
+	}
+	_, err = StageJobFile(procRoot, []int{101, 202}, t.TempDir(), 2)
+	if err == nil || !strings.Contains(err.Error(), "multi-GPU CUDA processes are missing") {
+		t.Fatalf("expected missing multi-GPU launch-job error, got %v", err)
+	}
+}
+
+func TestCheckpointProcessTreePersistsStateAfterEveryProcessCheckpoint(t *testing.T) {
+	tempDir := t.TempDir()
+	trace := filepath.Join(tempDir, "trace")
+	helper := filepath.Join(tempDir, "cuda-checkpoint-helper")
+	script := `#!/bin/sh
+action=""
+pid=""
+job_file=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --action) action="$2"; shift 2 ;;
+        --pid) pid="$2"; shift 2 ;;
+        --job-file) job_file="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [ "$job_file" != "$DYNAMO_TEST_JOB_FILE" ]; then
+    printf 'job file = %s, want %s\n' "$job_file" "$DYNAMO_TEST_JOB_FILE" >&2
+    exit 1
+fi
+printf '%s %s\n' "$action" "$pid" >> "$DYNAMO_TEST_TRACE"
+if [ "$action" = checkpoint ]; then printf '|%s' "$pid" >> "$job_file"; fi
+`
+	if err := os.WriteFile(helper, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	originalHelper := cudaCheckpointHelperBinary
+	cudaCheckpointHelperBinary = helper
+	t.Cleanup(func() { cudaCheckpointHelperBinary = originalHelper })
+
+	liveJobFile := filepath.Join(tempDir, "live-job")
+	checkpointDir := filepath.Join(tempDir, "checkpoint")
+	if err := os.Mkdir(checkpointDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveJobFile, []byte("initial"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName), []byte("validation-copy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DYNAMO_TEST_TRACE", trace)
+	t.Setenv("DYNAMO_TEST_JOB_FILE", liveJobFile)
+
+	if _, err := CheckpointProcessTree(context.Background(), []int{101, 202}, liveJobFile, checkpointDir, logr.Discard()); err != nil {
+		t.Fatalf("CheckpointProcessTree() error = %v", err)
+	}
+	traceContent, err := os.ReadFile(trace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(traceContent), "lock 101\nlock 202\ncheckpoint 101\ncheckpoint 202\n"; got != want {
+		t.Fatalf("helper call order = %q, want %q", got, want)
+	}
+	artifact, err := os.ReadFile(filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(artifact), "initial|101|202"; got != want {
+		t.Fatalf("persisted job state = %q, want %q", got, want)
+	}
+}
+
+func TestSetLiveJobFileOwner(t *testing.T) {
+	jobFile := filepath.Join(t.TempDir(), "job-file")
+	if err := os.WriteFile(jobFile, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	wantUID, wantGID := os.Getuid(), os.Getgid()
+	if os.Geteuid() == 0 {
+		wantUID, wantGID = 1234, 2345
+	}
+	if err := SetLiveJobFileOwner(jobFile, wantUID, wantGID); err != nil {
+		t.Fatalf("SetLiveJobFileOwner() error = %v", err)
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Stat(jobFile, &stat); err != nil {
+		t.Fatal(err)
+	}
+	if gotUID, gotGID := int(stat.Uid), int(stat.Gid); gotUID != wantUID || gotGID != wantGID {
+		t.Fatalf("job file ownership = %d:%d, want %d:%d", gotUID, gotGID, wantUID, wantGID)
+	}
+}
+
+func TestSetLiveJobFileOwnerRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	jobFile := filepath.Join(dir, "job-file")
+	if err := os.Symlink(target, jobFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetLiveJobFileOwner(jobFile, os.Getuid(), os.Getgid()); err == nil {
+		t.Fatal("SetLiveJobFileOwner() accepted a symlink")
+	}
+}
+
+func TestJobFileFromCheckpointRejectsSymlink(t *testing.T) {
+	checkpointDir := t.TempDir()
+	target := filepath.Join(checkpointDir, "target")
+	if err := os.WriteFile(target, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(checkpointDir, snapshotv1alpha1.CUDAJobFileName)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := JobFileFromCheckpoint(checkpointDir)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("expected symlink artifact to be rejected, got %v", err)
+	}
+}
+
+func TestPrepareLiveJobFileReplacesMutatedState(t *testing.T) {
+	staged := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	live := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	if err := os.WriteFile(staged, []byte("capture-time-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(live, []byte("longer-mutated-restore-state"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareLiveJobFile(staged, live); err != nil {
+		t.Fatalf("prepareLiveJobFile() error = %v", err)
+	}
+	content, err := os.ReadFile(live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "capture-time-state" {
+		t.Fatalf("live content = %q", content)
+	}
+	info, err := os.Stat(live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("live mode = %o, want 600", got)
+	}
+}
+
+func TestPrepareLiveJobFileKeepsRestoreTargetsIsolated(t *testing.T) {
+	staged := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	if err := os.WriteFile(staged, []byte("capture-time-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	second := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	if err := prepareLiveJobFile(staged, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareLiveJobFile(staged, second); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(first, []byte("first-restore-mutated-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "capture-time-state" {
+		t.Fatalf("second restore content changed to %q", content)
+	}
+}
+
+func TestPrepareLiveJobFileRejectsSymlinkDestination(t *testing.T) {
+	staged := filepath.Join(t.TempDir(), snapshotv1alpha1.CUDAJobFileName)
+	if err := os.WriteFile(staged, []byte("capture-time-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	destinationDir := t.TempDir()
+	target := filepath.Join(destinationDir, "target")
+	if err := os.WriteFile(target, []byte("must-not-change"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	live := filepath.Join(destinationDir, snapshotv1alpha1.CUDAJobFileName)
+	if err := os.Symlink(target, live); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareLiveJobFile(staged, live); err == nil {
+		t.Fatal("expected symlink destination to be rejected")
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "must-not-change" {
+		t.Fatalf("symlink target changed to %q", content)
+	}
+}

--- a/agent/internal/cuda/shim_job_file.go
+++ b/agent/internal/cuda/shim_job_file.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
+)
+
+func lockWithJobFile(ctx context.Context, pid int, jobFile string, log logr.Logger) error {
+	if jobFile == "" {
+		return lock(ctx, pid, log)
+	}
+	return runActionWithJobFile(ctx, pid, actionLock, jobFile, log)
+}
+
+func checkpointWithJobFile(ctx context.Context, pid int, jobFile string, log logr.Logger) error {
+	if jobFile == "" {
+		return checkpoint(ctx, pid, log)
+	}
+	return runActionWithJobFile(ctx, pid, actionCheckpoint, jobFile, log)
+}
+
+func runActionWithJobFile(ctx context.Context, pid int, action, jobFile string, log logr.Logger) error {
+	args := []string{"--action", action, "--pid", strconv.Itoa(pid), "--job-file", jobFile}
+	cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return normalizeProcessGroupKillError(syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
+	}
+	cmd.WaitDelay = helperWaitDelay
+	details := snapshotruntime.ProcessDetails{
+		ObservedPID:   pid,
+		OutermostPID:  pid,
+		InnermostPID:  pid,
+		NamespacePIDs: []int{pid},
+	}
+	if process, err := snapshotruntime.ReadProcessDetails("/proc", pid); err == nil {
+		details = process
+	}
+	start := time.Now()
+	output, err := cmd.CombinedOutput()
+	duration := time.Since(start)
+	out := strings.TrimSpace(string(output))
+	if err != nil {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		log.Error(err, "cuda-checkpoint-helper command failed",
+			"pid", pid,
+			"outermost_pid", details.OutermostPID,
+			"innermost_pid", details.InnermostPID,
+			"cmdline", details.Cmdline,
+			"action", action,
+			"duration", duration,
+			"output", out,
+		)
+		return fmt.Errorf("cuda-checkpoint-helper %v failed for pid %d after %s: %w (output: %s)", args, pid, duration, err, out)
+	}
+	log.V(1).Info("cuda-checkpoint-helper command succeeded",
+		"pid", pid,
+		"outermost_pid", details.OutermostPID,
+		"innermost_pid", details.InnermostPID,
+		"cmdline", details.Cmdline,
+		"action", action,
+		"duration", duration,
+		"output", out,
+	)
+	return nil
+}

--- a/agent/internal/cuda/shim_restore_job_file_test.go
+++ b/agent/internal/cuda/shim_restore_job_file_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
+)
+
+func TestRunActionInheritsJobFileEnvironment(t *testing.T) {
+	trace := filepath.Join(t.TempDir(), "trace")
+	installFakeCUDAHelper(t, "printf '%s' \"$CUDA_CHECKPOINT_JOB_FILE\" > \""+trace+"\"\n")
+	t.Setenv(JobFileEnv, snapshotv1alpha1.CUDAJobFilePath)
+
+	if err := runAction(context.Background(), 11, actionRestore, "", cudaCheckpointHelperBinary, logr.Discard()); err != nil {
+		t.Fatalf("runAction() error = %v", err)
+	}
+	content, err := os.ReadFile(trace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(content), snapshotv1alpha1.CUDAJobFilePath; got != want {
+		t.Fatalf("helper environment = %q, want %q", got, want)
+	}
+}

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -81,6 +81,10 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	if err != nil {
 		return err
 	}
+	cudaJobFile, err := cuda.StageJobFile(snapshotruntime.HostProcPath, state.CUDAHostPIDs, tmpDir, len(state.GPUUUIDs))
+	if err != nil {
+		return err
+	}
 
 	// Phase 2: Configure CRIU options and build checkpoint manifest
 	criuOpts, data, err := configureCheckpoint(log, state, req, cfg, tmpDir)
@@ -90,7 +94,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	phaseTimings.PrepareDuration = time.Since(prepareStart)
 
 	// Phase 3: Capture — CRIU dump, rootfs diff
-	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, log)
+	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, cudaJobFile, log)
 	if err != nil {
 		return err
 	}
@@ -253,12 +257,12 @@ func configureCheckpoint(
 	return criuOpts, m, nil
 }
 
-func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSettings *types.CRIUSettings, data *types.CheckpointManifest, state *types.CheckpointContainerSnapshot, checkpointDir string, log logr.Logger) (*checkpointPhaseTimings, error) {
+func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSettings *types.CRIUSettings, data *types.CheckpointManifest, state *types.CheckpointContainerSnapshot, checkpointDir, cudaJobFile string, log logr.Logger) (*checkpointPhaseTimings, error) {
 	timings := &checkpointPhaseTimings{}
 
 	// CUDA lock+checkpoint must happen before CRIU dump
 	if len(state.CUDAHostPIDs) > 0 {
-		cudaTimings, err := cuda.LockAndCheckpointProcessTree(ctx, state.CUDAHostPIDs, log)
+		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)
 		}

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -51,7 +51,6 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 		"cgroup_root", opts.CgroupRoot,
 		"target_pod_ip_present", opts.TargetPodIP != "",
 	)
-
 	manifestReadStart := time.Now()
 	m, err := types.ReadManifest(opts.CheckpointPath)
 	if err != nil {
@@ -64,6 +63,16 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 		"manage_cgroups_mode", m.CRIUDump.CRIU.ManageCgroupsMode,
 		"checkpoint_has_cuda", !m.CUDA.IsEmpty(),
 	)
+	cudaJobFile := ""
+	if !m.CUDA.IsEmpty() {
+		cudaJobFile, err = cuda.JobFileFromCheckpoint(opts.CheckpointPath)
+		if err != nil {
+			return nil, err
+		}
+		if len(m.CUDA.SourceGPUUUIDs) > 1 && cudaJobFile == "" {
+			return nil, fmt.Errorf("multi-GPU checkpoint is missing CUDA launch-job state")
+		}
+	}
 
 	// Phase 1: Configure — build CRIU opts from manifest
 	configureStart := time.Now()
@@ -77,7 +86,7 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	configureDuration := time.Since(configureStart)
 
 	// Phase 2: Execute — rootfs, CRIU restore, CUDA restore
-	executeTimings, restoredPID, err := executeRestore(ctx, criuOpts, m, opts, log)
+	executeTimings, restoredPID, err := executeRestore(ctx, criuOpts, m, opts, cudaJobFile, log)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +113,7 @@ type nsrestorePhaseTimings struct {
 	cudaDuration           time.Duration
 }
 
-func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.CheckpointManifest, opts RestoreOptions, log logr.Logger) (*nsrestorePhaseTimings, int, error) {
+func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.CheckpointManifest, opts RestoreOptions, cudaJobFile string, log logr.Logger) (*nsrestorePhaseTimings, int, error) {
 	timings := &nsrestorePhaseTimings{}
 
 	// Apply rootfs diff inside the namespace (target root is /)
@@ -115,6 +124,17 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 
 	if err := snapshotruntime.ApplyDeletedFiles(opts.CheckpointPath, "/", log); err != nil {
 		log.Error(err, "Failed to apply deleted files")
+	}
+	cudaRestoreJobFile := ""
+	if cudaJobFile != "" {
+		liveJobFile, err := cuda.PrepareLiveJobFile(cudaJobFile)
+		if err != nil {
+			return nil, 0, fmt.Errorf("prepare CUDA checkpoint job file: %w", err)
+		}
+		cudaRestoreJobFile = liveJobFile
+		if err := os.Setenv(cuda.JobFileEnv, cudaRestoreJobFile); err != nil {
+			return nil, 0, fmt.Errorf("set CUDA checkpoint job file environment: %w", err)
+		}
 	}
 
 	// Unmount placeholder's /dev/shm so CRIU can recreate tmpfs with checkpointed content
@@ -163,6 +183,15 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 	timings.criuRestoreDuration = time.Since(criuRestoreStart)
 
 	cudaStart := time.Now()
+	if cudaRestoreJobFile != "" {
+		uid, gid, err := snapshotruntime.ReadProcessFilesystemIDs("/proc", int(restoredPID))
+		if err != nil {
+			return nil, 0, fmt.Errorf("read restored process credentials: %w", err)
+		}
+		if err := cuda.SetLiveJobFileOwner(cudaRestoreJobFile, uid, gid); err != nil {
+			return nil, 0, fmt.Errorf("set CUDA checkpoint job file ownership: %w", err)
+		}
+	}
 	processes, err := snapshotruntime.ReadProcessTable("/proc")
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to read restored process table: %w", err)

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -104,3 +104,22 @@ func TestInspectRestoreUsesContainerIDWhenProvided(t *testing.T) {
 		t.Fatal("ResolveContainerByPod should not be used when ContainerID is provided")
 	}
 }
+
+func TestRestoreInNamespaceRejectsMultiGPUCheckpointWithoutLaunchJobState(t *testing.T) {
+	checkpointDir := t.TempDir()
+	manifest := types.NewCheckpointManifest(
+		"checkpoint-123",
+		types.CRIUDumpManifest{},
+		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil),
+		types.OverlayManifest{},
+	)
+	manifest.CUDA = types.NewCUDAManifest([]int{42, 43}, []string{"GPU-aaa", "GPU-bbb"})
+	if err := types.WriteManifest(checkpointDir, manifest); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	_, err := RestoreInNamespace(context.Background(), RestoreOptions{CheckpointPath: checkpointDir}, testr.New(t))
+	if err == nil || !strings.Contains(err.Error(), "missing CUDA launch-job state") {
+		t.Fatalf("expected missing multi-GPU launch-job error, got %v", err)
+	}
+}

--- a/agent/internal/runtime/process.go
+++ b/agent/internal/runtime/process.go
@@ -30,6 +30,51 @@ type ProcessDetails struct {
 	Cmdline       string
 }
 
+// ReadProcessFilesystemIDs returns the filesystem UID and GID from a proc status entry.
+func ReadProcessFilesystemIDs(procRoot string, pid int) (int, int, error) {
+	if pid <= 0 {
+		return 0, 0, fmt.Errorf("invalid PID %d", pid)
+	}
+
+	statusPath := filepath.Join(procRoot, strconv.Itoa(pid), "status")
+	statusBytes, err := os.ReadFile(statusPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read %s: %w", statusPath, err)
+	}
+	status := string(statusBytes)
+
+	uid, err := parseProcessFilesystemID(status, "Uid:")
+	if err != nil {
+		return 0, 0, err
+	}
+	gid, err := parseProcessFilesystemID(status, "Gid:")
+	if err != nil {
+		return 0, 0, err
+	}
+	return uid, gid, nil
+}
+
+func parseProcessFilesystemID(status, field string) (int, error) {
+	for _, line := range strings.Split(status, "\n") {
+		if !strings.HasPrefix(line, field) {
+			continue
+		}
+		values := strings.Fields(strings.TrimPrefix(line, field))
+		if len(values) != 4 {
+			return 0, fmt.Errorf("invalid %s process status field %q", strings.TrimSuffix(field, ":"), line)
+		}
+		value, err := strconv.Atoi(values[3])
+		if err != nil {
+			return 0, fmt.Errorf("invalid filesystem %s %q: %w", strings.TrimSuffix(field, ":"), values[3], err)
+		}
+		if value < 0 {
+			return 0, fmt.Errorf("invalid filesystem %s %q", strings.TrimSuffix(field, ":"), values[3])
+		}
+		return value, nil
+	}
+	return 0, fmt.Errorf("missing %s in process status", strings.TrimSuffix(field, ":"))
+}
+
 // ReadProcessDetails reads one proc entry from a proc root.
 func ReadProcessDetails(procRoot string, pid int) (ProcessDetails, error) {
 	if pid <= 0 {
@@ -107,7 +152,6 @@ func ReadProcessDetails(procRoot string, pid int) (ProcessDetails, error) {
 	}, nil
 }
 
-// TODO: dead code — remove once no longer synced from Dynamo.
 // ReadProcessDetailsOrDefault preserves pid-scoped logging even when proc parsing fails.
 func ReadProcessDetailsOrDefault(procRoot string, pid int) ProcessDetails {
 	details := ProcessDetails{

--- a/agent/internal/runtime/process_test.go
+++ b/agent/internal/runtime/process_test.go
@@ -10,6 +10,33 @@ import (
 	"testing"
 )
 
+func TestReadProcessFilesystemIDs(t *testing.T) {
+	procRoot := t.TempDir()
+	pidDir := filepath.Join(procRoot, "42")
+	if err := os.Mkdir(pidDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	status := "Uid:\t1000\t1001\t1002\t1003\nGid:\t2000\t2001\t2002\t2003\n"
+	if err := os.WriteFile(filepath.Join(pidDir, "status"), []byte(status), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	uid, gid, err := ReadProcessFilesystemIDs(procRoot, 42)
+	if err != nil {
+		t.Fatalf("ReadProcessFilesystemIDs() error = %v", err)
+	}
+	if uid != 1003 || gid != 2003 {
+		t.Fatalf("ReadProcessFilesystemIDs() = %d:%d, want 1003:2003", uid, gid)
+	}
+
+	if err := os.WriteFile(filepath.Join(pidDir, "status"), []byte("Uid:\t1000\t1001\t1002\t1003\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ReadProcessFilesystemIDs(procRoot, 42); err == nil {
+		t.Fatal("ReadProcessFilesystemIDs() accepted a status without Gid")
+	}
+}
+
 func TestParseProcExitCode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -82,7 +109,7 @@ func TestReadProcessDetails(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(procDir, "status"), []byte("Name:\tpython3\nPPid:\t0\nNSpid:\t2402711 1018\n"), 0644); err != nil {
 		t.Fatalf("WriteFile(status): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(procDir, "cmdline"), []byte("python3\x00-m\x00vllm\x00"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(procDir, "cmdline"), []byte("python3\x00-m\x00dynamo.vllm\x00"), 0644); err != nil {
 		t.Fatalf("WriteFile(cmdline): %v", err)
 	}
 
@@ -105,8 +132,8 @@ func TestReadProcessDetails(t *testing.T) {
 	if len(details.NamespacePIDs) != 2 || details.NamespacePIDs[0] != 2402711 || details.NamespacePIDs[1] != 1018 {
 		t.Fatalf("NamespacePIDs = %v, want [2402711 1018]", details.NamespacePIDs)
 	}
-	if details.Cmdline != "python3 -m vllm" {
-		t.Fatalf("Cmdline = %q, want %q", details.Cmdline, "python3 -m vllm")
+	if details.Cmdline != "python3 -m dynamo.vllm" {
+		t.Fatalf("Cmdline = %q, want %q", details.Cmdline, "python3 -m dynamo.vllm")
 	}
 }
 
@@ -143,7 +170,7 @@ func TestReadProcessTable(t *testing.T) {
 	}
 
 	writeEntry(768, "Name:\tworker\nPPid:\t1\nNSpid:\t2444000 768\n", "VLLM::Worker_TP0\x00")
-	writeEntry(1, "Name:\tpython3\nPPid:\t0\nNSpid:\t2443990 1\n", "python3\x00-m\x00vllm\x00")
+	writeEntry(1, "Name:\tpython3\nPPid:\t0\nNSpid:\t2443990 1\n", "python3\x00-m\x00dynamo.vllm\x00")
 
 	processes, err := ReadProcessTable(procRoot)
 	if err != nil {
@@ -161,7 +188,7 @@ func TestResolveManifestPIDsToObservedPIDs(t *testing.T) {
 	processes := []ProcessDetails{
 		{ObservedPID: 1, ParentPID: 0, OutermostPID: 1, InnermostPID: 1, NamespacePIDs: []int{1}, Cmdline: "sleep infinity"},
 		{ObservedPID: 50, ParentPID: 0, OutermostPID: 50, InnermostPID: 50, NamespacePIDs: []int{50}, Cmdline: "nsrestore"},
-		{ObservedPID: 74, ParentPID: 50, OutermostPID: 74, InnermostPID: 1, NamespacePIDs: []int{74, 1}, Cmdline: "python3 -m vllm"},
+		{ObservedPID: 74, ParentPID: 50, OutermostPID: 74, InnermostPID: 1, NamespacePIDs: []int{74, 1}, Cmdline: "python3 -m dynamo.vllm"},
 		{ObservedPID: 80, ParentPID: 74, OutermostPID: 80, InnermostPID: 750, NamespacePIDs: []int{80, 750}, Cmdline: "VLLM::EngineCore"},
 		{ObservedPID: 81, ParentPID: 74, OutermostPID: 81, InnermostPID: 749, NamespacePIDs: []int{81, 749}, Cmdline: "resource_tracker"},
 	}
@@ -182,7 +209,7 @@ func TestResolveManifestPIDsToObservedPIDsFailsWhenManifestPIDMissingFromRestore
 	processes := []ProcessDetails{
 		{ObservedPID: 1, ParentPID: 0, OutermostPID: 1, InnermostPID: 1, NamespacePIDs: []int{1}, Cmdline: "sleep infinity"},
 		{ObservedPID: 50, ParentPID: 0, OutermostPID: 50, InnermostPID: 50, NamespacePIDs: []int{50}, Cmdline: "nsrestore"},
-		{ObservedPID: 74, ParentPID: 50, OutermostPID: 74, InnermostPID: 1, NamespacePIDs: []int{74, 1}, Cmdline: "python3 -m vllm"},
+		{ObservedPID: 74, ParentPID: 50, OutermostPID: 74, InnermostPID: 1, NamespacePIDs: []int{74, 1}, Cmdline: "python3 -m dynamo.vllm"},
 	}
 
 	_, err := ResolveManifestPIDsToObservedPIDs(processes, 74, []int{1, 750})
@@ -194,7 +221,7 @@ func TestResolveManifestPIDsToObservedPIDsFailsWhenManifestPIDMissingFromRestore
 func TestResolveManifestPIDsToObservedPIDsFailsWhenNamespaceDepthIsNotTwo(t *testing.T) {
 	processes := []ProcessDetails{
 		{ObservedPID: 50, ParentPID: 0, OutermostPID: 50, InnermostPID: 50, NamespacePIDs: []int{50}, Cmdline: "nsrestore"},
-		{ObservedPID: 74, ParentPID: 50, OutermostPID: 74, InnermostPID: 1, NamespacePIDs: []int{900, 74, 1}, Cmdline: "python3 -m vllm"},
+		{ObservedPID: 74, ParentPID: 50, OutermostPID: 74, InnermostPID: 1, NamespacePIDs: []int{900, 74, 1}, Cmdline: "python3 -m dynamo.vllm"},
 		{ObservedPID: 80, ParentPID: 74, OutermostPID: 80, InnermostPID: 750, NamespacePIDs: []int{900, 80, 750}, Cmdline: "VLLM::EngineCore"},
 	}
 

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -93,4 +93,14 @@ const (
 	// checkpoint. Observed by the checkpoint job's kubelet readiness probe
 	// on the worker container.
 	ReadyForSnapshotFile = "ready-for-snapshot"
+
+	// CUDAJobFileName is the stable name the cuda-checkpoint-helper launch-job
+	// wrapper persists the CUDA checkpoint job file under, inside the control
+	// volume. The stable location survives past the transient path the CUDA
+	// driver reports via CUDA_CHECKPOINT_JOB_FILE.
+	CUDAJobFileName = "cuda-checkpoint-job"
+
+	// CUDAJobFilePath is the full stable path to the persisted CUDA checkpoint
+	// job file.
+	CUDAJobFilePath = SnapshotControlMountPath + "/" + CUDAJobFileName
 )

--- a/operator/internal/protocol/checkpoint.go
+++ b/operator/internal/protocol/checkpoint.go
@@ -149,13 +149,25 @@ func DisableCheckpointJobSidecarInjection(annotations map[string]string) map[str
 
 // wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the
 // workload is launched under `cuda-checkpoint --launch-job`, required for
-// multi-GPU checkpoints. The original command and args are preserved as-is
-// (including shell-form entrypoints): workload-to-agent signaling now uses
-// file sentinels in the snapshot-control volume, so an intervening shell at
-// PID 1 is no longer an issue.
+// multi-GPU checkpoints. The launch-job file is copied from its transient
+// procfs FD into the per-pod snapshot control volume before the original
+// command starts. The workload inherits that stable path, while the snapshot
+// agent stages the capture-time contents into the versioned artifact.
 func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	wrappedArgs := make([]string, 0, len(command)+len(args)+1)
-	wrappedArgs = append(wrappedArgs, "--launch-job")
+	const persistJobFileScript = `set -eu
+job_file="$1"
+shift
+if [ -z "${CUDA_CHECKPOINT_JOB_FILE:-}" ]; then
+    echo "CUDA_CHECKPOINT_JOB_FILE is missing; cuda-checkpoint --launch-job requires NVIDIA driver 610 or newer" >&2
+    exit 1
+fi
+umask 077
+cat "$CUDA_CHECKPOINT_JOB_FILE" > "$job_file"
+export CUDA_CHECKPOINT_JOB_FILE="$job_file"
+exec "$@"`
+
+	wrappedArgs := make([]string, 0, len(command)+len(args)+7)
+	wrappedArgs = append(wrappedArgs, "--launch-job", "/bin/sh", "-c", persistJobFileScript, "dynamo-cuda-checkpoint", snapshotv1alpha1.CUDAJobFilePath)
 	wrappedArgs = append(wrappedArgs, command...)
 	wrappedArgs = append(wrappedArgs, args...)
 	return []string{"cuda-checkpoint"}, wrappedArgs

--- a/operator/internal/protocol/checkpoint_job_identity_test.go
+++ b/operator/internal/protocol/checkpoint_job_identity_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
+)
+
+func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
+	tempDir := t.TempDir()
+	transientJobFile := filepath.Join(tempDir, "transient-job")
+	stableJobFile := filepath.Join(tempDir, "checkpoint", snapshotv1alpha1.CUDAJobFileName)
+	observedEnvironment := filepath.Join(tempDir, "observed-environment")
+	if err := os.WriteFile(transientJobFile, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(stableJobFile), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	_, args := wrapWithCudaCheckpointLaunchJob(
+		[]string{"/bin/sh", "-c"},
+		[]string{`printf '%s' "$CUDA_CHECKPOINT_JOB_FILE" > "$1"`, "workload", observedEnvironment},
+	)
+	args[5] = stableJobFile
+	cmd := exec.Command(args[1], args[2:]...)
+	cmd.Env = append(os.Environ(), "CUDA_CHECKPOINT_JOB_FILE="+transientJobFile)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("launch-job wrapper failed: %v (output: %s)", err, output)
+	}
+
+	content, err := os.ReadFile(stableJobFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "job-state" {
+		t.Fatalf("stable job file = %q", content)
+	}
+	info, err := os.Stat(stableJobFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("stable job file mode = %o, want 600", got)
+	}
+	observed, err := os.ReadFile(observedEnvironment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(observed) != stableJobFile {
+		t.Fatalf("workload observed %q, want %q", observed, stableJobFile)
+	}
+}
+
+func TestCudaCheckpointLaunchJobWrapperReportsMissingJobFile(t *testing.T) {
+	_, args := wrapWithCudaCheckpointLaunchJob([]string{"/bin/true"}, nil)
+	cmd := exec.Command(args[1], args[2:]...)
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("launch-job wrapper succeeded without CUDA_CHECKPOINT_JOB_FILE")
+	}
+	if got := string(output); !strings.Contains(got, "requires NVIDIA driver 610 or newer") {
+		t.Fatalf("launch-job wrapper output = %q", got)
+	}
+}

--- a/operator/internal/protocol/checkpoint_job_test.go
+++ b/operator/internal/protocol/checkpoint_job_test.go
@@ -25,6 +25,25 @@ func requireCheckpointContainer(t *testing.T, containers []corev1.Container, nam
 	return nil
 }
 
+func requireStableLaunchJobWrapper(t *testing.T, container *corev1.Container, original []string) {
+	t.Helper()
+	if strings.Join(container.Command, "|") != "cuda-checkpoint" {
+		t.Fatalf("expected cuda-checkpoint wrapper command, got %#v", container.Command)
+	}
+	if len(container.Args) < 6 {
+		t.Fatalf("launch-job wrapper args too short: %#v", container.Args)
+	}
+	if container.Args[0] != "--launch-job" || container.Args[1] != "/bin/sh" || container.Args[2] != "-c" || container.Args[4] != "dynamo-cuda-checkpoint" {
+		t.Fatalf("unexpected launch-job wrapper prefix: %#v", container.Args[:6])
+	}
+	if container.Args[5] != snapshotv1alpha1.CUDAJobFilePath {
+		t.Fatalf("stable job file = %q, want %q", container.Args[5], snapshotv1alpha1.CUDAJobFilePath)
+	}
+	if got := container.Args[6:]; strings.Join(got, "|") != strings.Join(original, "|") {
+		t.Fatalf("original command = %#v, want %#v", got, original)
+	}
+}
+
 func TestNewCheckpointJob(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -100,13 +119,7 @@ func TestNewCheckpointJob(t *testing.T) {
 	if job.Spec.Template.Spec.SecurityContext == nil || job.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", job.Spec.Template.Spec.SecurityContext)
 	}
-	if len(main.Command) != 1 || main.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected cuda-checkpoint wrapper command: %#v", main.Command)
-	}
-	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
-	if strings.Join(main.Args, "|") != strings.Join(expectedArgs, "|") {
-		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, main.Args)
-	}
+	requireStableLaunchJobWrapper(t, main, []string{"python3", "-m", "dynamo.vllm", "--model", "Qwen"})
 	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 0 {
 		t.Fatalf("expected backoffLimit 0, got %#v", job.Spec.BackoffLimit)
 	}
@@ -141,13 +154,7 @@ func TestNewCheckpointJobWrapsTargetContainer(t *testing.T) {
 	}
 
 	worker := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "worker")
-	if len(worker.Command) != 1 || worker.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected target container to be wrapped, got %#v", worker.Command)
-	}
-	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
-	if strings.Join(worker.Args, "|") != strings.Join(expectedArgs, "|") {
-		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, worker.Args)
-	}
+	requireStableLaunchJobWrapper(t, worker, []string{"python3", "-m", "dynamo.vllm", "--model", "Qwen"})
 
 	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar")
 	if len(sidecar.Command) != 1 || sidecar.Command[0] != "sleep" {


### PR DESCRIPTION
Sync upstream ai-dynamo/dynamo@6da21514 (#12961).


Signed-off-by: Oleg Kushniriov <okushniriov@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA checkpoint and restore support for launch-job state.
  * Added optional job-file configuration for CUDA checkpoint operations.
  * Preserved CUDA launch-job files across checkpoint and restore workflows.
  * Added validation for missing launch-job state in multi-GPU restores.

* **Bug Fixes**
  * Improved job-file security, ownership handling, permissions, and symlink protection.
  * Added clearer errors when job-file configuration or process identity data is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->