### PR TITLE
fix(agent): keep private CRIU restore images on local disk

### DIFF
--- a/agent/internal/criu/restore.go
+++ b/agent/internal/criu/restore.go
@@ -22,8 +22,9 @@ import (
 const RestoreLogFilename = "restore.log"
 
 const (
-	netNsPath        = "/proc/1/ns/net"
-	placeholderFDDir = "/proc/1/fd"
+	netNsPath                    = "/proc/1/ns/net"
+	placeholderFDDir             = "/proc/1/fd"
+	restoreScratchTempDirPattern = "criu-restore-*"
 )
 
 // ExecuteRestore opens the image/work directory FDs, configures inherited
@@ -42,18 +43,20 @@ func ExecuteRestore(
 	// and unlock. That keeps the window where the restored process runs with CUDA
 	// still locked as short as possible. cleanup is called on the error paths below.
 	var openFiles, inheritedFiles []*os.File
-	imageDirPath, removeImageDir, err := prepareRestoreImageDir(checkpointPath)
+	scratchDir, removeScratch, err := restoreScratchDir(settings.WorkDir)
 	if err != nil {
+		return 0, nil, err
+	}
+	imageDirPath, removeImageDir, err := prepareRestoreImageDir(checkpointPath, scratchDir)
+	if err != nil {
+		removeScratch()
 		return 0, nil, fmt.Errorf("failed to prepare CRIU image directory: %w", err)
 	}
-	var confTmpDir string
 	cleanup := func() {
 		closeFiles(inheritedFiles)
 		closeFiles(openFiles)
 		removeImageDir()
-		if err := os.RemoveAll(confTmpDir); err != nil {
-			log.Error(err, "failed to remove criu config temp dir", "path", confTmpDir)
-		}
+		removeScratch()
 	}
 
 	// Open image dir FD
@@ -67,10 +70,6 @@ func ExecuteRestore(
 
 	// Open work dir FD
 	if settings.WorkDir != "" {
-		if err := os.MkdirAll(settings.WorkDir, 0755); err != nil {
-			cleanup()
-			return 0, nil, fmt.Errorf("failed to create CRIU work directory: %w", err)
-		}
 		workDirFile, workDirFD, err := openPathForCRIU(settings.WorkDir)
 		if err != nil {
 			cleanup()
@@ -80,7 +79,7 @@ func ExecuteRestore(
 		criuOpts.WorkDirFd = proto.Int32(workDirFD)
 	}
 
-	overridePath, confTmpDir, err := rewriteCRIULibDir(criuOpts.ConfigFile, settings.WorkDir, bundleDir)
+	overridePath, err := rewriteCRIULibDir(criuOpts.ConfigFile, scratchDir, bundleDir)
 	if err != nil {
 		cleanup()
 		return 0, nil, err
@@ -213,42 +212,51 @@ func registerInheritFDs(c *criulib.Criu, stdioFDs []string, log logr.Logger) []*
 	return openFiles
 }
 
+// restoreScratchDir is the local parent for per-restore CRIU files that must
+// not live on the checkpoint PVC: criu-restore.conf and criu-restore-images-*.
+// When workDir is set (typically /var/criu-work) that durable directory is
+// used and not removed. When it is unset, a criu-restore-* temp is created.
+func restoreScratchDir(workDir string) (string, func(), error) {
+	if workDir != "" {
+		if err := os.MkdirAll(workDir, 0755); err != nil {
+			return "", nil, fmt.Errorf("failed to create CRIU work directory: %w", err)
+		}
+		return workDir, func() {}, nil
+	}
+	dir, err := os.MkdirTemp("", restoreScratchTempDirPattern)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create CRIU restore scratch directory: %w", err)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
 // rewriteCRIULibDir writes a criu.conf override that redirects the plugin libdir
 // to the injected bundle. The dump-time libdir points to the agent filesystem and
 // is unreachable inside the placeholder namespace; the override replaces it.
 // existingConfigFile is nil when the checkpoint was dumped without a criu.conf;
 // in that case the override is written from an empty base so CRIU always finds
-// its plugins at the injected path.
-// Returns (overridePath, tmpDir, err). tmpDir is non-empty only when workDir was
-// empty and a temporary directory was created; the caller must os.RemoveAll(tmpDir).
-func rewriteCRIULibDir(existingConfigFile *string, workDir, criuBundleDir string) (string, string, error) {
-	var tmpDir string
-	if workDir == "" {
-		// Older checkpoints may not have a WorkDir in their manifest. Fall back
-		// to a temp dir so the libdir override can still be written.
-		tmp, err := os.MkdirTemp("", "criu-restore-conf-*")
-		if err != nil {
-			return "", "", fmt.Errorf("rewriteCRIULibDir: no workDir and failed to create temp dir: %w", err)
-		}
-		workDir = tmp
-		tmpDir = tmp
+// its plugins at the injected path. scratchDir is the restore scratch from
+// restoreScratchDir (workDir or a criu-restore-* temp).
+func rewriteCRIULibDir(existingConfigFile *string, scratchDir, criuBundleDir string) (string, error) {
+	if scratchDir == "" {
+		return "", fmt.Errorf("CRIU restore scratch directory is empty")
 	}
 
 	var baseConf string
 	if existingConfigFile != nil {
 		data, err := os.ReadFile(*existingConfigFile)
 		if err != nil {
-			return "", tmpDir, fmt.Errorf("read criu config %s: %w", *existingConfigFile, err)
+			return "", fmt.Errorf("read criu config %s: %w", *existingConfigFile, err)
 		}
 		baseConf = string(data)
 	}
 
-	overridePath := filepath.Join(workDir, "criu-restore.conf")
+	overridePath := filepath.Join(scratchDir, "criu-restore.conf")
 	conf := overrideLibDir(baseConf, filepath.Join(criuBundleDir, "criu-plugins"))
 	if err := os.WriteFile(overridePath, []byte(conf), 0644); err != nil {
-		return "", tmpDir, fmt.Errorf("write criu libdir override to %s: %w", overridePath, err)
+		return "", fmt.Errorf("write criu libdir override to %s: %w", overridePath, err)
 	}
-	return overridePath, tmpDir, nil
+	return overridePath, nil
 }
 
 // bundledCRIUPath returns the path to the criu binary inside bundleDir.

--- a/agent/internal/criu/restore_images.go
+++ b/agent/internal/criu/restore_images.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	filesImageFilename            = "files.img"
-	restoreImageDirPattern        = "criu-restore-images-*"
+	restoreImagesTempDirPattern   = "criu-restore-images-*"
 	placeholderMountNamespacePath = "/proc/self/ns/mnt"
 	cudaUVMFDSocketNamePrefix     = "\x00cuda-uvmfd-"
 	linuxUnixSocketStateListen    = 10
@@ -117,7 +117,7 @@ func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64)
 	// Keep the private view on local disk. Hard-linking thousands of *.img
 	// names onto the checkpoint PVC is one NFS RPC per link and again per
 	// unlink in cleanup(); the page inodes stay in the original checkpoint.
-	privateDir, err := os.MkdirTemp("", restoreImageDirPattern)
+	privateDir, err := os.MkdirTemp("", restoreImagesTempDirPattern)
 	if err != nil {
 		closeFDs(reservationFDs)
 		return "", nil, fmt.Errorf("failed to create private CRIU image directory: %w", err)

--- a/agent/internal/criu/restore_images.go
+++ b/agent/internal/criu/restore_images.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	filesImageFilename            = "files.img"
+	restoreImageDirPattern        = "criu-restore-images-*"
 	placeholderMountNamespacePath = "/proc/self/ns/mnt"
 	cudaUVMFDSocketNamePrefix     = "\x00cuda-uvmfd-"
 	linuxUnixSocketStateListen    = 10
@@ -116,7 +117,7 @@ func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64)
 	// Keep the private view on local disk. Hard-linking thousands of *.img
 	// names onto the checkpoint PVC is one NFS RPC per link and again per
 	// unlink in cleanup(); the page inodes stay in the original checkpoint.
-	privateDir, err := os.MkdirTemp("", ".dynamo-criu-restore-*")
+	privateDir, err := os.MkdirTemp("", restoreImageDirPattern)
 	if err != nil {
 		closeFDs(reservationFDs)
 		return "", nil, fmt.Errorf("failed to create private CRIU image directory: %w", err)

--- a/agent/internal/criu/restore_images.go
+++ b/agent/internal/criu/restore_images.go
@@ -113,7 +113,10 @@ func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64)
 		return checkpointPath, func() {}, nil
 	}
 
-	privateDir, err := os.MkdirTemp(filepath.Dir(checkpointPath), ".dynamo-criu-restore-*")
+	// Keep the private view on local disk. Hard-linking thousands of *.img
+	// names onto the checkpoint PVC is one NFS RPC per link and again per
+	// unlink in cleanup(); the page inodes stay in the original checkpoint.
+	privateDir, err := os.MkdirTemp("", ".dynamo-criu-restore-*")
 	if err != nil {
 		closeFDs(reservationFDs)
 		return "", nil, fmt.Errorf("failed to create private CRIU image directory: %w", err)
@@ -139,10 +142,12 @@ func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64)
 		if name == filesImageFilename || !strings.HasSuffix(name, ".img") {
 			continue
 		}
-		// CRIU does not modify restore images; hard links keep them visible after it
-		// enters the restored mount namespace without copying large page images.
-		if err := os.Link(filepath.Join(checkpointPath, name), filepath.Join(privateDir, name)); err != nil {
-			return fail(fmt.Errorf("failed to hard-link CRIU image %s: %w", name, err))
+		// CRIU does not modify restore images. Absolute symlinks let it open
+		// the original page files via the images-dir FD without copying them
+		// and without creating NFS directory entries for the private view.
+		target := filepath.Join(checkpointPath, name)
+		if err := os.Symlink(target, filepath.Join(privateDir, name)); err != nil {
+			return fail(fmt.Errorf("failed to symlink CRIU image %s: %w", name, err))
 		}
 	}
 

--- a/agent/internal/criu/restore_images.go
+++ b/agent/internal/criu/restore_images.go
@@ -39,16 +39,16 @@ type tcpPortRewrite struct {
 	port   uint32
 }
 
-func prepareRestoreImageDir(checkpointPath string) (string, func(), error) {
+func prepareRestoreImageDir(checkpointPath, scratchDir string) (string, func(), error) {
 	// The placeholder mount namespace remains container-specific with shareProcessNamespace.
 	var stat unix.Stat_t
 	if err := unix.Stat(placeholderMountNamespacePath, &stat); err != nil {
 		return "", nil, fmt.Errorf("failed to stat placeholder mount namespace at %s: %w", placeholderMountNamespacePath, err)
 	}
-	return prepareRestoreImageDirForRestoreID(checkpointPath, stat.Ino)
+	return prepareRestoreImageDirForRestoreID(checkpointPath, stat.Ino, scratchDir)
 }
 
-func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64) (string, func(), error) {
+func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64, scratchDir string) (string, func(), error) {
 	checkpointPath, err := filepath.Abs(checkpointPath)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to resolve checkpoint path: %w", err)
@@ -114,10 +114,15 @@ func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64)
 		return checkpointPath, func() {}, nil
 	}
 
-	// Keep the private view on local disk. Hard-linking thousands of *.img
-	// names onto the checkpoint PVC is one NFS RPC per link and again per
-	// unlink in cleanup(); the page inodes stay in the original checkpoint.
-	privateDir, err := os.MkdirTemp("", restoreImagesTempDirPattern)
+	// Keep the private view on local scratch (CRIU workDir, or a criu-restore-*
+	// temp when workDir is unset). Hard-linking thousands of *.img names onto
+	// the checkpoint PVC is one NFS RPC per link and again per unlink in
+	// cleanup(); the page inodes stay in the original checkpoint.
+	if scratchDir == "" {
+		closeFDs(reservationFDs)
+		return "", nil, fmt.Errorf("CRIU restore scratch directory is empty")
+	}
+	privateDir, err := os.MkdirTemp(scratchDir, restoreImagesTempDirPattern)
 	if err != nil {
 		closeFDs(reservationFDs)
 		return "", nil, fmt.Errorf("failed to create private CRIU image directory: %w", err)

--- a/agent/internal/criu/restore_images_test.go
+++ b/agent/internal/criu/restore_images_test.go
@@ -91,6 +91,62 @@ func TestPrepareRestoreImageDirRewritesObservedSocketTopology(t *testing.T) {
 	}
 }
 
+func TestPrepareRestoreImageDirUsesLocalSymlinks(t *testing.T) {
+	checkpointPath := t.TempDir()
+	writeFilesImage(t, checkpointPath, observedSocketTopology())
+	pagePath := filepath.Join(checkpointPath, "pages-1.img")
+	if err := os.WriteFile(pagePath, []byte("page-bytes"), 0600); err != nil {
+		t.Fatalf("write pages image: %v", err)
+	}
+
+	imageDir, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, 987654321)
+	if err != nil {
+		t.Fatalf("prepare restore image directory: %v", err)
+	}
+	defer cleanup()
+	if imageDir == checkpointPath {
+		t.Fatal("socket conflicts did not produce a private restore image")
+	}
+	if filepath.Dir(imageDir) != os.TempDir() {
+		t.Fatalf("private image dir %q is not under %q", imageDir, os.TempDir())
+	}
+
+	linkPath := filepath.Join(imageDir, "pages-1.img")
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat pages image: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("pages-1.img mode = %v, want symlink", info.Mode())
+	}
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink pages image: %v", err)
+	}
+	want, err := filepath.Abs(pagePath)
+	if err != nil {
+		t.Fatalf("abs pages image: %v", err)
+	}
+	if got != want {
+		t.Fatalf("pages-1.img symlink = %q, want %q", got, want)
+	}
+	data, err := os.ReadFile(linkPath)
+	if err != nil {
+		t.Fatalf("read through symlink: %v", err)
+	}
+	if string(data) != "page-bytes" {
+		t.Fatalf("symlink target data = %q, want %q", string(data), "page-bytes")
+	}
+
+	cleanup()
+	if _, err := os.Stat(imageDir); !os.IsNotExist(err) {
+		t.Fatalf("private image dir still exists after cleanup: %v", err)
+	}
+	if _, err := os.Stat(pagePath); err != nil {
+		t.Fatalf("canonical pages image was removed: %v", err)
+	}
+}
+
 func TestPrepareRestoreImageDirConcurrentRestoresAreIndependent(t *testing.T) {
 	checkpointPath := t.TempDir()
 	writeFilesImage(t, checkpointPath, observedSocketTopology())

--- a/agent/internal/criu/restore_images_test.go
+++ b/agent/internal/criu/restore_images_test.go
@@ -25,7 +25,7 @@ func TestPrepareRestoreImageDirRewritesObservedSocketTopology(t *testing.T) {
 	entries := observedSocketTopology()
 	canonical := writeFilesImage(t, checkpointPath, entries)
 
-	imageDir, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, 987654321)
+	imageDir, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, 987654321, t.TempDir())
 	if err != nil {
 		t.Fatalf("prepare restore image directory: %v", err)
 	}
@@ -99,7 +99,8 @@ func TestPrepareRestoreImageDirUsesLocalSymlinks(t *testing.T) {
 		t.Fatalf("write pages image: %v", err)
 	}
 
-	imageDir, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, 987654321)
+	scratchDir := t.TempDir()
+	imageDir, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, 987654321, scratchDir)
 	if err != nil {
 		t.Fatalf("prepare restore image directory: %v", err)
 	}
@@ -107,8 +108,8 @@ func TestPrepareRestoreImageDirUsesLocalSymlinks(t *testing.T) {
 	if imageDir == checkpointPath {
 		t.Fatal("socket conflicts did not produce a private restore image")
 	}
-	if filepath.Dir(imageDir) != os.TempDir() {
-		t.Fatalf("private image dir %q is not under %q", imageDir, os.TempDir())
+	if filepath.Dir(imageDir) != scratchDir {
+		t.Fatalf("private image dir %q is not under scratch %q", imageDir, scratchDir)
 	}
 
 	linkPath := filepath.Join(imageDir, "pages-1.img")
@@ -150,6 +151,7 @@ func TestPrepareRestoreImageDirUsesLocalSymlinks(t *testing.T) {
 func TestPrepareRestoreImageDirConcurrentRestoresAreIndependent(t *testing.T) {
 	checkpointPath := t.TempDir()
 	writeFilesImage(t, checkpointPath, observedSocketTopology())
+	scratchDir := t.TempDir()
 
 	type result struct {
 		path    string
@@ -162,7 +164,7 @@ func TestPrepareRestoreImageDirConcurrentRestoresAreIndependent(t *testing.T) {
 		wait.Add(1)
 		go func() {
 			defer wait.Done()
-			path, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, restoreID)
+			path, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, restoreID, scratchDir)
 			results <- result{path: path, cleanup: cleanup, err: err}
 		}()
 	}

--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -153,6 +154,10 @@ func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
 }
 
 // ApplyRootfsDiff extracts rootfs-diff.tar into the target root.
+//
+// The archive is copied to local disk first. tar walks members with many small
+// reads; doing that directly from NFS is much slower than one sequential copy
+// plus a local extract.
 func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
 	info, err := os.Stat(rootfsDiffPath)
@@ -168,17 +173,49 @@ func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 		return nil
 	}
 
+	localPath, cleanup, err := stageRootfsDiffLocally(rootfsDiffPath)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
 	// --skip-old-files: silently skip files that already exist in the restore target.
 	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
 	// like triton caches, tmp files) — base image files should not be overwritten.
-	log.Info("Applying rootfs diff", "target", targetRoot)
-	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", rootfsDiffPath)
+	log.Info("Applying rootfs diff", "target", targetRoot, "bytes", info.Size())
+	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", localPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("tar extract failed: %w", err)
 	}
 	return nil
+}
+
+func stageRootfsDiffLocally(src string) (string, func(), error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to open rootfs diff: %w", err)
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp("", rootfsDiffFilename+".*.tmp")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create local rootfs diff: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("failed to stage rootfs diff locally: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to close local rootfs diff: %w", err)
+	}
+	return tmpPath, cleanup, nil
 }
 
 // ApplyDeletedFiles removes files marked as deleted in the checkpoint.

--- a/agent/internal/runtime/overlay_test.go
+++ b/agent/internal/runtime/overlay_test.go
@@ -250,6 +250,32 @@ func TestApplyRootfsDiff(t *testing.T) {
 			t.Fatal("ApplyRootfsDiff should propagate non-ENOENT stat error")
 		}
 	})
+
+	t.Run("staged local copy is removed after extract", func(t *testing.T) {
+		upperDir := t.TempDir()
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(upperDir, "generated.txt"), []byte("runtime data"), 0644); err != nil {
+			t.Fatalf("write upperdir file: %v", err)
+		}
+		if _, err := CaptureRootfsDiff(upperDir, checkpointDir, types.OverlaySettings{}, nil); err != nil {
+			t.Fatalf("CaptureRootfsDiff: %v", err)
+		}
+
+		before, err := filepath.Glob(filepath.Join(os.TempDir(), rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob staged copies: %v", err)
+		}
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+		after, err := filepath.Glob(filepath.Join(os.TempDir(), rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob staged copies: %v", err)
+		}
+		if len(after) != len(before) {
+			t.Fatalf("staged local copies leaked: before %v after %v", before, after)
+		}
+	})
 }
 
 func TestCaptureDeletedFiles(t *testing.T) {


### PR DESCRIPTION
## Stack
Stacked on #73. #75 stacks on this. Merge #73 first, then this, then #75.

## Summary
- `prepareRestoreImageDir` still rewrites `files.img` (CUDA UVM sockets + clone TCP ports) into a private directory; it no longer hard-links thousands of `*.img` names onto the checkpoint PVC
- that private dir is now `criu-restore-images-*` under the same local scratch as `criu-restore.conf`: CRIU `workDir` when set (typically `/var/criu-work`), or one `criu-restore-*` temp when it is unset
- every other `*.img` is an absolute symlink back to the checkpoint; `cleanup()` still `RemoveAll`s the private images dir (and the `criu-restore-*` temp when there is no `workDir`), but those unlinks are local dentries, not Vast RPCs
- page inodes stay in the original checkpoint either way; this was never deleting ~160 GB

Measured on the tx5tk dest (same `*.img` lists as restore, throwaway dirs):

| | names | NFS hardlink + `RemoveAll` | local symlink + `RemoveAll` |
|---|---:|---:|---:|
| vLLM `815df0` | 1618 | 5.81 s (3.38 + 2.42) | 46 ms |
| SGLang `683cb8` | 3938 | 15.25 s (9.54 + 5.71) | 146 ms |

That matches the leftover we were already attributing on the CRIU timer (prepare) and the post-CUDA tail (`cleanup()`). CUDA H2D does not change.

CRIU opens images via the images-dir FD (`openat`). Absolute `/checkpoints/…` symlink targets must still resolve in the restored mount namespace (the dest already mounts that PVC).

## Test plan
- [x] `go test ./agent/internal/criu -count=1`
- [ ] restore vLLM `815df0` and SGLang `683cb8` on a dest recycle and confirm `criu_restore` drops by ~3 s / ~8 s and the post-CUDA tail drops by ~2.5 s / ~6 s
- [ ] confirm CRIU follows the restore-dir symlinks after the mount-ns switch (restore succeeds, pages come from the original checkpoint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore image staging with a dedicated scratch directory.
  * Restore image files are now accessed through absolute links while preserving their original content.
  * Configured work directories are preserved, while automatically created temporary data is cleaned up safely.
  * Invalid empty scratch-directory settings are now rejected.
  * Root filesystem archives are staged locally and removed after extraction to improve reliability and cleanup.

* **Tests**
  * Added coverage for directory placement, link behavior, content access, concurrent restores, archive cleanup, and safe cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->