### PR TITLE
feat(agent): mount PageBroker staging for restores

### DIFF
--- a/agent/cmd/ns-bind-mount/main.c
+++ b/agent/cmd/ns-bind-mount/main.c
@@ -60,6 +60,8 @@ struct mount_attr {
 #define BUNDLE_DESTINATION "/tmp/snapshot-binaries"
 #define CHECKPOINT_ROOT "/checkpoints"
 #define CHECKPOINT_DESTINATION "/tmp/checkpoint"
+#define PAGEBROKER_RESTORE_ROOT "/pagebroker/staging/restore"
+#define PAGEBROKER_DESTINATION "/tmp/pagebroker"
 
 static int
 parse_fd(const char* value)
@@ -83,11 +85,11 @@ is_portable_path_char(char value)
 /* The Go caller constructs this path from validated single path elements. This
  * second check keeps the privileged helper safe if that caller regresses. */
 static int
-check_checkpoint_path(const char* value)
+check_storage_path(const char* value, const char* root)
 {
-  size_t root_len = strlen(CHECKPOINT_ROOT);
-  if (strncmp(value, CHECKPOINT_ROOT, root_len) != 0 || value[root_len] != '/') {
-    fprintf(stderr, "checkpoint path must be below %s: %s\n", CHECKPOINT_ROOT, value);
+  size_t root_len = strlen(root);
+  if (strncmp(value, root, root_len) != 0 || value[root_len] != '/') {
+    fprintf(stderr, "storage path must be below %s: %s\n", root, value);
     return -1;
   }
 
@@ -95,7 +97,7 @@ check_checkpoint_path(const char* value)
   for (const char* p = component;; p++) {
     if (*p != '/' && *p != '\0') {
       if (!is_portable_path_char(*p)) {
-        fprintf(stderr, "checkpoint path contains unsupported character: %s\n", value);
+        fprintf(stderr, "storage path contains unsupported character: %s\n", value);
         return -1;
       }
       continue;
@@ -104,13 +106,25 @@ check_checkpoint_path(const char* value)
     size_t len = (size_t)(p - component);
     if (len == 0 || (len == 1 && component[0] == '.') ||
         (len == 2 && component[0] == '.' && component[1] == '.')) {
-      fprintf(stderr, "checkpoint path contains an empty or traversing component: %s\n", value);
+      fprintf(stderr, "storage path contains an empty or traversing component: %s\n", value);
       return -1;
     }
     if (*p == '\0')
       return 0;
     component = p + 1;
   }
+}
+
+static int
+check_checkpoint_path(const char* value)
+{
+  return check_storage_path(value, CHECKPOINT_ROOT);
+}
+
+static int
+check_pagebroker_path(const char* value)
+{
+  return check_storage_path(value, PAGEBROKER_RESTORE_ROOT);
 }
 
 /* Returns 1 when this invocation created dst, 0 when a plain directory was
@@ -238,6 +252,23 @@ mount_checkpoint(int argc, char* argv[])
 }
 
 static int
+mount_pagebroker(int argc, char* argv[])
+{
+  if (argc != 4) {
+    fprintf(stderr, "usage: ns-bind-mount mount-pagebroker-fd <namespace-fd> <staging-path>\n");
+    return 1;
+  }
+  int ns_fd = parse_fd(argv[2]);
+  if (ns_fd < 0 || check_pagebroker_path(argv[3]) < 0)
+    return 1;
+  return install_mount(
+      ns_fd,
+      argv[3],
+      PAGEBROKER_DESTINATION,
+      MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC);
+}
+
+static int
 unmount_role(int argc, char* argv[], const char* dst, const char* usage)
 {
   if (argc != 3 && argc != 4) {
@@ -269,6 +300,8 @@ main(int argc, char* argv[])
     return mount_bundle(argc, argv);
   if (strcmp(argv[1], "mount-checkpoint-fd") == 0)
     return mount_checkpoint(argc, argv);
+  if (strcmp(argv[1], "mount-pagebroker-fd") == 0)
+    return mount_pagebroker(argc, argv);
   if (strcmp(argv[1], "unmount-bundle-fd") == 0)
     return unmount_role(
         argc,
@@ -281,6 +314,12 @@ main(int argc, char* argv[])
         argv,
         CHECKPOINT_DESTINATION,
         "usage: ns-bind-mount unmount-checkpoint-fd <namespace-fd> [created]");
+  if (strcmp(argv[1], "unmount-pagebroker-fd") == 0)
+    return unmount_role(
+        argc,
+        argv,
+        PAGEBROKER_DESTINATION,
+        "usage: ns-bind-mount unmount-pagebroker-fd <namespace-fd> [created]");
 
   fprintf(stderr, "unknown role command: %s\n", argv[1]);
   return 1;

--- a/agent/internal/nsmount/injector.go
+++ b/agent/internal/nsmount/injector.go
@@ -24,6 +24,10 @@ const (
 	// CheckpointDst is the mount destination for checkpoint data inside the
 	// placeholder namespace.
 	CheckpointDst = "/tmp/checkpoint"
+	// PageBrokerRestoreSrc is the agent-side PageBroker restore staging root.
+	PageBrokerRestoreSrc = "/pagebroker/staging/restore"
+	// PageBrokerDst is the mount destination for PageBroker staging inside the placeholder namespace.
+	PageBrokerDst = "/tmp/pagebroker"
 )
 
 // MountPoint represents an active bind-mount of a directory inside a foreign
@@ -79,6 +83,22 @@ func (nsm *NSMounter) MountArtifact(ctx context.Context, namespaceMount MountPoi
 	}
 	nsm.log.Info("mounting checkpoint into placeholder namespace", "src", src)
 	ref, err := nsm.mounter.MountCheckpoint(ctx, namespaceMount.NsFd(), src)
+	if err != nil {
+		return nil, err
+	}
+	return &mountPoint{mount: ref}, nil
+}
+
+// MountPageBroker exposes a staged PageBroker restore using the namespace
+// already pinned for the agent bundle.
+func (nsm *NSMounter) MountPageBroker(ctx context.Context, namespaceMount MountPoint, src string) (MountPoint, error) {
+	if err := validateWithin(PageBrokerRestoreSrc, src); err != nil {
+		return nil, err
+	}
+	if namespaceMount == nil || namespaceMount.NsFd() == nil {
+		return nil, fmt.Errorf("mount PageBroker: pinned mount namespace is required")
+	}
+	ref, err := nsm.mounter.MountPageBroker(ctx, namespaceMount.NsFd(), src)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/internal/nsmount/injector_test.go
+++ b/agent/internal/nsmount/injector_test.go
@@ -60,6 +60,15 @@ func (m *mockMounter) MountCheckpoint(_ context.Context, nsFd *os.File, src stri
 	return &fakeMountRef{dst: "checkpoint", unmountLog: &m.unmountLog}, nil
 }
 
+func (m *mockMounter) MountPageBroker(_ context.Context, nsFd *os.File, src string) (mountRef, error) {
+	i := len(m.calls)
+	m.calls = append(m.calls, mountCall{role: "pagebroker", nsFd: nsFd, src: src})
+	if i < len(m.results) && m.results[i] != nil {
+		return nil, m.results[i]
+	}
+	return &fakeMountRef{dst: "pagebroker", unmountLog: &m.unmountLog}, nil
+}
+
 const testPID = 42
 
 func newMounter(t *testing.T, m *mockMounter) *NSMounter {

--- a/agent/internal/nsmount/mount.go
+++ b/agent/internal/nsmount/mount.go
@@ -33,6 +33,7 @@ type mountRef interface {
 type mounter interface {
 	MountBundle(ctx context.Context, pid int) (mountRef, error)
 	MountCheckpoint(ctx context.Context, nsFd *os.File, checkpointPath string) (mountRef, error)
+	MountPageBroker(ctx context.Context, nsFd *os.File, stagingPath string) (mountRef, error)
 }
 
 type execMounter struct {
@@ -97,6 +98,18 @@ func (m *execMounter) MountCheckpoint(ctx context.Context, nsFd *os.File, checkp
 	}
 	unix.CloseOnExec(dupFd)
 	return m.mount(ctx, os.NewFile(uintptr(dupFd), nsFd.Name()), "mount-checkpoint-fd", "unmount-checkpoint-fd", checkpointPath)
+}
+
+func (m *execMounter) MountPageBroker(ctx context.Context, nsFd *os.File, stagingPath string) (mountRef, error) {
+	if nsFd == nil {
+		return nil, fmt.Errorf("mount namespace fd is required")
+	}
+	dupFd, err := unix.Dup(int(nsFd.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("duplicate mount namespace fd: %w", err)
+	}
+	unix.CloseOnExec(dupFd)
+	return m.mount(ctx, os.NewFile(uintptr(dupFd), nsFd.Name()), "mount-pagebroker-fd", "unmount-pagebroker-fd", stagingPath)
 }
 
 func (m *execMounter) mount(ctx context.Context, nsFd *os.File, mountCmd, unmountCmd string, args ...string) (mountRef, error) {


### PR DESCRIPTION
## What

Adds the namespace mount path that exposes broker-owned restore staging inside the placeholder namespace.

- The privileged helper accepts the fixed PageBroker source path.
- `/pagebroker` is shared only by the trusted PageBroker and privileged Snapshot Agent; workloads do not mount it.
- The staged directory is mounted read-only at `/tmp/pagebroker`.
- Existing snapshot-binaries mounts are unchanged.

## Scope

Namespace mount validation only. No restore routing, Helm deployment, PageBroker daemon behavior, GPU path, S3, NIXL, or CRIU provider integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for restoring PageBroker data through a dedicated mount.
  * Added commands to mount and unmount PageBroker storage.
  * PageBroker mounts use read-only, nosuid, nodev, and noexec protections.

* **Bug Fixes**
  * Improved storage-path validation for checkpoint and PageBroker paths, including rejecting root paths.
  * Added validation for required namespace handles during mounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->