### PR TITLE
feat(agent): forward POSIX CUDA VMM APIs

### DIFF
--- a/agent/cmd/cuinterpose/Makefile
+++ b/agent/cmd/cuinterpose/Makefile
@@ -2,15 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 BUILD_DIR ?= build
+CUDA_HOME ?= /usr/local/cuda
 INTERPOSER := $(BUILD_DIR)/libcuinterposer.so
 COORDINATOR := $(BUILD_DIR)/cuinterposer-coordinator
+FORWARD_TEST := $(BUILD_DIR)/forward-test
+MIN_GLIBC := GLIBC_2.34
+INTERPOSER_CPPFLAGS := -DCUINTERPOSER_DLSYM_VERSION=\"$(MIN_GLIBC)\"
 COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror
 INTERPOSER_SOURCES := interpose.c multicast.c posix.c symbols.c util.c
 INTERPOSER_HEADERS := multicast.h posix.h protocol.h symbols.h util.h
 COORDINATOR_SOURCES := coordinator.c util.c
 COORDINATOR_HEADERS := protocol.h util.h
 
-.PHONY: all clean
+.PHONY: all clean test
 
 all: $(INTERPOSER) $(COORDINATOR)
 
@@ -18,14 +22,34 @@ $(BUILD_DIR):
 	mkdir -p $@
 
 $(INTERPOSER): $(INTERPOSER_SOURCES) $(INTERPOSER_HEADERS) | $(BUILD_DIR)
-	$(CC) $(COMMON_FLAGS) -fPIC -shared -o $@.tmp $(INTERPOSER_SOURCES)
+	$(CC) $(COMMON_FLAGS) $(INTERPOSER_CPPFLAGS) \
+		-fPIC -shared -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
+		-o $@.tmp $(INTERPOSER_SOURCES) -Wl,-Bsymbolic-functions -ldl -pthread
 	readelf -d $@.tmp >/dev/null
+	! readelf -d $@.tmp | grep -Eq 'NEEDED.*(libcuda|libcudart)'
+	max=$$(readelf -V $@.tmp | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1); \
+		[ "$$(printf '%s\n%s\n' "$$max" "$(MIN_GLIBC)" | sort -uV | tail -1)" = "$(MIN_GLIBC)" ]
+	readelf --dyn-syms -W $@.tmp | grep -q 'dlvsym@$(MIN_GLIBC)'
 	mv $@.tmp $@
 
 $(COORDINATOR): $(COORDINATOR_SOURCES) $(COORDINATOR_HEADERS) | $(BUILD_DIR)
 	$(CC) $(COMMON_FLAGS) -static -o $@.tmp $(COORDINATOR_SOURCES)
 	! readelf -d $@.tmp 2>/dev/null | grep -q NEEDED
 	mv $@.tmp $@
+
+test: $(INTERPOSER)
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations \
+		-I$(CUDA_HOME)/include -Wl,-soname,libcuda.so.1 \
+		-o $(BUILD_DIR)/libcuda.so.1 tests/fake_cuda.c -ldl
+	ln -sf libcuda.so.1 $(BUILD_DIR)/libcuda.so
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations \
+		-I$(CUDA_HOME)/include -Wl,-soname,libcudart.so.13 \
+		-o $(BUILD_DIR)/libcudart.so.13 tests/fake_cudart.c
+	ln -sf libcudart.so.13 $(BUILD_DIR)/libcudart.so
+	$(CC) $(COMMON_FLAGS) -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
+		-L$(BUILD_DIR) -Wl,-rpath,'$$ORIGIN' -o $(FORWARD_TEST) \
+		tests/forward_test.c -lcuda -lcudart -ldl
+	LD_PRELOAD=$(abspath $(INTERPOSER)) $(FORWARD_TEST)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -4,8 +4,87 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * CUDA entry-point interposition is added by the forwarding layer.
- * Keep this translation unit so packaging and later behavior use one layout.
- */
-static const char cuinterposer_skeleton[] __attribute__((used)) = "cuinterposer";
+#include "symbols.h"
+
+#define LOOKUP(name, type) ((type)cuinterposer_lookup_real_symbol(#name))
+
+CUresult CUDAAPI
+cuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties,
+    unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+  function_type function = LOOKUP(cuMemCreate, function_type);
+  return function != NULL ? function(output, size, properties, flags) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemRelease(CUmemGenericAllocationHandle handle)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle);
+  function_type function = LOOKUP(cuMemRelease, function_type);
+  return function != NULL ? function(handle) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle*, void*);
+  function_type function = LOOKUP(cuMemRetainAllocationHandle, function_type);
+  return function != NULL ? function(output, address) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemMap(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+  function_type function = LOOKUP(cuMemMap, function_type);
+  return function != NULL ? function(address, size, offset, handle, flags) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemUnmap(CUdeviceptr address, size_t size)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUdeviceptr, size_t);
+  function_type function = LOOKUP(cuMemUnmap, function_type);
+  return function != NULL ? function(address, size) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+  function_type function = LOOKUP(cuMemSetAccess, function_type);
+  return function != NULL ? function(address, size, descriptors, count) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemExportToShareableHandle(
+    void* output, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+  function_type function = LOOKUP(cuMemExportToShareableHandle, function_type);
+  return function != NULL ? function(output, handle, type, flags) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+  function_type function = LOOKUP(cuMemImportFromShareableHandle, function_type);
+  return function != NULL ? function(output, os_handle, type) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+  function_type function = LOOKUP(cuMemGetAllocationPropertiesFromHandle, function_type);
+  return function != NULL ? function(properties, handle) : cuinterposer_unavailable();
+}
+
+#undef LOOKUP

--- a/agent/cmd/cuinterpose/symbols.c
+++ b/agent/cmd/cuinterpose/symbols.c
@@ -4,4 +4,297 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define _GNU_SOURCE
+
 #include "symbols.h"
+
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <link.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifndef CUINTERPOSER_DLSYM_VERSION
+#error "CUINTERPOSER_DLSYM_VERSION must be set by the build"
+#endif
+
+#undef cuGetProcAddress
+#undef cudaGetDriverEntryPoint
+#undef cudaGetDriverEntryPointByVersion
+
+CUresult CUDAAPI cuMemCreate(CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+CUresult CUDAAPI cuMemRelease(CUmemGenericAllocationHandle);
+CUresult CUDAAPI cuMemRetainAllocationHandle(CUmemGenericAllocationHandle*, void*);
+CUresult CUDAAPI cuMemMap(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+CUresult CUDAAPI cuMemUnmap(CUdeviceptr, size_t);
+CUresult CUDAAPI cuMemSetAccess(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+CUresult CUDAAPI cuMemExportToShareableHandle(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+CUresult CUDAAPI cuMemImportFromShareableHandle(
+    CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+CUresult CUDAAPI cuMemGetAllocationPropertiesFromHandle(
+    CUmemAllocationProp*, CUmemGenericAllocationHandle);
+CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
+CUresult CUDAAPI cuGetProcAddress_v2(
+    const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+CUresult CUDAAPI cuGetProcAddress_v2_ptsz(
+    const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPoint(
+    const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion(
+    const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPoint_ptsz(
+    const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion_ptsz(
+    const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+
+static pthread_once_t real_dlsym_once = PTHREAD_ONCE_INIT;
+static void* (*real_dlsym_function)(void*, const char*);
+static _Atomic(uintptr_t) explicit_libcuda_handle;
+static _Atomic(uintptr_t) explicit_libcudart_handle;
+static _Atomic(uintptr_t) explicit_cu_get_proc_address;
+static _Atomic(uintptr_t) explicit_cu_get_proc_address_v2;
+
+static void* replacement(const char*, int);
+
+CUresult
+cuinterposer_unavailable(void)
+{
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+static void
+initialize_real_dlsym(void)
+{
+  real_dlsym_function =
+      (void* (*)(void*, const char*))dlvsym(RTLD_NEXT, "dlsym", CUINTERPOSER_DLSYM_VERSION);
+}
+
+static void*
+real_dlsym(void* handle, const char* name)
+{
+  if (pthread_once(&real_dlsym_once, initialize_real_dlsym) != 0 || real_dlsym_function == NULL)
+    return NULL;
+  return real_dlsym_function(handle, name);
+}
+
+void*
+cuinterposer_lookup_real_symbol(const char* name)
+{
+  void* symbol = real_dlsym(RTLD_NEXT, name);
+  void* handle;
+
+  if (symbol != NULL)
+    return symbol;
+  handle = (void*)atomic_load(&explicit_libcuda_handle);
+  if (handle != NULL && (symbol = real_dlsym(handle, name)) != NULL)
+    return symbol;
+  handle = (void*)atomic_load(&explicit_libcudart_handle);
+  return handle == NULL ? NULL : real_dlsym(handle, name);
+}
+
+static bool
+is_cuda_library(void* handle, void* symbol, const char** library)
+{
+  struct link_map* map;
+  Dl_info info;
+  const char* provider;
+  const char* requested;
+
+  if (dladdr(symbol, &info) == 0)
+    return false;
+  provider = strrchr(info.dli_fname, '/');
+  provider = provider == NULL ? info.dli_fname : provider + 1;
+  if (strncmp(provider, "libcuda.so", 10) != 0 && strncmp(provider, "libcudart.so", 12) != 0)
+    return false;
+  *library = provider;
+  if (handle == NULL || handle == RTLD_NEXT)
+    return true;
+  if (dlinfo(handle, RTLD_DI_LINKMAP, &map) != 0 || map == NULL)
+    return false;
+  requested = strrchr(map->l_name, '/');
+  requested = requested == NULL ? map->l_name : requested + 1;
+  return (strncmp(requested, "libcuda.so", 10) == 0 && strncmp(provider, "libcuda.so", 10) == 0) ||
+         (strncmp(requested, "libcudart.so", 12) == 0 && strncmp(provider, "libcudart.so", 12) == 0);
+}
+
+void*
+dlsym(void* handle, const char* name)
+{
+  void* symbol = real_dlsym(handle, name);
+  void* entry;
+  const char* library;
+
+  if (symbol == NULL || !is_cuda_library(handle, symbol, &library))
+    return symbol;
+  if (strncmp(library, "libcuda.so", 10) == 0) {
+    if (handle != NULL && handle != RTLD_NEXT)
+      atomic_store(&explicit_libcuda_handle, (uintptr_t)handle);
+    if (strcmp(name, "cuGetProcAddress") == 0)
+      atomic_store(&explicit_cu_get_proc_address, (uintptr_t)symbol);
+    if (strcmp(name, "cuGetProcAddress_v2") == 0)
+      atomic_store(&explicit_cu_get_proc_address_v2, (uintptr_t)symbol);
+  } else if (handle != NULL && handle != RTLD_NEXT)
+    atomic_store(&explicit_libcudart_handle, (uintptr_t)handle);
+  entry = replacement(name, 0);
+  return entry == NULL || entry == symbol ? symbol : entry;
+}
+
+static cudaError_t
+runtime_driver_entry_point(
+    const char* resolver, const char* symbol, void** output, unsigned int version,
+    unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  cudaError_t result;
+  void* entry;
+
+  if (strcmp(resolver, "cudaGetDriverEntryPoint") == 0 ||
+      strcmp(resolver, "cudaGetDriverEntryPoint_ptsz") == 0) {
+    typedef cudaError_t(CUDARTAPI * function_type)(
+        const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+    function_type function = (function_type)cuinterposer_lookup_real_symbol(resolver);
+    result = function != NULL ? function(symbol, output, flags, status) : cudaErrorInitializationError;
+  } else {
+    typedef cudaError_t(CUDARTAPI * function_type)(
+        const char*, void**, unsigned int, unsigned long long,
+        enum cudaDriverEntryPointQueryResult*);
+    function_type function = (function_type)cuinterposer_lookup_real_symbol(resolver);
+    result = function != NULL ? function(symbol, output, version, flags, status) : cudaErrorInitializationError;
+  }
+  if (result == cudaSuccess && output != NULL && *output != NULL &&
+      (status == NULL || *status == cudaDriverEntryPointSuccess) &&
+      (entry = replacement(symbol, version == 0 ? CUDA_VERSION : (int)version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(
+    const char* symbol, void** output, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPoint", symbol, output, 0, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(
+    const char* symbol, void** output, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPoint_ptsz", symbol, output, 0, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point(
+      "cudaGetDriverEntryPointByVersion", symbol, output, version, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion_ptsz(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point(
+      "cudaGetDriverEntryPointByVersion_ptsz", symbol, output, version, flags, status);
+}
+
+static void*
+replacement(const char* symbol, int version)
+{
+#define ENTRY(name)               \
+  if (strcmp(symbol, #name) == 0) \
+  return (void*)&name
+  if (symbol == NULL)
+    return NULL;
+  ENTRY(cuMemCreate);
+  ENTRY(cuMemRelease);
+  ENTRY(cuMemRetainAllocationHandle);
+  ENTRY(cuMemMap);
+  ENTRY(cuMemUnmap);
+  ENTRY(cuMemSetAccess);
+  ENTRY(cuMemExportToShareableHandle);
+  ENTRY(cuMemImportFromShareableHandle);
+  ENTRY(cuMemGetAllocationPropertiesFromHandle);
+  ENTRY(cuGetProcAddress_v2);
+  ENTRY(cuGetProcAddress_v2_ptsz);
+  ENTRY(cudaGetDriverEntryPoint);
+  ENTRY(cudaGetDriverEntryPoint_ptsz);
+  ENTRY(cudaGetDriverEntryPointByVersion);
+  ENTRY(cudaGetDriverEntryPointByVersion_ptsz);
+#undef ENTRY
+  if (strcmp(symbol, "cuGetProcAddress") == 0)
+    return version >= 12000 ? (void*)&cuGetProcAddress_v2 : (void*)&cuGetProcAddress;
+  return NULL;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address);
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)cuinterposer_lookup_real_symbol("cuGetProcAddress");
+  result = function != NULL ? function(symbol, output, version, flags) : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2(
+    const char* symbol, void** output, int version, cuuint64_t flags,
+    CUdriverProcAddressQueryResult* status)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address_v2);
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)cuinterposer_lookup_real_symbol("cuGetProcAddress_v2");
+  result = function != NULL ? function(symbol, output, version, flags, status)
+                            : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (status == NULL || *status == CU_GET_PROC_ADDRESS_SUCCESS) &&
+      (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2_ptsz(
+    const char* symbol, void** output, int version, cuuint64_t flags,
+    CUdriverProcAddressQueryResult* status)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address_v2);
+  const cuuint64_t stream_flags =
+      CU_GET_PROC_ADDRESS_LEGACY_STREAM | CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)cuinterposer_lookup_real_symbol("cuGetProcAddress_v2");
+  if ((flags & stream_flags) == 0)
+    flags |= CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
+  result = function != NULL ? function(symbol, output, version, flags, status)
+                            : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (status == NULL || *status == CU_GET_PROC_ADDRESS_SUCCESS) &&
+      (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}

--- a/agent/cmd/cuinterpose/symbols.h
+++ b/agent/cmd/cuinterpose/symbols.h
@@ -7,4 +7,9 @@
 #ifndef CUINTERPOSER_SYMBOLS_H
 #define CUINTERPOSER_SYMBOLS_H
 
+#include <cuda.h>
+
+CUresult cuinterposer_unavailable(void);
+void* cuinterposer_lookup_real_symbol(const char* name);
+
 #endif

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include <cuda.h>
+#include <dlfcn.h>
+#include <string.h>
+
+#undef cuGetProcAddress
+
+enum {
+  result_create = 101,
+  result_release,
+  result_retain,
+  result_map,
+  result_unmap,
+  result_access,
+  result_export,
+  result_import,
+  result_properties,
+};
+
+CUresult CUDAAPI
+fakeCuMemCreateOriginal(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties,
+    unsigned long long flags)
+{
+  (void)size;
+  (void)properties;
+  (void)flags;
+  *output = 0xabc;
+  return (CUresult)result_create;
+}
+
+CUresult CUDAAPI
+cuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties,
+    unsigned long long flags)
+{
+  return fakeCuMemCreateOriginal(output, size, properties, flags);
+}
+
+CUresult CUDAAPI
+cuMemRelease(CUmemGenericAllocationHandle handle)
+{
+  (void)handle;
+  return (CUresult)result_release;
+}
+
+CUresult CUDAAPI
+cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
+{
+  (void)address;
+  *output = 0xdef;
+  return (CUresult)result_retain;
+}
+
+CUresult CUDAAPI
+cuMemMap(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle,
+    unsigned long long flags)
+{
+  (void)address;
+  (void)size;
+  (void)offset;
+  (void)handle;
+  (void)flags;
+  return (CUresult)result_map;
+}
+
+CUresult CUDAAPI
+cuMemUnmap(CUdeviceptr address, size_t size)
+{
+  (void)address;
+  (void)size;
+  return (CUresult)result_unmap;
+}
+
+CUresult CUDAAPI
+cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  (void)address;
+  (void)size;
+  (void)descriptors;
+  (void)count;
+  return (CUresult)result_access;
+}
+
+CUresult CUDAAPI
+cuMemExportToShareableHandle(
+    void* output, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type,
+    unsigned long long flags)
+{
+  (void)output;
+  (void)handle;
+  (void)type;
+  (void)flags;
+  return (CUresult)result_export;
+}
+
+CUresult CUDAAPI
+cuMemImportFromShareableHandle(
+    CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
+{
+  (void)os_handle;
+  (void)type;
+  *output = 0x123;
+  return (CUresult)result_import;
+}
+
+CUresult CUDAAPI
+cuMemGetAllocationPropertiesFromHandle(
+    CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+{
+  (void)properties;
+  (void)handle;
+  return (CUresult)result_properties;
+}
+
+static void*
+original(const char* symbol)
+{
+  if (strcmp(symbol, "cuMemCreate") == 0)
+    return (void*)&fakeCuMemCreateOriginal;
+  return dlsym(RTLD_DEFAULT, symbol);
+}
+
+CUresult CUDAAPI
+cuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flags)
+{
+  (void)version;
+  (void)flags;
+  *output = original(symbol);
+  return *output == NULL ? CUDA_ERROR_NOT_FOUND : CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2(
+    const char* symbol, void** output, int version, cuuint64_t flags,
+    CUdriverProcAddressQueryResult* status)
+{
+  CUresult result = cuGetProcAddress(symbol, output, version, flags);
+  if (status != NULL)
+    *status = result == CUDA_SUCCESS ? CU_GET_PROC_ADDRESS_SUCCESS : CU_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND;
+  return result;
+}

--- a/agent/cmd/cuinterpose/tests/fake_cudart.c
+++ b/agent/cmd/cuinterpose/tests/fake_cudart.c
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <string.h>
+
+extern CUresult CUDAAPI fakeCuMemCreateOriginal(
+    CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+
+static cudaError_t
+resolve(const char* symbol, void** output, enum cudaDriverEntryPointQueryResult* status)
+{
+  *output = strcmp(symbol, "cuMemCreate") == 0 ? (void*)&fakeCuMemCreateOriginal : NULL;
+  if (status != NULL)
+    *status = *output != NULL ? cudaDriverEntryPointSuccess : cudaDriverEntryPointSymbolNotFound;
+  return *output != NULL ? cudaSuccess : cudaErrorSymbolNotFound;
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(
+    const char* symbol, void** output, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  (void)flags;
+  return resolve(symbol, output, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(
+    const char* symbol, void** output, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return cudaGetDriverEntryPoint(symbol, output, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  (void)version;
+  return cudaGetDriverEntryPoint(symbol, output, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion_ptsz(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return cudaGetDriverEntryPointByVersion(symbol, output, version, flags, status);
+}

--- a/agent/cmd/cuinterpose/tests/forward_test.c
+++ b/agent/cmd/cuinterpose/tests/forward_test.c
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#undef cuGetProcAddress
+
+CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
+
+extern CUresult CUDAAPI fakeCuMemCreateOriginal(
+    CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+
+static void
+require(int condition, const char* message)
+{
+  if (!condition) {
+    fprintf(stderr, "FAIL: %s\n", message);
+    exit(1);
+  }
+}
+
+static void
+test_direct_forwarding(void)
+{
+  CUmemGenericAllocationHandle handle = 0;
+
+  require(cuMemCreate(&handle, 1, NULL, 0) == (CUresult)101 && handle == 0xabc, "cuMemCreate");
+  require(cuMemRelease(handle) == (CUresult)102, "cuMemRelease");
+  require(cuMemRetainAllocationHandle(&handle, NULL) == (CUresult)103 && handle == 0xdef, "cuMemRetain");
+  require(cuMemMap(1, 2, 3, handle, 0) == (CUresult)104, "cuMemMap");
+  require(cuMemUnmap(1, 2) == (CUresult)105, "cuMemUnmap");
+  require(cuMemSetAccess(1, 2, NULL, 0) == (CUresult)106, "cuMemSetAccess");
+  require(cuMemExportToShareableHandle(NULL, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) == (CUresult)107,
+          "cuMemExport");
+  require(cuMemImportFromShareableHandle(&handle, NULL, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) == (CUresult)108 &&
+              handle == 0x123,
+          "cuMemImport");
+  require(cuMemGetAllocationPropertiesFromHandle(NULL, handle) == (CUresult)109, "cuMemGetProperties");
+}
+
+static void
+test_resolvers(void)
+{
+  typedef CUresult(CUDAAPI * create_type)(
+      CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+  void* cuda = dlopen("libcuda.so.1", RTLD_NOW);
+  void* symbol = NULL;
+  CUmemGenericAllocationHandle handle = 0;
+  enum cudaDriverEntryPointQueryResult runtime_status;
+
+  require(cuda != NULL, "dlopen libcuda");
+  symbol = dlsym(cuda, "cuMemCreate");
+  require(symbol != NULL && symbol != (void*)&fakeCuMemCreateOriginal, "dlsym substitution");
+  require(((create_type)symbol)(&handle, 1, NULL, 0) == (CUresult)101, "dlsym forwarding");
+
+  symbol = NULL;
+  require(cuGetProcAddress("cuMemCreate", &symbol, CUDA_VERSION, 0) == CUDA_SUCCESS, "cuGetProcAddress");
+  require(symbol != NULL && symbol != (void*)&fakeCuMemCreateOriginal, "cuGetProcAddress substitution");
+
+  symbol = NULL;
+  require(cudaGetDriverEntryPoint("cuMemCreate", &symbol, 0, &runtime_status) == cudaSuccess,
+          "cudaGetDriverEntryPoint");
+  require(runtime_status == cudaDriverEntryPointSuccess && symbol != (void*)&fakeCuMemCreateOriginal,
+          "runtime substitution");
+  dlclose(cuda);
+}
+
+int
+main(void)
+{
+  test_direct_forwarding();
+  test_resolvers();
+  puts("forwarding OK");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- replace the delivery artifact with transparent POSIX CUDA VMM wrappers in `interpose.c`
- cover direct ELF binding, `dlsym`, `cuGetProcAddress`, and CUDA runtime resolver families
- bootstrap the real `dlsym` with one Makefile-pinned `dlvsym(..., \"GLIBC_2.34\")` call
- reject CUDA linkage and glibc requirements newer than 2.34 at build time
- forward every intercepted call and result unchanged; no checkpoint state or multicast surface yet

This is layer 2 of [stack #156](https://github.com/ai-dynamo/snapshot/stack/156).

## Validation
- CPU-only fake CUDA driver/runtime test covers direct and resolver forwarding
- pinned CUDA-devel image build with `-Wall -Wextra -Werror`
- `go test ./api/... ./operator/... ./agent/...`
