### PR TITLE
fix(charts): allow runtime storage directory override

### DIFF
--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -99,5 +99,7 @@ Host directory holding per-container storage (overlay upperdirs the agent
 reads for rootfs-diff capture, and CRI-O config.json fallback).
 */}}
 {{- define "snapshot.runtimeStorageDir" -}}
-{{- if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
+{{- if .Values.runtime.storageDir -}}
+{{- .Values.runtime.storageDir -}}
+{{- else if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
 {{- end }}

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -58,6 +58,9 @@ crdUpgrade:
 runtime:
   type: containerd  # containerd | crio
   socketPath: ""
+  # Host directory containing container runtime snapshots and overlay upperdirs.
+  # Leave empty to use /var/lib/containerd (or /var/lib/containers for CRI-O).
+  storageDir: ""
 
 # Gates the OCP RBAC template and the DS required-scc annotation. Keep false
 # on vanilla Kubernetes (it references an OCP-only built-in SCC).


### PR DESCRIPTION
Adds the optional rootfs-diff mount used by the PageBroker-enabled agent image.

Validation: Helm lint and render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to configure the host directory for container runtime snapshots and overlay upper directories.
  * When omitted, the appropriate default directory is selected automatically based on the container runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->