### PR TITLE
fix(agent): name dump and restore timing phases after the work

### DIFF
--- a/agent/internal/criu/restore.go
+++ b/agent/internal/criu/restore.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	criulib "github.com/checkpoint-restore/go-criu/v8"
 	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
@@ -35,8 +36,9 @@ func ExecuteRestore(
 	checkpointPath string,
 	bundleDir string,
 	log logr.Logger,
-) (int32, func(), error) {
+) (int32, func(), time.Duration, time.Duration, error) {
 	settings := m.CRIUDump.CRIU
+	var prepare, restore time.Duration
 
 	// Return the FD closers as cleanup() rather than deferring them here, so the
 	// caller can run them after cuda unlock instead of between the CRIU restore
@@ -45,12 +47,14 @@ func ExecuteRestore(
 	var openFiles, inheritedFiles []*os.File
 	scratchDir, removeScratch, err := restoreScratchDir(settings.WorkDir)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, 0, 0, err
 	}
+	prepareStart := time.Now()
 	imageDirPath, removeImageDir, err := prepareRestoreImageDir(checkpointPath, scratchDir)
+	prepare = time.Since(prepareStart)
 	if err != nil {
 		removeScratch()
-		return 0, nil, fmt.Errorf("failed to prepare CRIU image directory: %w", err)
+		return 0, nil, prepare, 0, fmt.Errorf("failed to prepare CRIU image directory: %w", err)
 	}
 	cleanup := func() {
 		closeFiles(inheritedFiles)
@@ -63,7 +67,7 @@ func ExecuteRestore(
 	imageDir, imageDirFD, err := openPathForCRIU(imageDirPath)
 	if err != nil {
 		cleanup()
-		return 0, nil, fmt.Errorf("failed to open image directory: %w", err)
+		return 0, nil, prepare, 0, fmt.Errorf("failed to open image directory: %w", err)
 	}
 	openFiles = append(openFiles, imageDir)
 	criuOpts.ImagesDirFd = proto.Int32(imageDirFD)
@@ -73,7 +77,7 @@ func ExecuteRestore(
 		workDirFile, workDirFD, err := openPathForCRIU(settings.WorkDir)
 		if err != nil {
 			cleanup()
-			return 0, nil, fmt.Errorf("failed to open CRIU work directory: %w", err)
+			return 0, nil, prepare, 0, fmt.Errorf("failed to open CRIU work directory: %w", err)
 		}
 		openFiles = append(openFiles, workDirFile)
 		criuOpts.WorkDirFd = proto.Int32(workDirFD)
@@ -82,14 +86,14 @@ func ExecuteRestore(
 	overridePath, err := rewriteCRIULibDir(criuOpts.ConfigFile, scratchDir, bundleDir)
 	if err != nil {
 		cleanup()
-		return 0, nil, err
+		return 0, nil, prepare, 0, err
 	}
 	criuOpts.ConfigFile = proto.String(overridePath)
 
 	criuBin, err := bundledCRIUPath(bundleDir)
 	if err != nil {
 		cleanup()
-		return 0, nil, err
+		return 0, nil, prepare, 0, err
 	}
 	c := criulib.MakeCriu()
 	c.SetCriuPath(criuBin)
@@ -97,7 +101,7 @@ func ExecuteRestore(
 	netNsFile, err := os.Open(netNsPath)
 	if err != nil {
 		cleanup()
-		return 0, nil, fmt.Errorf("failed to open net NS at %s: %w", netNsPath, err)
+		return 0, nil, prepare, 0, fmt.Errorf("failed to open net NS at %s: %w", netNsPath, err)
 	}
 	openFiles = append(openFiles, netNsFile)
 	c.AddInheritFd("extNetNs", netNsFile)
@@ -106,14 +110,17 @@ func ExecuteRestore(
 
 	notify := &restoreNotify{log: log}
 	log.V(1).Info("Executing go-criu Restore call")
+	restoreStart := time.Now()
 	if err := c.Restore(criuOpts, notify); err != nil {
+		restore = time.Since(restoreStart)
 		log.Error(err, "go-criu Restore returned error")
 		logging.LogRestoreErrors(imageDirPath, settings.WorkDir, log)
 		cleanup()
-		return 0, nil, fmt.Errorf("CRIU restore failed: %w", err)
+		return 0, nil, prepare, restore, fmt.Errorf("CRIU restore failed: %w", err)
 	}
+	restore = time.Since(restoreStart)
 
-	return notify.restoredPID, cleanup, nil
+	return notify.restoredPID, cleanup, prepare, restore, nil
 }
 
 // BuildRestoreOpts assembles CriuOpts for a CRIU restore from the checkpoint manifest.

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -39,23 +39,18 @@ type CheckpointRequest struct {
 }
 
 type checkpointPhaseTimings struct {
-	PrepareDuration        time.Duration
-	CUDADuration           time.Duration
+	CUDACheckpointDuration time.Duration
 	CRIUDumpDuration       time.Duration
 	OverlayCaptureDuration time.Duration
-	FinalizeDuration       time.Duration
 }
 
 // Checkpoint performs a CRIU dump of a container.
-// The operation has three phases: inspect, configure, capture.
 //
 // The checkpoint directory is staged under tmp/<uuid> during the operation.
 // On success, the previous checkpoint is removed and the staged directory is
 // renamed into place at the base path root.
 func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req CheckpointRequest, cfg *types.AgentConfig) error {
 	checkpointStart := time.Now()
-	phaseTimings := checkpointPhaseTimings{}
-	prepareStart := time.Now()
 	log.Info("=== Starting checkpoint operation ===")
 
 	if strings.TrimSpace(req.CheckpointID) == "" {
@@ -76,8 +71,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Phase 1: Inspect container state
-	state, err := inspectContainer(ctx, rt, log, req)
+	state, gpuDeviceMapDuration, err := inspectContainer(ctx, rt, log, req)
 	if err != nil {
 		return err
 	}
@@ -89,60 +83,59 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 		}
 	}
 
-	// Phase 2: Configure CRIU options and build checkpoint manifest
 	criuOpts, data, err := configureCheckpoint(log, state, req, cfg, tmpDir)
 	if err != nil {
 		return err
 	}
-	phaseTimings.PrepareDuration = time.Since(prepareStart)
 
-	// Phase 3: Capture — CRIU dump, rootfs diff
 	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, cudaJobFile, log)
 	if err != nil {
 		return err
 	}
-	phaseTimings.CUDADuration = captureTimings.CUDADuration
-	phaseTimings.CRIUDumpDuration = captureTimings.CRIUDumpDuration
-	phaseTimings.OverlayCaptureDuration = captureTimings.OverlayCaptureDuration
 
 	// Remove any previous checkpoint with the same identity hash, then
 	// promote the staged checkpoint directory into place.
-	finalizeStart := time.Now()
+	switchStart := time.Now()
 	if err := os.RemoveAll(finalDir); err != nil {
 		return fmt.Errorf("failed to remove previous checkpoint directory: %w", err)
 	}
 	if err := os.Rename(tmpDir, finalDir); err != nil {
 		return fmt.Errorf("failed to finalize checkpoint directory: %w", err)
 	}
-	phaseTimings.FinalizeDuration = time.Since(finalizeStart)
+	switchDuration := time.Since(switchStart)
 
-	totalDuration := time.Since(checkpointStart)
-	log.Info("Checkpoint timing summary",
-		"checkpoint", map[string]any{
-			"duration": totalDuration.String(),
-			"phases": map[string]string{
-				"prepare_duration":         phaseTimings.PrepareDuration.String(),
-				"cuda_duration":            phaseTimings.CUDADuration.String(),
-				"criu_dump_duration":       phaseTimings.CRIUDumpDuration.String(),
-				"overlay_capture_duration": phaseTimings.OverlayCaptureDuration.String(),
-				"finalize_duration":        phaseTimings.FinalizeDuration.String(),
-			},
-		},
+	wall := time.Since(checkpointStart)
+	unaccounted := remainingDuration(wall,
+		gpuDeviceMapDuration,
+		captureTimings.CUDACheckpointDuration,
+		captureTimings.CRIUDumpDuration,
+		captureTimings.OverlayCaptureDuration,
+		switchDuration,
 	)
-	if !req.StartedAt.IsZero() {
-		log.Info("Checkpoint wall time from agent detection",
-			"started_to_checkpoint_complete", time.Since(req.StartedAt),
-		)
+	summary := map[string]any{
+		"duration": wall.String(),
+		"phases": map[string]string{
+			"gpu_device_map":                gpuDeviceMapDuration.String(),
+			"cuda_checkpoint":               captureTimings.CUDACheckpointDuration.String(),
+			"criu_dump":                     captureTimings.CRIUDumpDuration.String(),
+			"overlay_capture":               captureTimings.OverlayCaptureDuration.String(),
+			"remove_old_version_and_switch": switchDuration.String(),
+			"unaccounted":                   unaccounted.String(),
+		},
 	}
+	if !req.StartedAt.IsZero() {
+		summary["started_to_complete"] = time.Since(req.StartedAt).String()
+	}
+	log.Info("Checkpoint timing summary", "checkpoint", summary)
 
 	return nil
 }
 
-func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req CheckpointRequest) (*types.CheckpointContainerSnapshot, error) {
+func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req CheckpointRequest) (*types.CheckpointContainerSnapshot, time.Duration, error) {
 	containerID := req.ContainerID
 	pid, ociSpec, err := rt.ResolveContainer(ctx, containerID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve container: %w", err)
+		return nil, 0, fmt.Errorf("failed to resolve container: %w", err)
 	}
 
 	var hostCgroupPath string
@@ -152,23 +145,23 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 
 	rootFS, err := snapshotruntime.GetRootFS(pid)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get rootfs: %w", err)
+		return nil, 0, fmt.Errorf("failed to get rootfs: %w", err)
 	}
 
 	upperDir, err := snapshotruntime.GetOverlayUpperDir(pid)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get overlay upperdir: %w", err)
+		return nil, 0, fmt.Errorf("failed to get overlay upperdir: %w", err)
 	}
 
 	mountInfo, err := snapshotruntime.ReadMountInfo(pid)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse mountinfo: %w", err)
+		return nil, 0, fmt.Errorf("failed to parse mountinfo: %w", err)
 	}
 	mounts := snapshotruntime.ClassifyMounts(mountInfo, ociSpec, rootFS)
 
 	netNSInode, err := snapshotruntime.GetNetNSInode(pid)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get net namespace inode: %w", err)
+		return nil, 0, fmt.Errorf("failed to get net namespace inode: %w", err)
 	}
 
 	// Read stdio FD targets (like runc's getPipeFds / descriptors.json).
@@ -189,10 +182,10 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	for _, cudaHostPID := range cudaHostPIDs {
 		process, err := snapshotruntime.ReadProcessDetails(snapshotruntime.HostProcPath, cudaHostPID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read process details for CUDA process %d: %w", cudaHostPID, err)
+			return nil, 0, fmt.Errorf("failed to read process details for CUDA process %d: %w", cudaHostPID, err)
 		}
 		if len(process.NamespacePIDs) != 2 {
-			return nil, fmt.Errorf("CUDA process %d has namespace depth %d, want 2", cudaHostPID, len(process.NamespacePIDs))
+			return nil, 0, fmt.Errorf("CUDA process %d has namespace depth %d, want 2", cudaHostPID, len(process.NamespacePIDs))
 		}
 		cudaNamespacePIDs = append(cudaNamespacePIDs, process.InnermostPID)
 	}
@@ -200,7 +193,9 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
 	var gpuUUIDs []string
+	var gpuDeviceMapDuration time.Duration
 	if len(cudaHostPIDs) > 0 {
+		gpuStart := time.Now()
 		gpuUUIDs, err = cuda.DiscoverGPUUUIDs(
 			ctx,
 			req.Clientset,
@@ -211,8 +206,9 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 			pid,
 			log,
 		)
+		gpuDeviceMapDuration = time.Since(gpuStart)
 		if err != nil {
-			return nil, fmt.Errorf("failed to discover source GPU UUIDs: %w", err)
+			return nil, 0, fmt.Errorf("failed to discover source GPU UUIDs: %w", err)
 		}
 	}
 
@@ -228,7 +224,7 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		CUDAHostPIDs:   cudaHostPIDs,
 		CUDANSPIDs:     cudaNamespacePIDs,
 		GPUUUIDs:       gpuUUIDs,
-	}, nil
+	}, gpuDeviceMapDuration, nil
 }
 
 func configureCheckpoint(
@@ -269,7 +265,7 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)
 		}
-		timings.CUDADuration = cudaTimings.TotalDuration
+		timings.CUDACheckpointDuration = cudaTimings.TotalDuration
 	}
 
 	criuDumpDuration, err := criu.ExecuteDump(criuOpts, checkpointDir, criuSettings, log)

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -33,31 +33,24 @@ type RestoreOptions struct {
 
 type RestoreInNamespaceResult struct {
 	RestoredPID            int           `json:"restoredPID"`
-	NSRestoreSetupDuration time.Duration `json:"nsrestoreSetupDuration"`
+	OverlayCaptureDuration time.Duration `json:"overlayCaptureDuration"`
+	CRIUPrepareDuration    time.Duration `json:"criuPrepareDuration"`
 	CRIURestoreDuration    time.Duration `json:"criuRestoreDuration"`
-	CUDADuration           time.Duration `json:"cudaDuration"`
-}
-
-// TotalDuration returns the sum of all in-namespace restore phase durations.
-func (r RestoreInNamespaceResult) TotalDuration() time.Duration {
-	return r.NSRestoreSetupDuration + r.CRIURestoreDuration + r.CUDADuration
+	CUDARestoreDuration    time.Duration `json:"cudaRestoreDuration"`
 }
 
 // RestoreInNamespace performs a full restore from inside the target container's namespaces.
 func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logger) (*RestoreInNamespaceResult, error) {
-	restoreStart := time.Now()
 	log.Info("Starting nsrestore workflow",
 		"checkpoint_path", opts.CheckpointPath,
 		"has_cuda_map", opts.CUDADeviceMap != "",
 		"cgroup_root", opts.CgroupRoot,
 		"target_pod_ip_present", opts.TargetPodIP != "",
 	)
-	manifestReadStart := time.Now()
 	m, err := types.ReadManifest(opts.CheckpointPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest: %w", err)
 	}
-	manifestReadDuration := time.Since(manifestReadStart)
 	log.V(1).Info("Loaded checkpoint manifest",
 		"ext_mounts", len(m.CRIUDump.ExtMnt),
 		"criu_log_level", m.CRIUDump.CRIU.LogLevel,
@@ -75,8 +68,6 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 		}
 	}
 
-	// Phase 1: Configure — build CRIU opts from manifest
-	configureStart := time.Now()
 	if err := criu.ConfigureInetRemap(m, opts.TargetPodIP, log); err != nil {
 		return nil, err
 	}
@@ -84,48 +75,39 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	if err != nil {
 		return nil, err
 	}
-	configureDuration := time.Since(configureStart)
 
-	// Phase 2: Execute — rootfs, CRIU restore, CUDA restore
 	executeTimings, restoredPID, err := executeRestore(ctx, criuOpts, m, opts, cudaJobFile, log)
 	if err != nil {
 		return nil, err
 	}
 
-	result := &RestoreInNamespaceResult{
+	return &RestoreInNamespaceResult{
 		RestoredPID:            restoredPID,
-		NSRestoreSetupDuration: manifestReadDuration + configureDuration + executeTimings.nsrestoreSetupDuration,
+		OverlayCaptureDuration: executeTimings.overlayCaptureDuration,
+		CRIUPrepareDuration:    executeTimings.criuPrepareDuration,
 		CRIURestoreDuration:    executeTimings.criuRestoreDuration,
-		CUDADuration:           executeTimings.cudaDuration,
-	}
-	log.V(1).Info("nsrestore timing summary",
-		"restored_pid", restoredPID,
-		"nsrestore_setup_duration", result.NSRestoreSetupDuration,
-		"criu_restore_duration", result.CRIURestoreDuration,
-		"cuda_duration", result.CUDADuration,
-		"total_duration", time.Since(restoreStart),
-	)
-	return result, nil
+		CUDARestoreDuration:    executeTimings.cudaRestoreDuration,
+	}, nil
 }
 
 type nsrestorePhaseTimings struct {
-	nsrestoreSetupDuration time.Duration
+	overlayCaptureDuration time.Duration
+	criuPrepareDuration    time.Duration
 	criuRestoreDuration    time.Duration
-	cudaDuration           time.Duration
+	cudaRestoreDuration    time.Duration
 }
 
 func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.CheckpointManifest, opts RestoreOptions, cudaJobFile string, log logr.Logger) (*nsrestorePhaseTimings, int, error) {
 	timings := &nsrestorePhaseTimings{}
 
-	// Apply rootfs diff inside the namespace (target root is /)
-	nsrestoreSetupStart := time.Now()
+	overlayStart := time.Now()
 	if err := snapshotruntime.ApplyRootfsDiff(opts.CheckpointPath, "/", log); err != nil {
 		return nil, 0, fmt.Errorf("rootfs diff failed: %w", err)
 	}
-
 	if err := snapshotruntime.ApplyDeletedFiles(opts.CheckpointPath, "/", log); err != nil {
 		log.Error(err, "Failed to apply deleted files")
 	}
+	timings.overlayCaptureDuration = time.Since(overlayStart)
 	cudaRestoreJobFile := ""
 	if cudaJobFile != "" {
 		liveJobFile, err := cuda.PrepareLiveJobFile(cudaJobFile)
@@ -146,7 +128,6 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 	if err := snapshotruntime.RemountProcSys(true); err != nil {
 		return nil, 0, fmt.Errorf("failed to remount /proc/sys read-write for restore: %w", err)
 	}
-	timings.nsrestoreSetupDuration = time.Since(nsrestoreSetupStart)
 	defer func() {
 		if err := snapshotruntime.RemountProcSys(false); err != nil {
 			log.Error(err, "Failed to remount /proc/sys read-only after restore")
@@ -180,9 +161,7 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 		return nil, 0, fmt.Errorf("remove stale restore-complete sentinel: %w", err)
 	}
 
-	// CRIU restore
-	criuRestoreStart := time.Now()
-	restoredPID, cleanup, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, opts.BundleDir, log)
+	restoredPID, cleanup, prepare, restore, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, opts.BundleDir, log)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -190,9 +169,9 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 	// restore-complete sentinel below, so nothing but the required PID resolve
 	// sits between the CRIU restore and unlock. Runs on any return, incl. errors.
 	defer cleanup()
-	timings.criuRestoreDuration = time.Since(criuRestoreStart)
+	timings.criuPrepareDuration = prepare
+	timings.criuRestoreDuration = restore
 
-	cudaStart := time.Now()
 	if cudaRestoreJobFile != "" {
 		uid, gid, err := snapshotruntime.ReadProcessFilesystemIDs("/proc", int(restoredPID))
 		if err != nil {
@@ -235,12 +214,13 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 			"restored_cuda_pids", restorePIDs,
 			"criu_callback_pid", restoredPID,
 		)
+		cudaStart := time.Now()
 		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, cudaHelperFdPath, log)
+		timings.cudaRestoreDuration = time.Since(cudaStart)
 		if err != nil {
 			return nil, 0, fmt.Errorf("CUDA restore failed: %w", err)
 		}
 	}
-	timings.cudaDuration = time.Since(cudaStart)
 
 	return timings, int(restoredPID), nil
 }

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -62,21 +62,15 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		"container", req.ContainerName,
 	)
 
-	// Phase 1: Host inspect — resolve placeholder, discover target GPUs, build device map.
-	hostInspectStart := time.Now()
-	snap, err := inspectRestore(ctx, rt, log, req)
+	snap, gpuDeviceMapDuration, err := inspectRestore(ctx, rt, log, req)
 	if err != nil {
 		return 0, err
 	}
-	hostInspectDuration := time.Since(hostInspectStart)
 
-	// Phase 2: Mount agent binaries into the placeholder's namespace so nsrestore is reachable.
-	injectStart := time.Now()
 	mp, err := mountBundle(ctx, mounter, snap.PlaceholderPID)
 	if err != nil {
 		return 0, err
 	}
-	injectDuration := time.Since(injectStart)
 	defer func() {
 		// Pass a background context: mp.Unmount has its own internal timeout
 		// (nsmount.unmountTimeout) around the ns-bind-mount subprocess.
@@ -89,43 +83,54 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		}
 	}()
 
-	// Phase 3: Execute — nsrestore handles rootfs, CRIU restore, and CUDA restore inside namespace.
 	result, err := execNSRestore(ctx, log, req, snap, mp)
 	if err != nil {
 		return 0, fmt.Errorf("nsrestore failed: %w", err)
 	}
-	restoreDuration := hostInspectDuration + injectDuration + result.TotalDuration()
-	log.Info("Restore timing summary",
-		"restore", map[string]any{
-			"duration": restoreDuration.String(),
-			"phases": map[string]string{
-				"host_inspect_duration":    hostInspectDuration.String(),
-				"inject_duration":          injectDuration.String(),
-				"nsrestore_setup_duration": result.NSRestoreSetupDuration.String(),
-				"criu_restore_duration":    result.CRIURestoreDuration.String(),
-				"cuda_duration":            result.CUDADuration.String(),
-			},
-		},
-	)
-	if !req.StartedAt.IsZero() {
-		log.Info("Restore wall time from agent detection",
-			"started_to_restore_complete", time.Since(req.StartedAt),
-		)
-	}
-
-	validationStart := time.Now()
 	if err := validateRestoredProcess(snap.TargetRoot, result.RestoredPID, log); err != nil {
 		return 0, err
 	}
 
+	wall := time.Since(restoreStart)
+	unaccounted := remainingDuration(wall,
+		gpuDeviceMapDuration,
+		result.OverlayCaptureDuration,
+		result.CRIUPrepareDuration,
+		result.CRIURestoreDuration,
+		result.CUDARestoreDuration,
+	)
+	summary := map[string]any{
+		"duration": wall.String(),
+		"phases": map[string]string{
+			"gpu_device_map":  gpuDeviceMapDuration.String(),
+			"overlay_capture": result.OverlayCaptureDuration.String(),
+			"criu_prepare":    result.CRIUPrepareDuration.String(),
+			"criu_restore":    result.CRIURestoreDuration.String(),
+			"cuda_restore":    result.CUDARestoreDuration.String(),
+			"unaccounted":     unaccounted.String(),
+		},
+	}
+	if !req.StartedAt.IsZero() {
+		summary["started_to_complete"] = time.Since(req.StartedAt).String()
+	}
+	log.Info("Restore timing summary", "restore", summary)
 	log.Info("=== External restore completed ===",
 		"restored_pid", result.RestoredPID,
 		"placeholder_host_pid", snap.PlaceholderPID,
-		"validation_duration", time.Since(validationStart),
-		"total_duration", time.Since(restoreStart),
 	)
 
 	return snap.PlaceholderPID, nil
+}
+
+func remainingDuration(wall time.Duration, parts ...time.Duration) time.Duration {
+	var sum time.Duration
+	for _, part := range parts {
+		sum += part
+	}
+	if wall <= sum {
+		return 0
+	}
+	return wall - sum
 }
 
 func mountBundle(ctx context.Context, mounter Mounter, pid int) (nsmount.MountPoint, error) {
@@ -146,27 +151,27 @@ func validateRestoredProcess(targetRoot string, restoredPID int, log logr.Logger
 	return nil
 }
 
-func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req RestoreRequest) (*types.RestoreContainerSnapshot, error) {
+func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req RestoreRequest) (*types.RestoreContainerSnapshot, time.Duration, error) {
 	if req.CheckpointLocation == "" {
-		return nil, fmt.Errorf("checkpoint location is required")
+		return nil, 0, fmt.Errorf("checkpoint location is required")
 	}
 
 	checkpointPath := req.CheckpointLocation
 	baseAbs, err := filepath.Abs(filepath.Dir(checkpointPath))
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve checkpoint base path: %w", err)
+		return nil, 0, fmt.Errorf("failed to resolve checkpoint base path: %w", err)
 	}
 	checkpointAbs, err := filepath.Abs(checkpointPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve checkpoint path: %w", err)
+		return nil, 0, fmt.Errorf("failed to resolve checkpoint path: %w", err)
 	}
 	if checkpointAbs != baseAbs && !strings.HasPrefix(checkpointAbs, baseAbs+string(os.PathSeparator)) {
-		return nil, fmt.Errorf("invalid checkpoint id %q", req.CheckpointID)
+		return nil, 0, fmt.Errorf("invalid checkpoint id %q", req.CheckpointID)
 	}
 
 	m, err := types.ReadManifest(checkpointPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read checkpoint manifest: %w", err)
+		return nil, 0, fmt.Errorf("failed to read checkpoint manifest: %w", err)
 	}
 
 	containerName := req.ContainerName
@@ -181,7 +186,7 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 		placeholderPID, _, err = rt.ResolveContainerByPod(ctx, req.PodName, req.PodNamespace, containerName)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve placeholder container: %w", err)
+		return nil, 0, fmt.Errorf("failed to resolve placeholder container: %w", err)
 	}
 	log.V(1).Info("Resolved placeholder container", "pid", placeholderPID)
 
@@ -192,10 +197,12 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 	}
 
 	cudaDeviceMap := ""
+	var gpuDeviceMapDuration time.Duration
 	if !m.CUDA.IsEmpty() {
 		if len(m.CUDA.SourceGPUUUIDs) == 0 {
-			return nil, fmt.Errorf("missing source GPU UUIDs in checkpoint manifest")
+			return nil, 0, fmt.Errorf("missing source GPU UUIDs in checkpoint manifest")
 		}
+		gpuStart := time.Now()
 		targetGPUUUIDs, err := cuda.DiscoverGPUUUIDs(
 			ctx,
 			req.Clientset,
@@ -207,14 +214,15 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 			log,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get target GPU UUIDs: %w", err)
+			return nil, 0, fmt.Errorf("failed to get target GPU UUIDs: %w", err)
 		}
 		if len(targetGPUUUIDs) == 0 {
-			return nil, fmt.Errorf("missing target GPU UUIDs for %s/%s container %s", req.PodNamespace, req.PodName, containerName)
+			return nil, 0, fmt.Errorf("missing target GPU UUIDs for %s/%s container %s", req.PodNamespace, req.PodName, containerName)
 		}
 		cudaDeviceMap, err = cuda.BuildDeviceMap(m.CUDA.SourceGPUUUIDs, targetGPUUUIDs, log)
+		gpuDeviceMapDuration = time.Since(gpuStart)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build CUDA device map: %w", err)
+			return nil, 0, fmt.Errorf("failed to build CUDA device map: %w", err)
 		}
 		log.V(1).Info("GPU UUIDs for device map",
 			"source_uuids", m.CUDA.SourceGPUUUIDs,
@@ -229,7 +237,7 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 		TargetRoot:     fmt.Sprintf("%s/%d/root", snapshotruntime.HostProcPath, placeholderPID),
 		CgroupRoot:     cgroupRoot,
 		CUDADeviceMap:  cudaDeviceMap,
-	}, nil
+	}, gpuDeviceMapDuration, nil
 }
 
 // execNSRestore launches the nsrestore binary inside the placeholder container's

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -71,7 +71,12 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 	if err != nil {
 		return 0, err
 	}
-	defer func() {
+	mountActive := true
+	unmount := func() {
+		if !mountActive {
+			return
+		}
+		mountActive = false
 		// Pass a background context: mp.Unmount has its own internal timeout
 		// (nsmount.unmountTimeout) around the ns-bind-mount subprocess.
 		if cleanupErr := mp.Unmount(context.Background()); cleanupErr != nil {
@@ -81,7 +86,8 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 			// already restored successfully. Log it and let the pod continue.
 			log.Error(cleanupErr, "failed to unmount agent bundle from placeholder namespace")
 		}
-	}()
+	}
+	defer unmount()
 
 	result, err := execNSRestore(ctx, log, req, snap, mp)
 	if err != nil {
@@ -91,6 +97,7 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		return 0, err
 	}
 
+	unmount()
 	wall := time.Since(restoreStart)
 	unaccounted := remainingDuration(wall,
 		gpuDeviceMapDuration,

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -81,7 +82,7 @@ func TestInspectRestoreUsesContainerIDWhenProvided(t *testing.T) {
 	}
 
 	rt := &restoreFakeRuntime{}
-	_, err := inspectRestore(
+	_, _, err := inspectRestore(
 		context.Background(),
 		rt,
 		testr.New(t),
@@ -121,5 +122,15 @@ func TestRestoreInNamespaceRejectsMultiGPUCheckpointWithoutLaunchJobState(t *tes
 	_, err := RestoreInNamespace(context.Background(), RestoreOptions{CheckpointPath: checkpointDir}, testr.New(t))
 	if err == nil || !strings.Contains(err.Error(), "missing CUDA launch-job state") {
 		t.Fatalf("expected missing multi-GPU launch-job error, got %v", err)
+	}
+}
+
+func TestRemainingDuration(t *testing.T) {
+	got := remainingDuration(10*time.Second, 4*time.Second, 3*time.Second)
+	if got != 3*time.Second {
+		t.Fatalf("remainingDuration = %s, want 3s", got)
+	}
+	if remainingDuration(5*time.Second, 4*time.Second, 3*time.Second) != 0 {
+		t.Fatal("remainingDuration should not go negative")
 	}
 }


### PR DESCRIPTION
## Stack
Stacked on #74 (which is on #73). Merge #73, then #74, then this.

## Summary
- Restore and dump Info summaries now use **wall time**, not a sum of named buckets
- Phases are named after the work: `gpu_device_map`, `overlay_capture` (tar + deleted files), `criu_prepare` / `criu_restore` / `cuda_restore` on restore; `cuda_checkpoint`, `criu_dump`, `remove_old_version_and_switch` on dump
- `unaccounted` is wall minus those phases (nsenter, leftover setup, CRIU image-dir cleanup, validation, inspect/configure)
- Dropped `host_inspect`, `inject`, `nsrestore_setup`, and the extra `started_to_*_complete` Info line (that clock is `started_to_complete` on the same summary)

## Test plan
- [x] `go test ./agent/internal/executor ./agent/internal/criu -count=1`
- [ ] Dump and restore a dest and confirm the Info summary phases sum with `unaccounted` to `duration`
- [ ] Cold restore: `overlay_capture` should show the tar; `criu_prepare` should show image-dir rewrite
- [ ] Dump with a prior version present: `remove_old_version_and_switch` should cover NFS unlink + rename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Monitoring**
  * Added detailed timing visibility for checkpoint and restore phases, including GPU discovery, overlay handling, CRIU preparation and restore, and CUDA operations.
  * Improved timing summaries to show unaccounted elapsed time and preserve measurements across error scenarios.
* **Reliability**
  * Restore failures continue to retain cleanup and logging behavior while providing more complete diagnostic timing information.
* **Tests**
  * Added coverage for remaining-duration calculations, including zero-duration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->