### PR TITLE
feat(charts): deploy opted-in tmpfs PageBroker

### DIFF
--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -101,3 +101,6 @@ reads for rootfs-diff capture, and CRI-O config.json fallback).
 {{- define "snapshot.runtimeStorageDir" -}}
 {{- if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
 {{- end }}
+
+{{- define "snapshot.pageBrokerControlPath" -}}/pagebroker/control{{- end -}}
+{{- define "snapshot.pageBrokerStagingPath" -}}/pagebroker/staging{{- end -}}

--- a/charts/snapshot/templates/configmap.yaml
+++ b/charts/snapshot/templates/configmap.yaml
@@ -25,6 +25,12 @@ data:
     overlay:
       exclusions: {{ toYaml .Values.config.overlay.exclusions | nindent 8 }}
 
+    pageBroker:
+      enabled: {{ .Values.pageBroker.enabled }}
+      {{- if .Values.pageBroker.enabled }}
+      controlSocketPath: {{ printf "%s/pagebroker.sock" (include "snapshot.pageBrokerControlPath" .) | quote }}
+      {{- end }}
+
     restore:
       restoreTimeoutSeconds: {{ .Values.config.restore.restoreTimeoutSeconds }}
 

--- a/charts/snapshot/templates/daemonset.yaml
+++ b/charts/snapshot/templates/daemonset.yaml
@@ -2,6 +2,8 @@
 {{- $socket := include "snapshot.runtimeSocket" . -}}
 {{- $socketDir := $socket | dir -}}
 {{- $storageDir := include "snapshot.runtimeStorageDir" . -}}
+{{- $pageBrokerControlPath := include "snapshot.pageBrokerControlPath" . -}}
+{{- $pageBrokerStagingPath := include "snapshot.pageBrokerStagingPath" . -}}
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -104,6 +106,24 @@ spec:
               mountPath: /host-seccomp
       {{- end }}
       containers:
+        {{- if .Values.pageBroker.enabled }}
+        - name: pagebroker
+          image: "{{ .Values.pageBroker.image.repository }}:{{ .Values.pageBroker.image.tag }}"
+          imagePullPolicy: {{ .Values.pageBroker.image.pullPolicy }}
+          args:
+            - {{ printf "%s/pagebroker.sock" $pageBrokerControlPath | quote }}
+            - {{ $pageBrokerStagingPath | quote }}
+            - {{ .Values.storage.pvc.basePath | quote }}
+            - --max-concurrent-requests
+            - {{ .Values.pageBroker.maxConcurrentRequests | quote }}
+          resources:
+            {{- toYaml .Values.pageBroker.resources | nindent 12 }}
+          volumeMounts:
+            - name: pagebroker
+              mountPath: /pagebroker
+            - name: checkpoints
+              mountPath: {{ .Values.storage.pvc.basePath }}
+        {{- end }}
         - name: agent
           image: "{{ .Values.image.agent.repository }}:{{ .Values.image.agent.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.agent.pullPolicy }}
@@ -127,6 +147,10 @@ spec:
             - name: config
               mountPath: /etc/snapshot
               readOnly: true
+            {{- if .Values.pageBroker.enabled }}
+            - name: pagebroker
+              mountPath: /pagebroker
+            {{- end }}
             {{- if eq .Values.storage.type "pvc" }}
             # Every agent owns direct access to the shared checkpoint store.
             - name: checkpoints
@@ -173,6 +197,12 @@ spec:
         - name: config
           configMap:
             name: {{ include "snapshot.fullname" . }}-config
+        {{- if .Values.pageBroker.enabled }}
+        - name: pagebroker
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.pageBroker.stagingSizeLimit | quote }}
+        {{- end }}
         {{- if .Values.seccomp.deploy }}
         # Seccomp profile ConfigMap (used by initContainer)
         - name: seccomp-profiles

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -92,6 +92,22 @@ storage:
   oci:
     uri: ""
 
+pageBroker:
+  enabled: false
+  maxConcurrentRequests: 16
+  stagingSizeLimit: 64Gi
+  resources:
+    requests:
+      cpu: 8
+      memory: 64Gi
+    limits:
+      cpu: 32
+      memory: 72Gi
+  image:
+    repository: nvcr.io/nvidia/ai-dynamo/pagebroker
+    tag: 1.4.0
+    pullPolicy: Always
+
 # DaemonSet configuration for the checkpoint/restore agent
 daemonset:
   # Agent and nsrestore log level (trace, debug, info, warn, error)


### PR DESCRIPTION
Adds the opt-in PageBroker sidecar, shared tmpfs staging, and control-socket mounts.

Validation: enabled and disabled Helm renders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Page Broker support to the Snapshot deployment.
  * Configures Page Broker control and staging paths automatically.
  * Added settings for enabling Page Broker, selecting its image and pull policy, limiting concurrent requests, and configuring resource requests and limits.
  * Added configurable memory-backed staging storage with an optional size limit.
  * Page Broker is disabled by default and can be enabled through chart configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->