### PR TITLE
refactor: rename control-dir env to SNAPSHOT_CONTROL_DIR

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -75,15 +75,18 @@ const (
 	// the workload container.
 	SnapshotControlMountPath = "/snapshot-control"
 
-	// SnapshotControlDirEnv is the environment variable exposing the control
-	// mount path to the workload. This is the canonical name.
+	// SnapshotControlDirEnv is the canonical environment variable exposing the
+	// control mount path to the workload.
 	SnapshotControlDirEnv = "SNAPSHOT_CONTROL_DIR"
 
-	// LegacySnapshotControlDirEnv is the deprecated name for
-	// SnapshotControlDirEnv. EnsureControlVolume injects both during the
-	// migration window so existing workload images (which read this name)
-	// keep working while new images can move to SnapshotControlDirEnv.
-	// Remove once no workload image depends on it.
+	// LegacySnapshotControlDirEnv is the environment variable exposing the
+	// control mount path to the workload. EnsureControlVolume injects both
+	// during the migration window so existing workload images (which read
+	// this name) keep working while new images can move to
+	// SnapshotControlDirEnv.
+	//
+	// Deprecated: use SnapshotControlDirEnv instead. Remove once no workload
+	// image depends on this name.
 	LegacySnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"
 
 	// SnapshotCompleteFile is written by the snapshot agent inside the

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -76,8 +76,15 @@ const (
 	SnapshotControlMountPath = "/snapshot-control"
 
 	// SnapshotControlDirEnv is the environment variable exposing the control
-	// mount path to the workload.
-	SnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"
+	// mount path to the workload. This is the canonical name.
+	SnapshotControlDirEnv = "SNAPSHOT_CONTROL_DIR"
+
+	// LegacySnapshotControlDirEnv is the deprecated name for
+	// SnapshotControlDirEnv. EnsureControlVolume injects both during the
+	// migration window so existing workload images (which read this name)
+	// keep working while new images can move to SnapshotControlDirEnv.
+	// Remove once no workload image depends on it.
+	LegacySnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"
 
 	// SnapshotCompleteFile is written by the snapshot agent inside the
 	// control volume when a checkpoint has completed successfully.

--- a/e2e/snapshot_e2e/workloads.py
+++ b/e2e/snapshot_e2e/workloads.py
@@ -110,7 +110,7 @@ def restore_pod(
     }
     spec["containers"][0]["env"] = [
         {"name": "DYN_SNAPSHOT_RESTORE_STANDBY", "value": "1"},
-        {"name": "DYN_SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
+        {"name": "SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
         {"name": RESTORE_TOKEN_ENV, "value": run.restore_token},
     ]
     spec["containers"][0]["startupProbe"] = {

--- a/operator/.golangci.yml
+++ b/operator/.golangci.yml
@@ -34,6 +34,12 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019:.*GetEventRecorderFor.*deprecated"
+    # LegacySnapshotControlDirEnv is deprecated for new callers, but
+    # EnsureControlVolume must keep injecting it during the migration window
+    # so existing workload images that read the old name keep working.
+    - linters:
+        - staticcheck
+      text: "SA1019:.*LegacySnapshotControlDirEnv.*deprecated"
 
 linters:
   disable-all: true

--- a/operator/.golangci.yml
+++ b/operator/.golangci.yml
@@ -37,7 +37,10 @@ issues:
     # LegacySnapshotControlDirEnv is deprecated for new callers, but
     # EnsureControlVolume must keep injecting it during the migration window
     # so existing workload images that read the old name keep working.
-    - linters:
+    # Scoped to this file (and its test) so any other future reference stays
+    # flagged.
+    - path: "internal/protocol/control_volume(_test)?\\.go"
+      linters:
         - staticcheck
       text: "SA1019:.*LegacySnapshotControlDirEnv.*deprecated"
 

--- a/operator/internal/protocol/checkpoint.go
+++ b/operator/internal/protocol/checkpoint.go
@@ -70,7 +70,7 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	// Snapshot contract: control volume + ready-file readiness probe. The
 	// agent reads the pod's Ready condition before starting CRIU dump, so
 	// the workload signals "model loaded, safe to checkpoint" by writing
-	// $DYN_SNAPSHOT_CONTROL_DIR/ready-for-snapshot. Any per-container
+	// $SNAPSHOT_CONTROL_DIR/ready-for-snapshot. Any per-container
 	// liveness/startup probes are cleared — a checkpoint job runs to a
 	// quiesce-and-sit state, not a long-lived serving state.
 	EnsureControlVolume(&podTemplate.Spec, targetContainer)

--- a/operator/internal/protocol/control_volume.go
+++ b/operator/internal/protocol/control_volume.go
@@ -12,9 +12,14 @@ import (
 // EnsureControlVolume adds the snapshot-control emptyDir to the pod spec,
 // mounts it on the given container at SnapshotControlMountPath (using
 // subPath=<containerName> so concurrent target containers in a failover pod
-// each see an isolated view), and sets DYN_SNAPSHOT_CONTROL_DIR on the
-// container's env. Idempotent — safe to call from multiple code paths
-// (operator checkpoint job, restore pod shaping, etc.).
+// each see an isolated view), and sets both SnapshotControlDirEnv (canonical)
+// and LegacySnapshotControlDirEnv (deprecated) on the container's env, so
+// workload images can migrate off the legacy name independently of the
+// operator release. Idempotent — safe to call from multiple code paths
+// (operator checkpoint job, restore pod shaping, etc.); each env var is
+// guarded independently so a pod that already carries one (e.g. a
+// hand-crafted template with only the legacy name) still gets the other
+// injected without duplicating either.
 //
 // Callers must pass the container's own name; the subPath makes the mount
 // container-scoped on disk even though the in-container path is the same.
@@ -58,17 +63,18 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 		})
 	}
 
-	hasEnv := false
+	ensureEnv(container, snapshotv1alpha1.SnapshotControlDirEnv, snapshotv1alpha1.SnapshotControlMountPath)
+	ensureEnv(container, snapshotv1alpha1.LegacySnapshotControlDirEnv, snapshotv1alpha1.SnapshotControlMountPath)
+}
+
+// ensureEnv sets name=value on the container if name is not already present,
+// so repeated calls (e.g. dual-injecting the canonical and legacy control-dir
+// env var names) never duplicate an entry.
+func ensureEnv(container *corev1.Container, name, value string) {
 	for _, e := range container.Env {
-		if e.Name == snapshotv1alpha1.SnapshotControlDirEnv {
-			hasEnv = true
-			break
+		if e.Name == name {
+			return
 		}
 	}
-	if !hasEnv {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  snapshotv1alpha1.SnapshotControlDirEnv,
-			Value: snapshotv1alpha1.SnapshotControlMountPath,
-		})
-	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
 }

--- a/operator/internal/protocol/control_volume_test.go
+++ b/operator/internal/protocol/control_volume_test.go
@@ -26,8 +26,22 @@ func TestEnsureControlVolume(t *testing.T) {
 		if c.VolumeMounts[0].SubPath != "main" {
 			t.Fatalf("expected subPath=%q, got %q", "main", c.VolumeMounts[0].SubPath)
 		}
-		if len(c.Env) != 1 || c.Env[0].Name != snapshotv1alpha1.SnapshotControlDirEnv || c.Env[0].Value != snapshotv1alpha1.SnapshotControlMountPath {
-			t.Fatalf("expected env %s=%s, got %#v", snapshotv1alpha1.SnapshotControlDirEnv, snapshotv1alpha1.SnapshotControlMountPath, c.Env)
+		if len(c.Env) != 2 {
+			t.Fatalf("expected two control-dir env vars, got %#v", c.Env)
+		}
+		for _, name := range []string{snapshotv1alpha1.SnapshotControlDirEnv, snapshotv1alpha1.LegacySnapshotControlDirEnv} {
+			found := false
+			for _, e := range c.Env {
+				if e.Name == name {
+					found = true
+					if e.Value != snapshotv1alpha1.SnapshotControlMountPath {
+						t.Fatalf("expected env %s=%s, got %#v", name, snapshotv1alpha1.SnapshotControlMountPath, e)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("expected env %s, got %#v", name, c.Env)
+			}
 		}
 	})
 
@@ -55,8 +69,50 @@ func TestEnsureControlVolume(t *testing.T) {
 		EnsureControlVolume(ps, &ps.Containers[0])
 		EnsureControlVolume(ps, &ps.Containers[0])
 		c := ps.Containers[0]
-		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 1 {
-			t.Fatalf("expected single volume/mount/env after two calls, got volumes=%d mounts=%d env=%d", len(ps.Volumes), len(c.VolumeMounts), len(c.Env))
+		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 2 {
+			t.Fatalf("expected single volume/mount and two envs after two calls, got volumes=%d mounts=%d env=%d", len(ps.Volumes), len(c.VolumeMounts), len(c.Env))
+		}
+	})
+
+	t.Run("legacy env pre-set backfills canonical", func(t *testing.T) {
+		ps := &corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "main",
+			Env:  []corev1.EnvVar{{Name: snapshotv1alpha1.LegacySnapshotControlDirEnv, Value: snapshotv1alpha1.SnapshotControlMountPath}},
+		}}}
+		EnsureControlVolume(ps, &ps.Containers[0])
+		c := ps.Containers[0]
+		if len(c.Env) != 2 {
+			t.Fatalf("expected legacy env preserved and canonical env added, got %#v", c.Env)
+		}
+		legacyCount := 0
+		for _, e := range c.Env {
+			if e.Name == snapshotv1alpha1.LegacySnapshotControlDirEnv {
+				legacyCount++
+			}
+		}
+		if legacyCount != 1 {
+			t.Fatalf("expected legacy env not duplicated, got %#v", c.Env)
+		}
+	})
+
+	t.Run("canonical env pre-set backfills legacy", func(t *testing.T) {
+		ps := &corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "main",
+			Env:  []corev1.EnvVar{{Name: snapshotv1alpha1.SnapshotControlDirEnv, Value: snapshotv1alpha1.SnapshotControlMountPath}},
+		}}}
+		EnsureControlVolume(ps, &ps.Containers[0])
+		c := ps.Containers[0]
+		if len(c.Env) != 2 {
+			t.Fatalf("expected canonical env preserved and legacy env added, got %#v", c.Env)
+		}
+		canonicalCount := 0
+		for _, e := range c.Env {
+			if e.Name == snapshotv1alpha1.SnapshotControlDirEnv {
+				canonicalCount++
+			}
+		}
+		if canonicalCount != 1 {
+			t.Fatalf("expected canonical env not duplicated, got %#v", c.Env)
 		}
 	})
 
@@ -91,7 +147,7 @@ func TestEnsureControlVolume(t *testing.T) {
 		}
 		EnsureControlVolume(ps, &ps.Containers[0])
 		c := ps.Containers[0]
-		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 2 {
+		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 3 {
 			t.Fatalf("expected existing + control entries, got volumes=%#v mounts=%#v env=%#v", ps.Volumes, c.VolumeMounts, c.Env)
 		}
 	})


### PR DESCRIPTION

### Summary

- Introduces `SnapshotControlDirEnv = "SNAPSHOT_CONTROL_DIR"` as the canonical control-dir env var name, replacing `DYN_SNAPSHOT_CONTROL_DIR`. The generic snapshot contract shouldn't carry Dynamo-specific branding.
- Adds `LegacySnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"` (deprecated) and dual-injects **both** names from `EnsureControlVolume` during a migration window, so existing workload images (vllm, sglang, Dynamo backends) that read the old name keep working without a coordinated operator+image release, while new images can move to the new name independently.
- Each env var is guarded independently and symmetrically — whichever name a caller already set (e.g. a hand-crafted pod template), the other gets backfilled without duplicating either.

### Scope

- `api/v1alpha1/constants.go` — canonical + legacy constants.
- `operator/internal/protocol/control_volume.go` — `EnsureControlVolume` dual-injects both via a small `ensureEnv(container, name, value)` helper.
- `operator/internal/protocol/checkpoint.go` — comment-only update (`$DYN_SNAPSHOT_CONTROL_DIR` → `$SNAPSHOT_CONTROL_DIR`); `restore.go` needed no change, it already goes through the constant.
- `e2e/snapshot_e2e/workloads.py` — restore pod's control-dir env renamed to the canonical name.

**Explicitly out of scope:** `DYN_SNAPSHOT_RESTORE_STANDBY` (`RestoreStandbyModeEnv`) is a separate, unrelated signal (restore-standby mode, not the control-dir sentinel path) and is untouched here.

### Test plan

- [x] `operator/internal/protocol/control_volume_test.go` — both env vars present after one call; second call is a no-op; each name backfills the other symmetrically (legacy-only → canonical added, canonical-only → legacy added), each guarded against duplication.
- [x] `go build`/`go vet` clean in `api` and `operator` modules.
- [x] `go test ./...` green in both modules.
- [x] Exit criterion: `grep -r DYN_SNAPSHOT_CONTROL_DIR` (excluding docs) returns only the `LegacySnapshotControlDirEnv` constant declaration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `SNAPSHOT_CONTROL_DIR` as the canonical snapshot control-directory setting.
  - Added compatibility support for the legacy `DYN_SNAPSHOT_CONTROL_DIR` setting.
  - Snapshot restore workloads now use the canonical setting.

- **Bug Fixes**
  - Ensured both control-directory settings are supported without duplication, including when either is already configured.

- **Tests**
  - Expanded coverage for compatibility, backfilling, preservation, and idempotent setting handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->