### PR TITLE
perf(agent): increase rootfs extraction tar blocking factor

### DIFF
--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -172,7 +172,7 @@ func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
 	// like triton caches, tmp files) — base image files should not be overwritten.
 	log.Info("Applying rootfs diff", "target", targetRoot)
-	cmd := exec.Command("tar", "--skip-old-files", "-C", targetRoot, "-xf", rootfsDiffPath)
+	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", rootfsDiffPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary
- use 1 MiB GNU tar records instead of the 10 KiB default during rootfs extraction
- match the measured 1 MiB-rsize VAST NFS restore path
- port of [ai-dynamo/dynamo#13351](https://github.com/ai-dynamo/dynamo/pull/13351); Dynamo PR left open

## Test plan
- [x] `go test ./agent/internal/runtime -run 'Test(Capture|Apply)RootfsDiff$' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root filesystem update extraction for greater compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->