### PR TITLE
build(agent): bump Go 1.26.5 references to 1.26.6

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -20,7 +20,7 @@
 # Build Arguments
 # =============================================================================
 ARG DOCKER_PROXY
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 # Default to upstream CRIU development branch. Custom forks can override both
 # args at build time, for example:
 #   --build-arg CRIU_REPO=<git-remote-url>

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -1,4 +1,4 @@
-GO_VERSION             ?= 1.26.5
+GO_VERSION             ?= 1.26.6
 
 CONTROLLER_GEN_VERSION ?= v0.19.0
 GOLANGCI_LINT_VERSION  ?= v1.62.2


### PR DESCRIPTION
bump go version to 1.26.6


Signed-off-by: Oleg Kushniriov <okushniriov@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Go toolchain to version 1.26.6.
  * Keeps development and build environments aligned with the latest configured Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->