### PR TITLE
chore: add hhzhang16 to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @yoedgin @dfeigin-nv @galletas1712 @julienmancuso @Hutm
+* @shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @yoedgin @dfeigin-nv @galletas1712 @julienmancuso @Hutm @hhzhang16


### PR DESCRIPTION
## Summary
- Add `@hhzhang16` as a repo-wide code owner in `.github/CODEOWNERS`.

## Test plan
- [ ] Confirm `hhzhang16` has write access so GitHub treats the entry as a valid owner
- [ ] After merge, open a test PR and confirm `@hhzhang16` is auto-requested as a reviewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership configuration to include an additional code reviewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->