### PR TITLE
fix(agent): clear stale restore sentinel before restore

### DIFF
--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -522,12 +522,13 @@ func (w *NodeController) startRestoreForContainer(
 }
 
 // runRestore runs the full restore workflow for one target container:
-//  1. Annotate the pod with restore in_progress
-//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. Write a restore-complete sentinel: the CRIU-restored process resumes
+//  1. Remove any restore-complete sentinel left by an earlier incarnation
+//  2. Annotate the pod with restore in_progress
+//  3. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
+//  4. Write a restore-complete sentinel: the CRIU-restored process resumes
 //     inside the polling loop that waits on this file, exits quiescence,
 //     and resumes the engine
-//  4. Annotate the pod with restore completed
+//  5. Annotate the pod with restore completed
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
@@ -576,6 +577,14 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return nil
 	}
 
+	placeholderHostPID, _, err := w.runtime.ResolveContainer(restoreCtx, containerID)
+	if err != nil {
+		return fmt.Errorf("resolve restore standby container: %w", err)
+	}
+	if err := snapshotruntime.RemoveControlSentinel(placeholderHostPID, snapshotv1alpha1.RestoreCompleteFile); err != nil {
+		return fmt.Errorf("remove stale restore-complete sentinel: %w", err)
+	}
+
 	if err := setRestoreStatus(snapshotv1alpha1.RestoreStatusInProgress); err != nil {
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
@@ -593,7 +602,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		ContainerName:               containerName,
 		Clientset:                   w.clientset,
 	}
-	placeholderHostPID, err := executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
+	placeholderHostPID, err = executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
 	if err != nil {
 		log.Error(err, "External restore failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -522,13 +522,15 @@ func (w *NodeController) startRestoreForContainer(
 }
 
 // runRestore runs the full restore workflow for one target container:
-//  1. Remove any restore-complete sentinel left by an earlier incarnation
-//  2. Annotate the pod with restore in_progress
-//  3. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  4. Write a restore-complete sentinel: the CRIU-restored process resumes
+//  1. Annotate the pod with restore in_progress
+//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace).
+//     nsrestore clears any stale restore-complete sentinel on the pod control
+//     volume before CRIU, so a prior incarnation cannot release the restored
+//     process early.
+//  3. Write a restore-complete sentinel: the CRIU-restored process resumes
 //     inside the polling loop that waits on this file, exits quiescence,
 //     and resumes the engine
-//  5. Annotate the pod with restore completed
+//  4. Annotate the pod with restore completed
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
@@ -577,14 +579,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return nil
 	}
 
-	placeholderHostPID, _, err := w.runtime.ResolveContainer(restoreCtx, containerID)
-	if err != nil {
-		return fmt.Errorf("resolve restore standby container: %w", err)
-	}
-	if err := snapshotruntime.RemoveControlSentinel(placeholderHostPID, snapshotv1alpha1.RestoreCompleteFile); err != nil {
-		return fmt.Errorf("remove stale restore-complete sentinel: %w", err)
-	}
-
 	if err := setRestoreStatus(snapshotv1alpha1.RestoreStatusInProgress); err != nil {
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
@@ -602,7 +596,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		ContainerName:               containerName,
 		Clientset:                   w.clientset,
 	}
-	placeholderHostPID, err = executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
+	placeholderHostPID, err := executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
 	if err != nil {
 		log.Error(err, "External restore failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
 // RestoreOptions holds configuration for an in-namespace restore.
@@ -168,6 +169,15 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 		}
 		defer f.Close()
 		cudaHelperFdPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
+	}
+
+	// The restore-complete sentinel lives on the pod emptyDir mounted at
+	// SnapshotControlMountPath. Clear it here, in that mount namespace, so a
+	// leftover from an earlier incarnation cannot release the restored process
+	// before this CRIU/CUDA attempt finishes. A missing file is already gone;
+	// a missing mount is a hard error.
+	if err := snapshotruntime.RemoveControlSentinel(snapshotv1alpha1.SnapshotControlMountPath, snapshotv1alpha1.RestoreCompleteFile); err != nil {
+		return nil, 0, fmt.Errorf("remove stale restore-complete sentinel: %w", err)
 	}
 
 	// CRIU restore

--- a/agent/internal/runtime/control.go
+++ b/agent/internal/runtime/control.go
@@ -32,6 +32,19 @@ func WriteControlSentinel(hostPID int, name string) error {
 	return writeSentinelInDir(dir, name)
 }
 
+// RemoveControlSentinel removes a sentinel from the workload container's
+// snapshot-control volume. A missing sentinel is already removed.
+func RemoveControlSentinel(hostPID int, name string) error {
+	if hostPID <= 0 {
+		return fmt.Errorf("invalid host PID %d for control sentinel %q", hostPID, name)
+	}
+	path := filepath.Join(HostProcPath, strconv.Itoa(hostPID), "root", snapshotv1alpha1.SnapshotControlMountPath, name)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove control sentinel %s: %w", path, err)
+	}
+	return nil
+}
+
 func writeSentinelInDir(dir, name string) error {
 	tmpPath := filepath.Join(dir, "."+name+".tmp")
 	finalPath := filepath.Join(dir, name)

--- a/agent/internal/runtime/control.go
+++ b/agent/internal/runtime/control.go
@@ -32,17 +32,12 @@ func WriteControlSentinel(hostPID int, name string) error {
 	return writeSentinelInDir(dir, name)
 }
 
-// RemoveControlSentinel removes a sentinel from the workload container's
-// snapshot-control volume. A missing sentinel is already removed.
-func RemoveControlSentinel(hostPID int, name string) error {
-	if hostPID <= 0 {
-		return fmt.Errorf("invalid host PID %d for control sentinel %q", hostPID, name)
-	}
-	path := filepath.Join(HostProcPath, strconv.Itoa(hostPID), "root", snapshotv1alpha1.SnapshotControlMountPath, name)
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove control sentinel %s: %w", path, err)
-	}
-	return nil
+// RemoveControlSentinel removes a sentinel from the snapshot-control mount at
+// dir. The directory must exist: a missing file is already removed, but a
+// missing mount is an error so callers do not confuse "cannot see the volume"
+// with "volume is clean".
+func RemoveControlSentinel(dir, name string) error {
+	return removeSentinelInDir(dir, name)
 }
 
 func writeSentinelInDir(dir, name string) error {
@@ -54,6 +49,21 @@ func writeSentinelInDir(dir, name string) error {
 	if err := os.Rename(tmpPath, finalPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename sentinel %s -> %s: %w", tmpPath, finalPath, err)
+	}
+	return nil
+}
+
+func removeSentinelInDir(dir, name string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("control sentinel dir %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("control sentinel dir %s: not a directory", dir)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove control sentinel %s: %w", path, err)
 	}
 	return nil
 }

--- a/agent/internal/runtime/control_test.go
+++ b/agent/internal/runtime/control_test.go
@@ -67,3 +67,12 @@ func TestWriteControlSentinel_RejectsInvalidPID(t *testing.T) {
 		t.Fatal("expected error for negative PID")
 	}
 }
+
+func TestRemoveControlSentinel_RejectsInvalidPID(t *testing.T) {
+	if err := RemoveControlSentinel(0, "restore-complete"); err == nil {
+		t.Fatal("expected error for PID 0")
+	}
+	if err := RemoveControlSentinel(-1, "restore-complete"); err == nil {
+		t.Fatal("expected error for negative PID")
+	}
+}

--- a/agent/internal/runtime/control_test.go
+++ b/agent/internal/runtime/control_test.go
@@ -68,11 +68,29 @@ func TestWriteControlSentinel_RejectsInvalidPID(t *testing.T) {
 	}
 }
 
-func TestRemoveControlSentinel_RejectsInvalidPID(t *testing.T) {
-	if err := RemoveControlSentinel(0, "restore-complete"); err == nil {
-		t.Fatal("expected error for PID 0")
+func TestRemoveControlSentinel_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := RemoveControlSentinel(dir, "restore-complete"); err != nil {
+		t.Fatalf("missing sentinel should be already removed: %v", err)
 	}
-	if err := RemoveControlSentinel(-1, "restore-complete"); err == nil {
-		t.Fatal("expected error for negative PID")
+}
+
+func TestRemoveControlSentinel_RemovesExisting(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeSentinelInDir(dir, "restore-complete"); err != nil {
+		t.Fatalf("writeSentinelInDir: %v", err)
+	}
+	if err := RemoveControlSentinel(dir, "restore-complete"); err != nil {
+		t.Fatalf("RemoveControlSentinel: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "restore-complete")); !os.IsNotExist(err) {
+		t.Fatalf("sentinel should be gone, stat error: %v", err)
+	}
+}
+
+func TestRemoveControlSentinel_MissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := RemoveControlSentinel(missing, "restore-complete"); err == nil {
+		t.Fatal("expected error for missing control mount")
 	}
 }


### PR DESCRIPTION
## Summary
- remove any `restore-complete` sentinel left by an earlier container incarnation before starting each restore attempt
- treat a missing sentinel as already removed, while failing the restore before CRIU on any other removal error
- prevent a stale sentinel from letting the restored process observe completion before the current restore attempt finishes
- port of [ai-dynamo/dynamo#12704](https://github.com/ai-dynamo/dynamo/pull/12704); Dynamo PR left open

## Test plan
- [x] `go test ./agent/internal/runtime ./agent/internal/controller -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes stale restore-complete indicators before starting a new restore.
  * Handles already-removed indicators without interrupting the restore workflow.
  * Reports control-volume access or indicator-removal errors clearly and stops the restore when necessary.

* **Documentation**
  * Clarified that stale restore-complete indicators are removed before restore execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->