### PR TITLE
feat(agent): forward CUDA multicast APIs

### DIFF
--- a/agent/cmd/cuinterpose/Makefile
+++ b/agent/cmd/cuinterpose/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR ?= build
 CUDA_HOME ?= /usr/local/cuda
 INTERPOSER := $(BUILD_DIR)/libcuinterposer.so
 COORDINATOR := $(BUILD_DIR)/cuinterposer-coordinator
-FORWARD_TEST := $(BUILD_DIR)/forward-test
+MULTICAST_FORWARD_TEST := $(BUILD_DIR)/multicast-forward-test
 MIN_GLIBC := GLIBC_2.34
 INTERPOSER_CPPFLAGS := -DCUINTERPOSER_DLSYM_VERSION=\"$(MIN_GLIBC)\"
 COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror
@@ -47,9 +47,11 @@ test: $(INTERPOSER)
 		-o $(BUILD_DIR)/libcudart.so.13 tests/fake_cudart.c
 	ln -sf libcudart.so.13 $(BUILD_DIR)/libcudart.so
 	$(CC) $(COMMON_FLAGS) -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
-		-L$(BUILD_DIR) -Wl,-rpath,'$$ORIGIN' -o $(FORWARD_TEST) \
-		tests/forward_test.c -lcuda -lcudart -ldl
-	LD_PRELOAD=$(abspath $(INTERPOSER)) $(FORWARD_TEST)
+		-L$(BUILD_DIR) -Wl,-rpath,'$$ORIGIN' -o $(MULTICAST_FORWARD_TEST) \
+		tests/multicast_forward_test.c -lcuda -lcudart -ldl
+	mkdir -p $(BUILD_DIR)/control
+	SNAPSHOT_CONTROL_DIR=$(abspath $(BUILD_DIR)/control) \
+		LD_PRELOAD=$(abspath $(INTERPOSER)) $(MULTICAST_FORWARD_TEST)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/agent/cmd/cuinterpose/multicast.c
+++ b/agent/cmd/cuinterpose/multicast.c
@@ -4,4 +4,113 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "multicast.h"
+#include "symbols.h"
+
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+
+#define LOOKUP(name, type) ((type)cuinterposer_lookup_real_symbol(#name))
+
+CUresult CUDAAPI
+cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+  function_type function = LOOKUP(cuMulticastCreate, function_type);
+  return function != NULL ? function(output, properties) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle, CUdevice);
+  function_type function = LOOKUP(cuMulticastAddDevice, function_type);
+  return function != NULL ? function(multicast, device) : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMulticastBindMem(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size,
+    unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t,
+      unsigned long long);
+  function_type function = LOOKUP(cuMulticastBindMem, function_type);
+  return function != NULL
+             ? function(multicast, multicast_offset, memory, memory_offset, size, flags)
+             : cuinterposer_unavailable();
+}
+
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI
+cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size,
+    unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle,
+      size_t, size_t, unsigned long long);
+  function_type function = LOOKUP(cuMulticastBindMem_v2, function_type);
+  return function != NULL
+             ? function(
+                   multicast, device, multicast_offset, memory, memory_offset, size, flags)
+             : cuinterposer_unavailable();
+}
+#endif
+
+CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory,
+    size_t size, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+  function_type function = LOOKUP(cuMulticastBindAddr, function_type);
+  return function != NULL
+             ? function(multicast, multicast_offset, memory, size, flags)
+             : cuinterposer_unavailable();
+}
+
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI
+cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
+    CUdeviceptr memory, size_t size, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t,
+      unsigned long long);
+  function_type function = LOOKUP(cuMulticastBindAddr_v2, function_type);
+  return function != NULL
+             ? function(multicast, device, multicast_offset, memory, size, flags)
+             : cuinterposer_unavailable();
+}
+#endif
+
+CUresult CUDAAPI
+cuMulticastGetGranularity(
+    size_t* granularity, const CUmulticastObjectProp* properties,
+    CUmulticastGranularity_flags option)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
+  function_type function = LOOKUP(cuMulticastGetGranularity, function_type);
+  return function != NULL ? function(granularity, properties, option)
+                          : cuinterposer_unavailable();
+}
+
+CUresult CUDAAPI
+cuMulticastUnbind(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+  function_type function = LOOKUP(cuMulticastUnbind, function_type);
+  return function != NULL ? function(multicast, device, offset, size)
+                          : cuinterposer_unavailable();
+}
+
+#undef LOOKUP

--- a/agent/cmd/cuinterpose/symbols.c
+++ b/agent/cmd/cuinterpose/symbols.c
@@ -22,6 +22,8 @@
 #endif
 
 #undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
 #undef cudaGetDriverEntryPoint
 #undef cudaGetDriverEntryPointByVersion
 
@@ -37,6 +39,28 @@ CUresult CUDAAPI cuMemImportFromShareableHandle(
     CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
 CUresult CUDAAPI cuMemGetAllocationPropertiesFromHandle(
     CUmemAllocationProp*, CUmemGenericAllocationHandle);
+CUresult CUDAAPI cuMulticastCreate(
+    CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+CUresult CUDAAPI cuMulticastAddDevice(CUmemGenericAllocationHandle, CUdevice);
+CUresult CUDAAPI cuMulticastBindMem(
+    CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t,
+    unsigned long long);
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t,
+    size_t, unsigned long long);
+#endif
+CUresult CUDAAPI cuMulticastBindAddr(
+    CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t,
+    unsigned long long);
+#endif
+CUresult CUDAAPI cuMulticastGetGranularity(
+    size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
+CUresult CUDAAPI cuMulticastUnbind(
+    CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
 CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
 CUresult CUDAAPI cuGetProcAddress_v2(
     const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
@@ -213,6 +237,12 @@ replacement(const char* symbol, int version)
   return (void*)&name
   if (symbol == NULL)
     return NULL;
+#if CUDA_VERSION >= 13010
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindMem") == 0)
+    return (void*)&cuMulticastBindMem_v2;
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindAddr") == 0)
+    return (void*)&cuMulticastBindAddr_v2;
+#endif
   ENTRY(cuMemCreate);
   ENTRY(cuMemRelease);
   ENTRY(cuMemRetainAllocationHandle);
@@ -222,6 +252,18 @@ replacement(const char* symbol, int version)
   ENTRY(cuMemExportToShareableHandle);
   ENTRY(cuMemImportFromShareableHandle);
   ENTRY(cuMemGetAllocationPropertiesFromHandle);
+  ENTRY(cuMulticastCreate);
+  ENTRY(cuMulticastAddDevice);
+  ENTRY(cuMulticastBindMem);
+#if CUDA_VERSION >= 13010
+  ENTRY(cuMulticastBindMem_v2);
+#endif
+  ENTRY(cuMulticastBindAddr);
+#if CUDA_VERSION >= 13010
+  ENTRY(cuMulticastBindAddr_v2);
+#endif
+  ENTRY(cuMulticastGetGranularity);
+  ENTRY(cuMulticastUnbind);
   ENTRY(cuGetProcAddress_v2);
   ENTRY(cuGetProcAddress_v2_ptsz);
   ENTRY(cudaGetDriverEntryPoint);

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -11,6 +11,8 @@
 #include <string.h>
 
 #undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
 
 enum {
   result_create = 101,
@@ -22,6 +24,12 @@ enum {
   result_export,
   result_import,
   result_properties,
+  result_multicast_create,
+  result_multicast_add_device,
+  result_multicast_bind_mem,
+  result_multicast_bind_address,
+  result_multicast_granularity,
+  result_multicast_unbind,
 };
 
 CUresult CUDAAPI
@@ -121,11 +129,87 @@ cuMemGetAllocationPropertiesFromHandle(
   return (CUresult)result_properties;
 }
 
+CUresult CUDAAPI
+fakeCuMulticastCreateOriginal(
+    CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  (void)properties;
+  *output = 0x456;
+  return (CUresult)result_multicast_create;
+}
+
+CUresult CUDAAPI
+cuMulticastCreate(
+    CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  return fakeCuMulticastCreateOriginal(output, properties);
+}
+
+CUresult CUDAAPI
+cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+{
+  (void)multicast;
+  (void)device;
+  return (CUresult)result_multicast_add_device;
+}
+
+CUresult CUDAAPI
+cuMulticastBindMem(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size,
+    unsigned long long flags)
+{
+  (void)multicast;
+  (void)multicast_offset;
+  (void)memory;
+  (void)memory_offset;
+  (void)size;
+  (void)flags;
+  return (CUresult)result_multicast_bind_mem;
+}
+
+CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory,
+    size_t size, unsigned long long flags)
+{
+  (void)multicast;
+  (void)multicast_offset;
+  (void)memory;
+  (void)size;
+  (void)flags;
+  return (CUresult)result_multicast_bind_address;
+}
+
+CUresult CUDAAPI
+cuMulticastGetGranularity(
+    size_t* granularity, const CUmulticastObjectProp* properties,
+    CUmulticastGranularity_flags option)
+{
+  (void)properties;
+  (void)option;
+  *granularity = 4096;
+  return (CUresult)result_multicast_granularity;
+}
+
+CUresult CUDAAPI
+cuMulticastUnbind(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+{
+  (void)multicast;
+  (void)device;
+  (void)offset;
+  (void)size;
+  return (CUresult)result_multicast_unbind;
+}
+
 static void*
 original(const char* symbol)
 {
   if (strcmp(symbol, "cuMemCreate") == 0)
     return (void*)&fakeCuMemCreateOriginal;
+  if (strcmp(symbol, "cuMulticastCreate") == 0)
+    return (void*)&fakeCuMulticastCreateOriginal;
   return dlsym(RTLD_DEFAULT, symbol);
 }
 

--- a/agent/cmd/cuinterpose/tests/fake_cudart.c
+++ b/agent/cmd/cuinterpose/tests/fake_cudart.c
@@ -10,11 +10,18 @@
 
 extern CUresult CUDAAPI fakeCuMemCreateOriginal(
     CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+extern CUresult CUDAAPI fakeCuMulticastCreateOriginal(
+    CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
 
 static cudaError_t
 resolve(const char* symbol, void** output, enum cudaDriverEntryPointQueryResult* status)
 {
-  *output = strcmp(symbol, "cuMemCreate") == 0 ? (void*)&fakeCuMemCreateOriginal : NULL;
+  if (strcmp(symbol, "cuMemCreate") == 0)
+    *output = (void*)&fakeCuMemCreateOriginal;
+  else if (strcmp(symbol, "cuMulticastCreate") == 0)
+    *output = (void*)&fakeCuMulticastCreateOriginal;
+  else
+    *output = NULL;
   if (status != NULL)
     *status = *output != NULL ? cudaDriverEntryPointSuccess : cudaDriverEntryPointSymbolNotFound;
   return *output != NULL ? cudaSuccess : cudaErrorSymbolNotFound;

--- a/agent/cmd/cuinterpose/tests/multicast_forward_test.c
+++ b/agent/cmd/cuinterpose/tests/multicast_forward_test.c
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+
+CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
+
+extern CUresult CUDAAPI fakeCuMulticastCreateOriginal(
+    CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+
+static void
+require(int condition, const char* message)
+{
+  if (!condition) {
+    fprintf(stderr, "FAIL: %s\n", message);
+    exit(1);
+  }
+}
+
+static void
+test_direct_forwarding(void)
+{
+  CUmemGenericAllocationHandle handle = 0;
+  size_t granularity = 0;
+
+  require(
+      cuMulticastCreate(&handle, NULL) == (CUresult)110 && handle == 0x456,
+      "cuMulticastCreate");
+  require(cuMulticastAddDevice(handle, 1) == (CUresult)111, "cuMulticastAddDevice");
+  require(
+      cuMulticastBindMem(handle, 2, 3, 4, 5, 0) == (CUresult)112,
+      "cuMulticastBindMem");
+  require(
+      cuMulticastBindAddr(handle, 2, 3, 4, 0) == (CUresult)113,
+      "cuMulticastBindAddr");
+  require(
+      cuMulticastGetGranularity(&granularity, NULL, 0) == (CUresult)114 &&
+          granularity == 4096,
+      "cuMulticastGetGranularity");
+  require(cuMulticastUnbind(handle, 1, 2, 3) == (CUresult)115, "cuMulticastUnbind");
+}
+
+static void
+test_resolvers(void)
+{
+  typedef CUresult(CUDAAPI * create_type)(
+      CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+  void* cuda = dlopen("libcuda.so.1", RTLD_NOW);
+  void* symbol = NULL;
+  CUmemGenericAllocationHandle handle = 0;
+  enum cudaDriverEntryPointQueryResult runtime_status;
+
+  require(cuda != NULL, "dlopen libcuda");
+  symbol = dlsym(cuda, "cuMulticastCreate");
+  require(
+      symbol != NULL && symbol != (void*)&fakeCuMulticastCreateOriginal,
+      "dlsym substitution");
+  require(
+      ((create_type)symbol)(&handle, NULL) == (CUresult)110,
+      "dlsym forwarding");
+
+  symbol = NULL;
+  require(
+      cuGetProcAddress("cuMulticastCreate", &symbol, CUDA_VERSION, 0) == CUDA_SUCCESS,
+      "cuGetProcAddress");
+  require(
+      symbol != NULL && symbol != (void*)&fakeCuMulticastCreateOriginal,
+      "cuGetProcAddress substitution");
+
+  symbol = NULL;
+  require(
+      cudaGetDriverEntryPoint(
+          "cuMulticastCreate", &symbol, 0, &runtime_status) == cudaSuccess,
+      "cudaGetDriverEntryPoint");
+  require(
+      runtime_status == cudaDriverEntryPointSuccess &&
+          symbol != (void*)&fakeCuMulticastCreateOriginal,
+      "runtime substitution");
+  dlclose(cuda);
+}
+
+int
+main(void)
+{
+  test_direct_forwarding();
+  test_resolvers();
+  puts("multicast forwarding OK");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add transparent CUDA multicast wrappers in `multicast.c`
- register multicast entry points across direct binding, `dlsym`, `cuGetProcAddress`, and CUDA runtime resolvers
- select CUDA 13.1 device-explicit bind ABIs when the build headers and requested API version support them
- forward calls and results unchanged; no multicast topology state or replay yet

This is layer 5 of [stack #156](https://github.com/ai-dynamo/snapshot/stack/156).

## Validation
- CPU-only fake CUDA driver/runtime test covers direct and resolver forwarding
- pinned CUDA-devel image build with the GLIBC 2.34 ceiling
- `go test ./api/... ./operator/... ./agent/...`
