### PR TITLE
feat(agent): route checkpoints through PageBroker

### DIFF
--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -585,19 +585,22 @@ func (w *NodeController) executorCheckpoint(ctx context.Context, params Checkpoi
 	log := logr.FromContextOrDiscard(ctx)
 
 	req := executor.CheckpointRequest{
-		ContainerID:   params.ContainerID,
-		ContainerName: params.ContainerName,
-		ContentUID:    params.ContentUID,
-		StartedAt:     params.StartedAt,
-		NodeName:      w.config.NodeName,
-		PodName:       params.Pod.Name,
-		PodNamespace:  params.Pod.Namespace,
-		PodIP:         params.Pod.Status.PodIP,
-		Clientset:     w.clientset,
+		ContainerID:         params.ContainerID,
+		ContainerName:       params.ContainerName,
+		ContentUID:          params.ContentUID,
+		StartedAt:           params.StartedAt,
+		NodeName:            w.config.NodeName,
+		PodName:             params.Pod.Name,
+		PodNamespace:        params.Pod.Namespace,
+		PodIP:               params.Pod.Status.PodIP,
+		Clientset:           w.clientset,
+		PageBrokerRequested: params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
 	}
 	if err := executor.Checkpoint(ctx, w.runtime, log, req, w.config); err != nil {
-		if killErr := w.killCheckpointProcess(log, params.ContainerPID, "checkpoint failed"); killErr != nil {
-			log.Error(killErr, "Failed to kill target after checkpoint failure")
+		if executor.CheckpointNeedsSourceKill(err) {
+			if killErr := w.killCheckpointProcess(log, params.ContainerPID, "checkpoint failed"); killErr != nil {
+				log.Error(killErr, "Failed to kill target after checkpoint failure")
+			}
 		}
 		return fmt.Errorf("checkpoint: %w", err)
 	}

--- a/agent/internal/controller/podsnapshotcontent_test.go
+++ b/agent/internal/controller/podsnapshotcontent_test.go
@@ -766,6 +766,36 @@ func TestRunCheckpoint_WritesFailedOnError(t *testing.T) {
 	assert.Equal(t, "CheckpointFailed", cond.Reason)
 }
 
+func TestExecutorCheckpointPageBrokerPrepareFailureDoesNotKill(t *testing.T) {
+	w := makeNodeController(t, &fakeCheckpointer{})
+	w.config.PageBroker = snapshottypes.PageBrokerSpec{
+		Enabled:           true,
+		ControlSocketPath: filepath.Join(t.TempDir(), "pagebroker.sock"),
+	}
+	ctx, target := startKillableTarget(t)
+	defer func() {
+		_ = target.Process.Kill()
+		_ = target.Wait()
+	}()
+
+	err := w.executorCheckpoint(context.Background(), CheckpointParams{
+		Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-0",
+			Namespace: "inference",
+			Annotations: map[string]string{
+				snapshotv1alpha1.PageBrokerAnnotation: snapshotv1alpha1.PageBrokerAnnotationEnabled,
+			},
+		}},
+		ContainerName: "main",
+		ContainerID:   "abc123",
+		ContainerPID:  target.Process.Pid,
+		ContentUID:    "content-uid",
+	})
+	require.ErrorContains(t, err, "prepare PageBroker checkpoint")
+	require.NoError(t, target.Process.Signal(syscall.Signal(0)), "PageBroker preflight failure must not kill the source")
+	require.NoError(t, ctx.Err())
+}
+
 // TestReconcilePodSnapshotContent_TerminalPodWithArtifactRecoversReady covers the pre-bind
 // gate's resync racing a finished capture: the pod is already terminal (killed by the dump)
 // and the artifact is committed, so the gate must recover Ready instead of writing SourcePodGone.

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -7,6 +7,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,21 +21,40 @@ import (
 	"github.com/ai-dynamo/snapshot/agent/internal/criu"
 	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
+	"github.com/ai-dynamo/snapshot/agent/internal/pagebroker"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
 
+const pageBrokerAbortTimeout = 5 * time.Second
+
+// checkpointNeedsSourceKillError reports a failure after CUDA or CRIU may have left the source unsafe.
+type checkpointNeedsSourceKillError struct{ cause error }
+
+func (e *checkpointNeedsSourceKillError) Error() string { return e.cause.Error() }
+
+func (e *checkpointNeedsSourceKillError) Unwrap() error { return e.cause }
+
+func checkpointNeedsSourceKill(err error) error { return &checkpointNeedsSourceKillError{cause: err} }
+
+// CheckpointNeedsSourceKill reports whether a failed checkpoint may have left the source unsafe.
+func CheckpointNeedsSourceKill(err error) bool {
+	var checkpointError *checkpointNeedsSourceKillError
+	return errors.As(err, &checkpointError)
+}
+
 // CheckpointRequest holds the content-owned inputs for a checkpoint operation.
 type CheckpointRequest struct {
-	ContainerID   string
-	ContainerName string
-	ContentUID    string
-	StartedAt     time.Time
-	NodeName      string
-	PodName       string
-	PodNamespace  string
-	PodIP         string
-	Clientset     kubernetes.Interface
+	ContainerID         string
+	ContainerName       string
+	ContentUID          string
+	StartedAt           time.Time
+	NodeName            string
+	PodName             string
+	PodNamespace        string
+	PodIP               string
+	Clientset           kubernetes.Interface
+	PageBrokerRequested bool
 }
 
 type checkpointPhaseTimings struct {
@@ -48,7 +68,7 @@ type checkpointPhaseTimings struct {
 // The checkpoint directory is staged under the content-owned .tmp directory.
 // On success, the previous checkpoint is removed and the staged directory is
 // renamed atomically into the content/container artifact path.
-func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req CheckpointRequest, cfg *types.AgentConfig) error {
+func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, req CheckpointRequest, cfg *types.AgentConfig) (retErr error) {
 	checkpointStart := time.Now()
 	log.Info("=== Starting checkpoint operation ===")
 
@@ -56,21 +76,44 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	if err != nil {
 		return fmt.Errorf("resolve checkpoint artifact path: %w", err)
 	}
-	tmpRoot, err := nsmount.ResolveArtifactStagingRoot(cfg.Storage.BasePath, req.ContentUID)
-	if err != nil {
-		return fmt.Errorf("resolve checkpoint staging root: %w", err)
+	brokered := req.PageBrokerRequested && cfg.PageBroker.Enabled
+	transactionID := uuid.NewString()
+	var broker pagebroker.Client
+	committed := false
+	var tmpDir string
+	if brokered {
+		broker = pagebroker.Client{ControlSocketPath: cfg.PageBroker.ControlSocketPath}
+		defer func() {
+			if !committed {
+				abortCtx, cancel := context.WithTimeout(context.Background(), pageBrokerAbortTimeout)
+				defer cancel()
+				if err := broker.Abort(abortCtx, transactionID); err != nil {
+					retErr = errors.Join(retErr, fmt.Errorf("abort PageBroker checkpoint %q: %w", transactionID, err))
+				}
+			}
+		}()
+		var err error
+		tmpDir, err = broker.PrepareCheckpoint(ctx, transactionID, finalDir)
+		if err != nil {
+			return fmt.Errorf("prepare PageBroker checkpoint: %w", err)
+		}
+	} else {
+		tmpRoot, err := nsmount.ResolveArtifactStagingRoot(cfg.Storage.BasePath, req.ContentUID)
+		if err != nil {
+			return fmt.Errorf("resolve checkpoint staging root: %w", err)
+		}
+		if err := os.MkdirAll(tmpRoot, 0700); err != nil {
+			return fmt.Errorf("failed to create checkpoint staging root: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(finalDir), 0700); err != nil {
+			return fmt.Errorf("failed to create checkpoint container root: %w", err)
+		}
+		tmpDir = filepath.Join(tmpRoot, transactionID)
+		if err := os.Mkdir(tmpDir, 0700); err != nil {
+			return fmt.Errorf("failed to create checkpoint staging directory: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
 	}
-	if err := os.MkdirAll(tmpRoot, 0700); err != nil {
-		return fmt.Errorf("failed to create checkpoint staging root: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(finalDir), 0700); err != nil {
-		return fmt.Errorf("failed to create checkpoint container root: %w", err)
-	}
-	tmpDir := filepath.Join(tmpRoot, uuid.NewString())
-	if err := os.Mkdir(tmpDir, 0700); err != nil {
-		return fmt.Errorf("failed to create checkpoint staging directory: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
 
 	state, gpuDeviceMapDuration, err := inspectContainer(ctx, rt, log, req)
 	if err != nil {
@@ -91,17 +134,24 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 
 	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, cudaJobFile, log)
 	if err != nil {
-		return err
+		return checkpointNeedsSourceKill(err)
 	}
 
-	// Remove any previous checkpoint with the same identity hash, then
-	// promote the staged checkpoint directory into place.
 	switchStart := time.Now()
-	if err := os.RemoveAll(finalDir); err != nil {
-		return fmt.Errorf("failed to remove previous checkpoint directory: %w", err)
-	}
-	if err := os.Rename(tmpDir, finalDir); err != nil {
-		return fmt.Errorf("failed to finalize checkpoint directory: %w", err)
+	if brokered {
+		if err := broker.Commit(ctx, transactionID); err != nil {
+			return fmt.Errorf("commit PageBroker checkpoint: %w", err)
+		}
+		committed = true
+	} else {
+		// Remove any previous checkpoint with the same identity hash, then
+		// promote the staged checkpoint directory into place.
+		if err := os.RemoveAll(finalDir); err != nil {
+			return fmt.Errorf("failed to remove previous checkpoint directory: %w", err)
+		}
+		if err := os.Rename(tmpDir, finalDir); err != nil {
+			return fmt.Errorf("failed to finalize checkpoint directory: %w", err)
+		}
 	}
 	switchDuration := time.Since(switchStart)
 

--- a/agent/internal/executor/checkpoint_test.go
+++ b/agent/internal/executor/checkpoint_test.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -46,4 +47,25 @@ func TestCheckpointPreparesContentArtifactParents(t *testing.T) {
 	require.ErrorContains(t, err, "stop after path preparation")
 	assert.DirExists(t, filepath.Dir(finalDir))
 	assert.DirExists(t, filepath.Join(cfg.Storage.BasePath, "artifacts", "content-uid", ".tmp"))
+}
+
+func TestCheckpointPageBrokerPrepareFailureDoesNotMutate(t *testing.T) {
+	cfg := &types.AgentConfig{
+		Storage:    types.StorageSpec{BasePath: t.TempDir()},
+		PageBroker: types.PageBrokerSpec{Enabled: true, ControlSocketPath: t.TempDir() + "/pagebroker.sock"},
+	}
+
+	err := Checkpoint(context.Background(), checkpointPathRuntime{}, logr.Discard(), CheckpointRequest{
+		ContentUID:          "content-uid",
+		ContainerName:       "main",
+		PageBrokerRequested: true,
+	}, cfg)
+	require.ErrorContains(t, err, "prepare PageBroker checkpoint")
+	assert.False(t, CheckpointNeedsSourceKill(err))
+}
+
+func TestCheckpointNeedsSourceKill(t *testing.T) {
+	assert.True(t, CheckpointNeedsSourceKill(checkpointNeedsSourceKill(errors.New("capture failed"))))
+	assert.False(t, CheckpointNeedsSourceKill(errors.New("prepare failed")))
+	assert.False(t, CheckpointNeedsSourceKill(fmt.Errorf("commit PageBroker checkpoint: %w", errors.New("failed"))))
 }

--- a/agent/internal/pagebroker/client.go
+++ b/agent/internal/pagebroker/client.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pagebroker
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// PageBroker control requests and responses are limited to 64 KiB.
+	maxMessageSize   = 64 << 10
+	commitRetryDelay = 100 * time.Millisecond
+)
+
+var errMessageTooLarge = fmt.Errorf("message exceeds %d bytes", maxMessageSize)
+
+// Client uses the deployment-wide filesystem/POSIX PageBroker plan.
+type Client struct {
+	ControlSocketPath string
+}
+
+func (c Client) PrepareCheckpoint(ctx context.Context, transactionID, destination string) (string, error) {
+	response, err := c.request(ctx, transactionID, &Request_PrepareStagedCheckpoint{
+		PrepareStagedCheckpoint: &PrepareStagedCheckpointRequest{Destination: filesystem(destination), IoEngine: posixCopy()},
+	})
+	if err != nil {
+		return "", err
+	}
+	return imageDirectory(response.GetStagedCheckpointDirectory().GetImageDirectory())
+}
+
+func imageDirectory(directory string) (string, error) {
+	if directory == "" {
+		return "", fmt.Errorf("unexpected PageBroker staging response")
+	}
+	return directory, nil
+}
+
+func (c Client) Commit(ctx context.Context, transactionID string) error {
+	for {
+		response, err := c.request(ctx, transactionID, &Request_Commit{Commit: &CommitRequest{}})
+		if err == nil {
+			if response.GetCommitComplete() != nil {
+				return nil
+			}
+			return fmt.Errorf("unexpected PageBroker commit response")
+		}
+		var transport transportError
+		if !errors.As(err, &transport) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(commitRetryDelay):
+		}
+	}
+}
+
+func (c Client) Abort(ctx context.Context, transactionID string) error {
+	response, err := c.request(ctx, transactionID, &Request_Abort{Abort: &AbortRequest{}})
+	if err != nil {
+		return err
+	}
+	if response.GetAbortComplete() == nil {
+		return fmt.Errorf("unexpected PageBroker abort response")
+	}
+	return nil
+}
+
+func (c Client) request(ctx context.Context, transactionID string, command isRequest_Command) (*Response, error) {
+	connection, err := (&net.Dialer{}).DialContext(ctx, "unix", c.ControlSocketPath)
+	if err != nil {
+		return nil, transportError{cause: fmt.Errorf("dial PageBroker: %w", err)}
+	}
+	defer connection.Close()
+	stopCancel := context.AfterFunc(ctx, func() { _ = connection.Close() })
+	defer stopCancel()
+
+	requestID := uuid.NewString()
+	request := &Request{RequestId: &requestID, TransactionId: &transactionID, Command: command}
+	message, err := proto.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal PageBroker request: %w", err)
+	}
+	if err := writeMessage(connection, message); err != nil {
+		return nil, transportError{cause: fmt.Errorf("write PageBroker request: %w", err)}
+	}
+	message, err = readMessage(connection)
+	if err != nil {
+		if errors.Is(err, errMessageTooLarge) {
+			return nil, err
+		}
+		return nil, transportError{cause: fmt.Errorf("read PageBroker response: %w", err)}
+	}
+	response := new(Response)
+	if err := proto.Unmarshal(message, response); err != nil {
+		return nil, fmt.Errorf("unmarshal PageBroker response: %w", err)
+	}
+	if response.GetRequestId() != requestID || response.GetTransactionId() != transactionID {
+		return nil, fmt.Errorf("PageBroker response identifiers do not match request")
+	}
+	if failure := response.GetFailure(); failure != nil {
+		return nil, failureError{code: failureCode(failure.GetCode()), message: failure.GetMessage()}
+	}
+	return response, nil
+}
+
+type failureError struct {
+	code    Failure_Code
+	message string
+}
+
+func failureCode(code Failure_Code) Failure_Code {
+	switch code {
+	case Failure_UNSPECIFIED, Failure_INVALID_REQUEST, Failure_TRANSACTION_NOT_FOUND, Failure_TRANSACTION_CONFLICT,
+		Failure_INSUFFICIENT_STORAGE, Failure_STORAGE_ERROR, Failure_INTERNAL_ERROR:
+		return code
+	default:
+		return Failure_UNSPECIFIED
+	}
+}
+
+type transportError struct {
+	cause error
+}
+
+func (e transportError) Error() string { return e.cause.Error() }
+
+func (e transportError) Unwrap() error { return e.cause }
+
+func (e failureError) Error() string {
+	return fmt.Sprintf("PageBroker %s: %s", e.code, e.message)
+}
+
+func filesystem(directory string) *StorageBackend {
+	return &StorageBackend{Kind: &StorageBackend_Filesystem{Filesystem: &FilesystemStorage{Directory: &directory}}}
+}
+
+func posixCopy() *IOEngine {
+	return &IOEngine{Kind: &IOEngine_PosixCopy{PosixCopy: &PosixCopyIOEngine{}}}
+}
+
+func writeMessage(writer io.Writer, message []byte) error {
+	if len(message) > maxMessageSize {
+		return fmt.Errorf("message exceeds %d bytes", maxMessageSize)
+	}
+	if err := binary.Write(writer, binary.BigEndian, uint32(len(message))); err != nil {
+		return err
+	}
+	for len(message) > 0 {
+		written, err := writer.Write(message)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		message = message[written:]
+	}
+	return nil
+}
+
+func readMessage(reader io.Reader) ([]byte, error) {
+	var size uint32
+	if err := binary.Read(reader, binary.BigEndian, &size); err != nil {
+		return nil, err
+	}
+	if size > maxMessageSize {
+		return nil, errMessageTooLarge
+	}
+	message := make([]byte, size)
+	_, err := io.ReadFull(reader, message)
+	return message, err
+}

--- a/agent/internal/pagebroker/client_test.go
+++ b/agent/internal/pagebroker/client_test.go
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pagebroker
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFailureCodeMapsUnknownValuesToUnspecified(t *testing.T) {
+	if got := failureCode(Failure_Code(99)); got != Failure_UNSPECIFIED {
+		t.Fatalf("failureCode(99) = %v, want %v", got, Failure_UNSPECIFIED)
+	}
+}
+
+func TestRequestStopsWhenContextIsCanceled(t *testing.T) {
+	listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "pagebroker.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err == nil {
+			accepted <- connection
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- (Client{ControlSocketPath: listener.Addr().String()}).Abort(ctx, "transaction")
+	}()
+
+	connection := <-accepted
+	defer connection.Close()
+	if _, err := readMessage(connection); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("request succeeded after its context was canceled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request did not stop after its context was canceled")
+	}
+}
+
+func TestCommitRetriesLostResponses(t *testing.T) {
+	listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "pagebroker.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	requests := make(chan *Request, 3)
+	server := make(chan error, 1)
+	go func() {
+		for attempt := 0; attempt < 3; attempt++ {
+			connection, err := listener.Accept()
+			if err != nil {
+				server <- err
+				return
+			}
+			message, err := readMessage(connection)
+			if err != nil {
+				_ = connection.Close()
+				server <- err
+				return
+			}
+			request := new(Request)
+			if err := proto.Unmarshal(message, request); err != nil {
+				_ = connection.Close()
+				server <- err
+				return
+			}
+			requests <- request
+			if attempt == 2 {
+				response := &Response{
+					RequestId:     request.RequestId,
+					TransactionId: request.TransactionId,
+					Result:        &Response_CommitComplete{CommitComplete: &CommitComplete{}},
+				}
+				message, err = proto.Marshal(response)
+				if err == nil {
+					err = writeMessage(connection, message)
+				}
+				if err != nil {
+					_ = connection.Close()
+					server <- err
+					return
+				}
+			}
+			_ = connection.Close()
+		}
+		server <- nil
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := (Client{ControlSocketPath: listener.Addr().String()}).Commit(ctx, "transaction"); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-server; err != nil {
+		t.Fatal(err)
+	}
+	for range 3 {
+		request := <-requests
+		if request.GetTransactionId() != "transaction" || request.GetCommit() == nil {
+			t.Fatalf("unexpected retry request: %v", request)
+		}
+	}
+}
+
+func TestAbortRequiresAbortComplete(t *testing.T) {
+	listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "pagebroker.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	server := make(chan error, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err != nil {
+			server <- err
+			return
+		}
+		defer connection.Close()
+		message, err := readMessage(connection)
+		if err != nil {
+			server <- err
+			return
+		}
+		request := new(Request)
+		if err := proto.Unmarshal(message, request); err != nil {
+			server <- err
+			return
+		}
+		message, err = proto.Marshal(&Response{
+			RequestId:     request.RequestId,
+			TransactionId: request.TransactionId,
+			Result:        &Response_CommitComplete{CommitComplete: &CommitComplete{}},
+		})
+		if err == nil {
+			err = writeMessage(connection, message)
+		}
+		server <- err
+	}()
+
+	if err := (Client{ControlSocketPath: listener.Addr().String()}).Abort(context.Background(), "transaction"); err == nil {
+		t.Fatal("abort accepted a commit response")
+	}
+	if err := <-server; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStagingRequestsRejectEmptyDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		call  func(Client, context.Context) error
+		reply func(*Request) *Response
+	}{
+		{
+			name: "checkpoint",
+			call: func(client Client, ctx context.Context) error {
+				_, err := client.PrepareCheckpoint(ctx, "transaction", "/checkpoints/destination")
+				return err
+			},
+			reply: func(request *Request) *Response {
+				return &Response{RequestId: request.RequestId, TransactionId: request.TransactionId,
+					Result: &Response_StagedCheckpointDirectory{StagedCheckpointDirectory: &StagedCheckpointDirectory{}}}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "pagebroker.sock"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+
+			server := make(chan error, 1)
+			go func() {
+				connection, err := listener.Accept()
+				if err != nil {
+					server <- err
+					return
+				}
+				defer connection.Close()
+				message, err := readMessage(connection)
+				if err != nil {
+					server <- err
+					return
+				}
+				request := new(Request)
+				if err := proto.Unmarshal(message, request); err != nil {
+					server <- err
+					return
+				}
+				message, err = proto.Marshal(tc.reply(request))
+				if err == nil {
+					err = writeMessage(connection, message)
+				}
+				server <- err
+			}()
+
+			if err := tc.call(Client{ControlSocketPath: listener.Addr().String()}, context.Background()); err == nil {
+				t.Fatal("staging request accepted an empty directory")
+			}
+			if err := <-server; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCommitDoesNotRetryInvalidFrame(t *testing.T) {
+	listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "pagebroker.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	server := make(chan error, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err != nil {
+			server <- err
+			return
+		}
+		defer connection.Close()
+		if _, err := readMessage(connection); err != nil {
+			server <- err
+			return
+		}
+		server <- binary.Write(connection, binary.BigEndian, uint32(maxMessageSize+1))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = (Client{ControlSocketPath: listener.Addr().String()}).Commit(ctx, "transaction")
+	if !errors.Is(err, errMessageTooLarge) {
+		t.Fatalf("Commit() error = %v, want invalid frame error", err)
+	}
+	if err := <-server; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/agent/internal/types/config.go
+++ b/agent/internal/types/config.go
@@ -18,11 +18,12 @@ const CheckpointBasePath = "/checkpoints"
 // AgentConfig holds the full agent configuration: static checkpoint settings
 // from the ConfigMap YAML, plus runtime fields from environment variables.
 type AgentConfig struct {
-	NodeName string          `yaml:"-"`
-	Storage  StorageSpec     `yaml:"storage"`
-	Overlay  OverlaySettings `yaml:"overlay"`
-	Restore  RestoreSpec     `yaml:"restore"`
-	CRIU     CRIUSettings    `yaml:"criu"`
+	NodeName   string          `yaml:"-"`
+	Storage    StorageSpec     `yaml:"storage"`
+	Overlay    OverlaySettings `yaml:"overlay"`
+	PageBroker PageBrokerSpec  `yaml:"pageBroker"`
+	Restore    RestoreSpec     `yaml:"restore"`
+	CRIU       CRIUSettings    `yaml:"criu"`
 }
 
 func (c *AgentConfig) LoadEnvOverrides() {
@@ -65,6 +66,11 @@ func (c *AgentConfig) Validate() error {
 type StorageSpec struct {
 	Type     string `yaml:"type"`
 	BasePath string `yaml:"basePath"`
+}
+
+type PageBrokerSpec struct {
+	Enabled           bool   `yaml:"enabled"`
+	ControlSocketPath string `yaml:"controlSocketPath"`
 }
 
 // RestoreSpec holds settings for the CRIU restore process.

--- a/agent/pagebroker/Makefile
+++ b/agent/pagebroker/Makefile
@@ -1,13 +1,12 @@
 PROTO := v1/pagebroker.proto
 GTEST_FLAGS := $(shell pkg-config --cflags --libs gtest_main)
-BROKER_SOURCES := broker.cpp checkpoint_transaction_descriptor.cpp posix_copy_engine.cpp restore_transaction_descriptor.cpp transfer_engine.cpp
 
 .PHONY: generate test
 
 generate:
 	protoc --proto_path=. --cpp_out=. $(PROTO)
 
-test: generate $(BROKER_SOURCES) daemon_test.cpp
+test: generate broker.cpp daemon_test.cpp
 	mkdir -p build
-	c++ -I. -std=c++20 -Wall -Werror $(BROKER_SOURCES) daemon_test.cpp v1/pagebroker.pb.cc -lprotobuf $(GTEST_FLAGS) -o build/pagebroker-test
+	c++ -I. -std=c++20 -Wall -Werror broker.cpp daemon_test.cpp v1/pagebroker.pb.cc -lprotobuf $(GTEST_FLAGS) -o build/pagebroker-test
 	./build/pagebroker-test

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -9,7 +9,9 @@ const (
 	// CaptureEligibleLabel is the gate-applied promotion label: the node agent's pre-bind gate
 	// adds it only after the source pod passes validation. The agent's source-pod capture
 	// informer keys on it so only gate-validated pods drive the capture path.
-	CaptureEligibleLabel = "nvidia.com/snapshot-capture-eligible"
+	CaptureEligibleLabel        = "nvidia.com/snapshot-capture-eligible"
+	PageBrokerAnnotation        = "nvidia.com/snapshot-pagebroker"
+	PageBrokerAnnotationEnabled = "true"
 
 	// SnapshotNodeLabel mirrors PodSnapshotContent.spec.source.nodeName onto the
 	// object so the per-node agent's cache can label-select work for its node.


### PR DESCRIPTION
## What

Routes checkpoints through PageBroker only when the Pod annotation requests it and the deployment enables PageBroker.

- Prepare a broker-owned tmpfs output directory before CRIU dumps.
- Commit publishes that directory through filesystem/POSIX copy.
- Abort cleans broker staging when checkpoint capture or publication fails.
- Commit retry after a lost local control-socket reply is bounded.

The existing local staging and rename path is unchanged when PageBroker is not selected.

## Scope

Checkpoint routing only. No restore routing, mount injection, Helm deployment, GPU path, S3, NIXL, or CRIU provider integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional PageBroker integration for checkpoint staging, commit, and abort operations.
  * Added configuration options for enabling PageBroker and specifying its control socket.
  * Checkpoint behavior can now be enabled through a pod annotation.

* **Bug Fixes**
  * Improved checkpoint transaction handling, including retries and cleanup after failures.

* **Tests**
  * Added coverage for cancellation, retries, invalid responses, oversized messages, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->