### PR TITLE
feat(agent): route opted-in restores through PageBroker

### DIFF
--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -861,16 +861,19 @@ func (w *NodeController) newRestoreOperation(
 func (op *restoreOperation) executeRestore(ctx context.Context) (int, error) {
 	w := op.controller
 	req := executor.RestoreRequest{
-		ContentUID:               op.artifact.ContentUID,
-		BasePath:                 w.config.Storage.BasePath,
-		ContainerID:              op.containerID,
-		StartedAt:                op.startedAt,
-		PodName:                  op.pod.Name,
-		PodNamespace:             op.pod.Namespace,
-		TargetPodIP:              op.pod.Status.PodIP,
-		ArtifactContainerName:    op.artifact.SourceContainerName,
-		DestinationContainerName: op.destination,
-		Clientset:                w.clientset,
+		ContentUID:                  op.artifact.ContentUID,
+		BasePath:                    w.config.Storage.BasePath,
+		ContainerID:                 op.containerID,
+		StartedAt:                   op.startedAt,
+		PodName:                     op.pod.Name,
+		PodNamespace:                op.pod.Namespace,
+		TargetPodIP:                 op.pod.Status.PodIP,
+		ArtifactContainerName:       op.artifact.SourceContainerName,
+		DestinationContainerName:    op.destination,
+		Clientset:                   w.clientset,
+		PageBrokerRequested:         op.pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
+		PageBrokerEnabled:           w.config.PageBroker.Enabled,
+		PageBrokerControlSocketPath: w.config.PageBroker.ControlSocketPath,
 	}
 	return w.restoreFn(ctx, w.runtime, op.log, req, w.injector)
 }

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -91,6 +91,10 @@ func (noopInjector) MountArtifact(_ context.Context, _ nsmount.MountPoint, _ str
 	return noopMountPoint{}, nil
 }
 
+func (noopInjector) MountPageBroker(_ context.Context, _ nsmount.MountPoint, _ string) (nsmount.MountPoint, error) {
+	return noopMountPoint{}, nil
+}
+
 type noopMountPoint struct{}
 
 func (noopMountPoint) Unmount(context.Context) error { return nil }

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -16,12 +16,14 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ai-dynamo/snapshot/agent/internal/criu"
 	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	"github.com/ai-dynamo/snapshot/agent/internal/logging"
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
+	"github.com/ai-dynamo/snapshot/agent/internal/pagebroker"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
@@ -31,6 +33,7 @@ import (
 type RestoreMounter interface {
 	MountBundle(ctx context.Context, pid int) (nsmount.MountPoint, error)
 	MountArtifact(ctx context.Context, namespaceMount nsmount.MountPoint, artifactPath string) (nsmount.MountPoint, error)
+	MountPageBroker(ctx context.Context, namespaceMount nsmount.MountPoint, stagingPath string) (nsmount.MountPoint, error)
 }
 
 // RestoreCleanupError reports a successful restore whose cleanup did not fully
@@ -64,16 +67,19 @@ func cleanupRestoreMounts(ctx context.Context, mounts []restoreMount) error {
 
 // RestoreRequest holds the parameters for a restore operation.
 type RestoreRequest struct {
-	ContentUID               string
-	BasePath                 string
-	ContainerID              string
-	StartedAt                time.Time
-	PodName                  string
-	PodNamespace             string
-	TargetPodIP              string
-	ArtifactContainerName    string
-	DestinationContainerName string
-	Clientset                kubernetes.Interface
+	ContentUID                  string
+	BasePath                    string
+	ContainerID                 string
+	StartedAt                   time.Time
+	PodName                     string
+	PodNamespace                string
+	TargetPodIP                 string
+	ArtifactContainerName       string
+	DestinationContainerName    string
+	Clientset                   kubernetes.Interface
+	PageBrokerRequested         bool
+	PageBrokerEnabled           bool
+	PageBrokerControlSocketPath string
 }
 
 // Restore performs external restore for the given request.
@@ -141,18 +147,55 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		point:  bundleMount,
 	})
 
-	artifactMount, err := mounts.MountArtifact(ctx, bundleMount, artifactPath)
-	if err != nil {
-		return 0, fmt.Errorf("mount checkpoint artifact into placeholder: %w", err)
+	containerCheckpointPath := nsmount.CheckpointDst
+	brokered := req.PageBrokerRequested && req.PageBrokerEnabled
+	transactionID := ""
+	var broker pagebroker.Client
+	committed := false
+	if brokered {
+		transactionID = uuid.NewString()
+		broker = pagebroker.Client{ControlSocketPath: req.PageBrokerControlSocketPath}
+		defer func() {
+			if !committed {
+				abortCtx, cancel := context.WithTimeout(context.Background(), pageBrokerAbortTimeout)
+				defer cancel()
+				_ = broker.Abort(abortCtx, transactionID)
+			}
+		}()
+		staged, err := broker.StagedRestore(ctx, transactionID, artifactPath)
+		if err != nil {
+			return 0, fmt.Errorf("stage PageBroker restore: %w", err)
+		}
+		stagingMount, err := mounts.MountPageBroker(ctx, bundleMount, staged)
+		if err != nil {
+			return 0, fmt.Errorf("mount PageBroker staging: %w", err)
+		}
+		activeMounts = append(activeMounts, restoreMount{
+			action: "unmount PageBroker staging from placeholder",
+			point:  stagingMount,
+		})
+		containerCheckpointPath = nsmount.PageBrokerDst
+	} else {
+		artifactMount, err := mounts.MountArtifact(ctx, bundleMount, artifactPath)
+		if err != nil {
+			return 0, fmt.Errorf("mount checkpoint artifact into placeholder: %w", err)
+		}
+		activeMounts = append(activeMounts, restoreMount{
+			action: "unmount checkpoint artifact from placeholder",
+			point:  artifactMount,
+		})
 	}
-	activeMounts = append(activeMounts, restoreMount{
-		action: "unmount checkpoint artifact from placeholder",
-		point:  artifactMount,
-	})
 
-	result, err := execNSRestore(ctx, log, req, snap, bundleMount, nsmount.CheckpointDst)
+	result, err := execNSRestore(ctx, log, req, snap, bundleMount, containerCheckpointPath)
 	if err != nil {
 		return 0, fmt.Errorf("nsrestore failed: %w", err)
+	}
+	if brokered {
+		if err := broker.Commit(ctx, transactionID); err != nil {
+			log.Error(err, "failed to commit PageBroker restore")
+		} else {
+			committed = true
+		}
 	}
 	if result.CleanupError != nil {
 		cleanupErr = errors.Join(cleanupErr, result.CleanupError)

--- a/agent/internal/pagebroker/client.go
+++ b/agent/internal/pagebroker/client.go
@@ -29,6 +29,16 @@ type Client struct {
 	ControlSocketPath string
 }
 
+func (c Client) StagedRestore(ctx context.Context, transactionID, source string) (string, error) {
+	response, err := c.request(ctx, transactionID, &Request_StagedRestore{
+		StagedRestore: &StagedRestoreRequest{Source: filesystem(source), IoEngine: posixCopy()},
+	})
+	if err != nil {
+		return "", err
+	}
+	return imageDirectory(response.GetStagedRestoreDirectory().GetImageDirectory())
+}
+
 func (c Client) PrepareCheckpoint(ctx context.Context, transactionID, destination string) (string, error) {
 	response, err := c.request(ctx, transactionID, &Request_PrepareStagedCheckpoint{
 		PrepareStagedCheckpoint: &PrepareStagedCheckpointRequest{Destination: filesystem(destination), IoEngine: posixCopy()},

--- a/agent/internal/pagebroker/client_test.go
+++ b/agent/internal/pagebroker/client_test.go
@@ -177,6 +177,17 @@ func TestStagingRequestsRejectEmptyDirectory(t *testing.T) {
 		reply func(*Request) *Response
 	}{
 		{
+			name: "restore",
+			call: func(client Client, ctx context.Context) error {
+				_, err := client.StagedRestore(ctx, "transaction", "/checkpoints/source")
+				return err
+			},
+			reply: func(request *Request) *Response {
+				return &Response{RequestId: request.RequestId, TransactionId: request.TransactionId,
+					Result: &Response_StagedRestoreDirectory{StagedRestoreDirectory: &StagedRestoreDirectory{}}}
+			},
+		},
+		{
 			name: "checkpoint",
 			call: func(client Client, ctx context.Context) error {
 				_, err := client.PrepareCheckpoint(ctx, "transaction", "/checkpoints/destination")


### PR DESCRIPTION
Routes PageBroker-enabled restores through tmpfs staging, bind-mounts the staged directory into the restore namespace, then commits cleanup after CRIU succeeds.

Non-opted-in restores keep the existing path.

## Planned CUDA restore 

This PR stages the checkpoint data through PageBroker, then Snapshot runs `nsrestore` and CRIU.

The next PageBroker step (#109 )will run after CRIU restores the processes: Snapshot sends PageBroker the validated restored host PIDs, and PageBroker restores CUDA for those processes. Snapshot marks the Pod ready only after PageBroker reports success.

If the CUDA restore fails, the restore fails and the Pod is not marked ready. Non-PageBroker restores keep the existing flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional PageBroker-backed checkpoint restoration.
  - Checkpoint data can be staged and restored through PageBroker, with transactions committed after successful completion.
  - Existing direct restoration remains available as a fallback.

- **Bug Fixes**
  - Failed or incomplete staging transactions are now safely aborted.
  - Restore errors from PageBroker are surfaced to improve failure handling.
  - Invalid or empty restored image locations are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->