### PR TITLE
fix(agent): stage rootfs-diff.tar locally before extract

### DIFF
--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -153,6 +154,10 @@ func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
 }
 
 // ApplyRootfsDiff extracts rootfs-diff.tar into the target root.
+//
+// The archive is copied to local disk first. tar walks members with many small
+// reads; doing that directly from NFS is much slower than one sequential copy
+// plus a local extract.
 func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
 	info, err := os.Stat(rootfsDiffPath)
@@ -168,17 +173,49 @@ func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 		return nil
 	}
 
+	localPath, cleanup, err := stageRootfsDiffLocally(rootfsDiffPath)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
 	// --skip-old-files: silently skip files that already exist in the restore target.
 	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
 	// like triton caches, tmp files) — base image files should not be overwritten.
-	log.Info("Applying rootfs diff", "target", targetRoot)
-	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", rootfsDiffPath)
+	log.Info("Applying rootfs diff", "target", targetRoot, "bytes", info.Size())
+	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", localPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("tar extract failed: %w", err)
 	}
 	return nil
+}
+
+func stageRootfsDiffLocally(src string) (string, func(), error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to open rootfs diff: %w", err)
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp("", rootfsDiffFilename+".*.tmp")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create local rootfs diff: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("failed to stage rootfs diff locally: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to close local rootfs diff: %w", err)
+	}
+	return tmpPath, cleanup, nil
 }
 
 // ApplyDeletedFiles removes files marked as deleted in the checkpoint.

--- a/agent/internal/runtime/overlay_test.go
+++ b/agent/internal/runtime/overlay_test.go
@@ -250,6 +250,32 @@ func TestApplyRootfsDiff(t *testing.T) {
 			t.Fatal("ApplyRootfsDiff should propagate non-ENOENT stat error")
 		}
 	})
+
+	t.Run("staged local copy is removed after extract", func(t *testing.T) {
+		upperDir := t.TempDir()
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(upperDir, "generated.txt"), []byte("runtime data"), 0644); err != nil {
+			t.Fatalf("write upperdir file: %v", err)
+		}
+		if _, err := CaptureRootfsDiff(upperDir, checkpointDir, types.OverlaySettings{}, nil); err != nil {
+			t.Fatalf("CaptureRootfsDiff: %v", err)
+		}
+
+		before, err := filepath.Glob(filepath.Join(os.TempDir(), rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob staged copies: %v", err)
+		}
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+		after, err := filepath.Glob(filepath.Join(os.TempDir(), rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob staged copies: %v", err)
+		}
+		if len(after) != len(before) {
+			t.Fatalf("staged local copies leaked: before %v after %v", before, after)
+		}
+	})
 }
 
 func TestCaptureDeletedFiles(t *testing.T) {


### PR DESCRIPTION
## Stack
#73 (this) → #74 → #75. Merge in that order.

## Summary
- copy `rootfs-diff.tar` to dest-local disk (`os.TempDir()`) before `tar -xf`, then delete the staged copy
- extracting the overlay archive member-by-member directly from NFS is much slower than one sequential read plus a local extract
- measured on VAST with a 3.52 GB / 13.7k-file vLLM GLM archive, dest overlay write target, cold NFS client: NFS `tar -xf` 30.5 s vs `cp` 1.75 s + local extract 2.02 s (3.77 s total). After the file was hot, NFS extract dropped to 2.29 s

## Test plan
- [x] `go test ./agent/internal/runtime -count=1`
- [ ] restore a vLLM GLM 500k/128 checkpoint on a node that has not read that `rootfs-diff.tar` and confirm `nsrestore_setup` is ~copy+extract, not ~30 s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root filesystem update reliability by staging archive files locally before extraction.
  * Added clearer extraction logging, including archive size.
  * Ensured temporary files are cleaned up after successful or failed operations.
  * Improved error handling for archive file operations.

* **Tests**
  * Added coverage verifying temporary files are removed after root filesystem updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->