### PR TITLE
fix(agent): bundle a statically linked tar for restore

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -103,6 +103,7 @@ ARG GNU_TAR_VERSION
 ARG GNU_TAR_SHA256
 
 RUN apk add --no-cache \
+    attr \
     build-base \
     ca-certificates \
     curl \
@@ -143,11 +144,14 @@ RUN set -eu; \
     echo preserved > /tmp/tar-smoke/target/existing; \
     echo replaced > /tmp/tar-smoke/source/existing; \
     echo created > /tmp/tar-smoke/source/created; \
-    /out/tar -C /tmp/tar-smoke/source -cf /tmp/tar-smoke/archive.tar .; \
+    setfattr -n user.snapshot-smoke -v smoke /tmp/tar-smoke/source/created; \
+    /out/tar --xattrs -C /tmp/tar-smoke/source -cf /tmp/tar-smoke/archive.tar .; \
     /out/tar --skip-old-files --blocking-factor=2048 \
+      --xattrs --xattrs-include='user.*' --xattrs-include='security.*' \
       -C /tmp/tar-smoke/target -xf /tmp/tar-smoke/archive.tar; \
     grep -qx preserved /tmp/tar-smoke/target/existing; \
-    grep -qx created /tmp/tar-smoke/target/created
+    grep -qx created /tmp/tar-smoke/target/created; \
+    test "$(getfattr --only-values -n user.snapshot-smoke /tmp/tar-smoke/target/created)" = smoke
 
 # =============================================================================
 # Stage: CUDA checkpoint helper builder

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -111,47 +111,13 @@ RUN apk add --no-cache \
 
 WORKDIR /tmp
 
-RUN set -eu; \
-    curl -fsSLo gnu-tar.tar.xz \
-      "https://ftp.gnu.org/gnu/tar/tar-${GNU_TAR_VERSION}.tar.xz"; \
-    echo "${GNU_TAR_SHA256}  gnu-tar.tar.xz" | sha256sum -c -; \
-    cp gnu-tar.tar.xz /gnu-tar-source.tar.xz; \
-    xz -d gnu-tar.tar.xz; \
-    tar -xf gnu-tar.tar
+COPY scripts/fetch-gnu-tar.sh scripts/build-gnu-tar.sh /tmp/scripts/
+
+RUN sh /tmp/scripts/fetch-gnu-tar.sh "${GNU_TAR_VERSION}" "${GNU_TAR_SHA256}"
 
 WORKDIR /tmp/tar-${GNU_TAR_VERSION}
 
-RUN set -eu; \
-    FORCE_UNSAFE_CONFIGURE=1 LDFLAGS=-static ./configure \
-      --disable-nls \
-      --without-posix-acls \
-      --without-selinux; \
-    make -j"$(nproc)"; \
-    mkdir -p /out; \
-    cp src/tar /out/tar; \
-    cp COPYING /out/COPYING; \
-    chmod 0755 /out/tar; \
-    strip /out/tar; \
-    if readelf -l /out/tar | grep -q 'INTERP'; then \
-      echo "ERROR: restore tar has a dynamic ELF interpreter" >&2; \
-      exit 1; \
-    fi; \
-    if readelf -d /out/tar | grep -q '(NEEDED)'; then \
-      echo "ERROR: restore tar has shared-library dependencies" >&2; \
-      exit 1; \
-    fi; \
-    mkdir -p /tmp/tar-smoke/source /tmp/tar-smoke/target; \
-    echo preserved > /tmp/tar-smoke/target/existing; \
-    echo replaced > /tmp/tar-smoke/source/existing; \
-    echo created > /tmp/tar-smoke/source/created; \
-    setfattr -n user.snapshot-smoke -v smoke /tmp/tar-smoke/source/created; \
-    /out/tar --xattrs -C /tmp/tar-smoke/source -cf /tmp/tar-smoke/archive.tar .; \
-    /out/tar --skip-old-files --blocking-factor=2048 \
-      --xattrs --xattrs-include='user.*' --xattrs-include='security.*' \
-      -C /tmp/tar-smoke/target -xf /tmp/tar-smoke/archive.tar; \
-    grep -qx preserved /tmp/tar-smoke/target/existing; \
-    grep -qx created /tmp/tar-smoke/target/created; \
-    test "$(getfattr --only-values -n user.snapshot-smoke /tmp/tar-smoke/target/created)" = smoke
+RUN sh /tmp/scripts/build-gnu-tar.sh
 
 # =============================================================================
 # Stage: CUDA checkpoint helper builder

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -27,6 +27,8 @@ ARG GO_VERSION=1.26.6
 #   --build-arg CRIU_REF=<fork-branch-or-sha>
 ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
 ARG CRIU_REF=criu-dev
+ARG GNU_TAR_VERSION=1.35
+ARG GNU_TAR_SHA256=4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16
 ARG AGENT_BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04@sha256:8315e2455736c4f9b597f15c5fb4d31f834e798e0c6b66bbdbdbac491ce26bd1
 
 # For placeholder target only - this default allows agent builds to succeed,
@@ -86,6 +88,66 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s
 
 # Corresponding source for the Go modules compiled into the binaries above.
 RUN mkdir -p /go-src && go mod vendor -o /go-src/vendor
+
+# =============================================================================
+# Stage: Restore tar builder
+#
+# Rootfs diffs are extracted inside the placeholder container. A dynamically
+# linked tar would use that image's ELF loader and glibc, which may be older
+# than the agent image's. Build GNU tar against musl so restore extraction does
+# not depend on any userspace library in the placeholder image.
+# =============================================================================
+FROM alpine:3.23 AS tar-builder
+
+ARG GNU_TAR_VERSION
+ARG GNU_TAR_SHA256
+
+RUN apk add --no-cache \
+    build-base \
+    ca-certificates \
+    curl \
+    xz
+
+WORKDIR /tmp
+
+RUN set -eu; \
+    curl -fsSLo gnu-tar.tar.xz \
+      "https://ftp.gnu.org/gnu/tar/tar-${GNU_TAR_VERSION}.tar.xz"; \
+    echo "${GNU_TAR_SHA256}  gnu-tar.tar.xz" | sha256sum -c -; \
+    cp gnu-tar.tar.xz /gnu-tar-source.tar.xz; \
+    xz -d gnu-tar.tar.xz; \
+    tar -xf gnu-tar.tar
+
+WORKDIR /tmp/tar-${GNU_TAR_VERSION}
+
+RUN set -eu; \
+    FORCE_UNSAFE_CONFIGURE=1 LDFLAGS=-static ./configure \
+      --disable-nls \
+      --without-posix-acls \
+      --without-selinux; \
+    make -j"$(nproc)"; \
+    mkdir -p /out; \
+    cp src/tar /out/tar; \
+    cp COPYING /out/COPYING; \
+    chmod 0755 /out/tar; \
+    strip /out/tar; \
+    if readelf -l /out/tar | grep -q 'INTERP'; then \
+      echo "ERROR: restore tar has a dynamic ELF interpreter" >&2; \
+      exit 1; \
+    fi; \
+    if readelf -d /out/tar | grep -q '(NEEDED)'; then \
+      echo "ERROR: restore tar has shared-library dependencies" >&2; \
+      exit 1; \
+    fi; \
+    mkdir -p /tmp/tar-smoke/source /tmp/tar-smoke/target; \
+    echo preserved > /tmp/tar-smoke/target/existing; \
+    echo replaced > /tmp/tar-smoke/source/existing; \
+    echo created > /tmp/tar-smoke/source/created; \
+    /out/tar -C /tmp/tar-smoke/source -cf /tmp/tar-smoke/archive.tar .; \
+    /out/tar --skip-old-files --blocking-factor=2048 \
+      -C /tmp/tar-smoke/target -xf /tmp/tar-smoke/archive.tar; \
+    grep -qx preserved /tmp/tar-smoke/target/existing; \
+    grep -qx created /tmp/tar-smoke/target/created
 
 # =============================================================================
 # Stage: CUDA checkpoint helper builder
@@ -207,6 +269,9 @@ RUN sh /tmp/collect-sources.sh /tmp/base-packages.tsv /sources/dpkg
 # CRIU source, at the exact ref this image was built from.
 COPY --from=criu-builder /criu-src.tar.gz /sources/criu/criu-src.tar.gz
 
+# Pinned upstream source for the statically linked restore-time GNU tar.
+COPY --from=tar-builder /gnu-tar-source.tar.xz /sources/gnu-tar/gnu-tar-source.tar.xz
+
 # Go module source for the statically linked binaries.
 COPY --from=builder /go-src/vendor /sources/go/vendor
 
@@ -246,17 +311,19 @@ COPY --from=criu-builder /criu-install/usr/local/sbin/criu /snapshot-binaries/cr
 COPY --from=criu-builder /criu-install/usr/local/lib/snapshot/criu-plugins/ /snapshot-binaries/criu-plugins/
 COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /snapshot-binaries/cuda-checkpoint
 COPY --from=cuda-helper-builder /cuda-checkpoint-helper /snapshot-binaries/cuda-checkpoint-helper
+COPY --from=tar-builder /out/tar /snapshot-binaries/tar
 
 # Network binaries needed during restore:
 #   ip  — address/route restore (criu/net.c)
-#   tar — used by runtime.ApplyRootfsDiff
+#   tar — used by runtime.ApplyRootfsDiff; statically linked and copied above
 # Network lock is set to SKIP (--network-lock skip) in BuildRestoreOpts, so
 # criu never forks iptables-restore/ip6tables-restore on this path and neither
 # binary needs to be in the bundle. See BuildRestoreOpts for why SKIP is safe
 # for restore specifically.
-# All resolve through PATH inside the namespace.
+# ip resolves through PATH inside the namespace. ApplyRootfsDiff invokes tar by
+# its explicit bundle path so it cannot fall back to the placeholder's tar.
 RUN set -eu; \
-    cp -L "$(command -v ip)" "$(command -v tar)" /snapshot-binaries/; \
+    cp -L "$(command -v ip)" /snapshot-binaries/; \
     chmod +x /snapshot-binaries/criu /snapshot-binaries/nsrestore \
              /snapshot-binaries/cuda-checkpoint /snapshot-binaries/cuda-checkpoint-helper \
              /snapshot-binaries/ip /snapshot-binaries/tar
@@ -285,7 +352,7 @@ RUN set -eu; \
 # a silent ldd failure leaves lib/ empty; asserting here catches that.
 RUN set -eu; \
     for f in /snapshot-binaries/criu /snapshot-binaries/ip \
-             /snapshot-binaries/tar /snapshot-binaries/criu-plugins/*.so; do \
+             /snapshot-binaries/criu-plugins/*.so; do \
       [ -f "$f" ] || continue; \
       if LD_LIBRARY_PATH=/snapshot-binaries/lib ldd "$f" 2>&1 | grep -q 'not found'; then \
         echo "ERROR: unresolved shared libraries in $f:" >&2; \
@@ -295,6 +362,7 @@ RUN set -eu; \
     done
 
 COPY --from=sources /sources /legal/source
+COPY --from=tar-builder /out/COPYING /legal/gnu-tar/COPYING
 
 # Attribution generated from the delta manifest and the vendored modules.
 COPY compliance/gen-attribution.sh /tmp/gen-attribution.sh
@@ -322,11 +390,11 @@ ENTRYPOINT ["/usr/local/bin/snapshot-agent"]
 # namespace, so nothing needs pre-provisioning here.
 #
 # Three constraints follow from that and must hold for every BASE_IMAGE:
-#   - BASE_IMAGE must be glibc-compatible with AGENT_BASE_IMAGE, because the
-#     bundle's library closure is built from AGENT_BASE_IMAGE (ubuntu 24.04,
-#     glibc 2.39) and loaded ahead of the placeholder's own libraries via
-#     LD_LIBRARY_PATH. A 22.04-based BASE_IMAGE builds green but fails at
-#     restore with "version 'GLIBC_2.38' not found".
+#   - BASE_IMAGE must be glibc-compatible with AGENT_BASE_IMAGE for the
+#     dynamically linked CRIU, ip, and CUDA tools. Their library closure is
+#     built from AGENT_BASE_IMAGE (ubuntu 24.04, glibc 2.39) and loaded ahead
+#     of the placeholder's own libraries via LD_LIBRARY_PATH. The restore tar
+#     is statically linked and does not share this constraint.
 #   - The node kernel must be >= 5.12 (mount_setattr, used by ns-bind-mount).
 #   - The placeholder pod must NOT set readOnlyRootFilesystem: true unless a
 #     writable volume is mounted at /tmp. The agent bind-mounts the binary

--- a/agent/compliance/README.source.txt
+++ b/agent/compliance/README.source.txt
@@ -11,6 +11,8 @@ Upstream source for the third-party components redistributed in this image.
                a package published without source by an NVIDIA repository; any
                other fetch failure fails the build.
   criu/        CRIU source at the commit this image was built from.
+  gnu-tar/     Pinned GNU tar source used to build the statically linked
+               restore-time tar binary.
   go/vendor/   Source for the Go modules linked into the binaries in this
                image; modules.txt records the exact module set.
 

--- a/agent/compliance/gen-attribution.sh
+++ b/agent/compliance/gen-attribution.sh
@@ -79,7 +79,7 @@ HEADER
 
     # Fold in the license texts the Dockerfile stages separately, so this file
     # is self-contained.
-    for extra in /legal/CRIU/COPYING /legal/cuda-checkpoint/LICENSE; do
+    for extra in /legal/CRIU/COPYING /legal/cuda-checkpoint/LICENSE /legal/gnu-tar/COPYING; do
         [ -f "$extra" ] || continue
         echo
         echo "================================================================================"

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -127,7 +127,8 @@ func executeRestore(
 	timings = &nsrestorePhaseTimings{}
 
 	overlayStart := time.Now()
-	if err := snapshotruntime.ApplyRootfsDiff(opts.CheckpointPath, "/", log); err != nil {
+	tarBinary := filepath.Join(opts.BundleDir, "tar")
+	if err := snapshotruntime.ApplyRootfsDiff(opts.CheckpointPath, "/", tarBinary, log); err != nil {
 		return nil, 0, nil, fmt.Errorf("rootfs diff failed: %w", err)
 	}
 	if err := snapshotruntime.ApplyDeletedFiles(opts.CheckpointPath, "/", log); err != nil {

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -127,7 +127,7 @@ func executeRestore(
 	timings = &nsrestorePhaseTimings{}
 
 	overlayStart := time.Now()
-	tarBinary := filepath.Join(opts.BundleDir, "tar")
+	tarBinary := filepath.Join(opts.BundleDir, snapshotruntime.RestoreTarBinaryName)
 	if err := snapshotruntime.ApplyRootfsDiff(opts.CheckpointPath, "/", tarBinary, log); err != nil {
 		return nil, 0, nil, fmt.Errorf("rootfs diff failed: %w", err)
 	}

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -310,9 +310,9 @@ func inspectRestore(
 //  2. nsrestore binary fd: we open nsrestore from the agent host side (SnapshotBinSrc)
 //     before entering any namespace and exec it via /proc/self/fd/N. This protects
 //     the nsrestore binary itself against path-based substitution inside the
-//     container. Binaries that nsrestore subsequently loads (criu, ip, tar, .so
-//     files) are still resolved by PATH/LD_LIBRARY_PATH inside the container's
-//     mount namespace.
+//     container. CRIU, ip, and shared objects that nsrestore subsequently loads
+//     are resolved by PATH/LD_LIBRARY_PATH inside the container's mount
+//     namespace. The restore tar is invoked by its explicit bundle path.
 func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, snap *types.RestoreContainerSnapshot, mp nsmount.MountPoint, checkpointPath string) (*RestoreInNamespaceResult, error) {
 
 	// Open nsrestore from the agent host side before entering the container

--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -159,6 +159,12 @@ func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
 // reads; doing that directly from NFS is much slower than one sequential copy
 // plus a local extract.
 func ApplyRootfsDiff(checkpointPath, targetRoot, tarBinary string, log logr.Logger) error {
+	// A relative path would resolve through PATH inside the placeholder —
+	// exactly the fallback the bundled static tar exists to prevent.
+	if !filepath.IsAbs(tarBinary) {
+		return fmt.Errorf("tar binary path %q is not absolute", tarBinary)
+	}
+
 	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
 	info, err := os.Stat(rootfsDiffPath)
 	if os.IsNotExist(err) {
@@ -182,8 +188,16 @@ func ApplyRootfsDiff(checkpointPath, targetRoot, tarBinary string, log logr.Logg
 	// --skip-old-files: silently skip files that already exist in the restore target.
 	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
 	// like triton caches, tmp files) — base image files should not be overwritten.
+	//
+	// The capture side archives with --xattrs; restore them, but only the user
+	// and security namespaces. The archive is cut from the overlay upperdir, so
+	// it can carry trusted.overlay.* entries that must never be re-applied
+	// through the restored container's overlay mount. These flags are mirrored
+	// by the tar-builder smoke test in the Dockerfile — keep them in sync.
 	log.Info("Applying rootfs diff", "target", targetRoot, "bytes", info.Size())
-	cmd := exec.Command(tarBinary, "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", localPath)
+	cmd := exec.Command(tarBinary, "--skip-old-files", "--blocking-factor=2048",
+		"--xattrs", "--xattrs-include=user.*", "--xattrs-include=security.*",
+		"-C", targetRoot, "-xf", localPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -20,6 +20,11 @@ import (
 const (
 	rootfsDiffFilename   = "rootfs-diff.tar"
 	deletedFilesFilename = "deleted-files.json"
+
+	// RestoreTarBinaryName is the file name of the statically linked GNU tar
+	// in the agent binary bundle. Must match the name the Dockerfile bundle
+	// stage copies into /snapshot-binaries/.
+	RestoreTarBinaryName = "tar"
 )
 
 // GetRootFS returns the container's root filesystem path via /host/proc.
@@ -193,7 +198,7 @@ func ApplyRootfsDiff(checkpointPath, targetRoot, tarBinary string, log logr.Logg
 	// and security namespaces. The archive is cut from the overlay upperdir, so
 	// it can carry trusted.overlay.* entries that must never be re-applied
 	// through the restored container's overlay mount. These flags are mirrored
-	// by the tar-builder smoke test in the Dockerfile — keep them in sync.
+	// by the smoke test in scripts/build-gnu-tar.sh — keep them in sync.
 	log.Info("Applying rootfs diff", "target", targetRoot, "bytes", info.Size())
 	cmd := exec.Command(tarBinary, "--skip-old-files", "--blocking-factor=2048",
 		"--xattrs", "--xattrs-include=user.*", "--xattrs-include=security.*",

--- a/agent/internal/runtime/overlay.go
+++ b/agent/internal/runtime/overlay.go
@@ -158,7 +158,7 @@ func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
 // The archive is copied to local disk first. tar walks members with many small
 // reads; doing that directly from NFS is much slower than one sequential copy
 // plus a local extract.
-func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
+func ApplyRootfsDiff(checkpointPath, targetRoot, tarBinary string, log logr.Logger) error {
 	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
 	info, err := os.Stat(rootfsDiffPath)
 	if os.IsNotExist(err) {
@@ -183,11 +183,11 @@ func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
 	// like triton caches, tmp files) — base image files should not be overwritten.
 	log.Info("Applying rootfs diff", "target", targetRoot, "bytes", info.Size())
-	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", localPath)
+	cmd := exec.Command(tarBinary, "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", localPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("tar extract failed: %w", err)
+		return fmt.Errorf("tar extract with %s failed: %w", tarBinary, err)
 	}
 	return nil
 }

--- a/agent/internal/runtime/overlay_test.go
+++ b/agent/internal/runtime/overlay_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -179,7 +180,7 @@ func TestCaptureRootfsDiff(t *testing.T) {
 		}
 
 		targetRoot := t.TempDir()
-		if err := ApplyRootfsDiff(checkpointDir, targetRoot, testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(checkpointDir, targetRoot, "tar", testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(targetRoot, "generated.txt"))
@@ -213,7 +214,7 @@ func TestCaptureRootfsDiff(t *testing.T) {
 
 func TestApplyRootfsDiff(t *testing.T) {
 	t.Run("missing archive is no-op", func(t *testing.T) {
-		if err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), "tar", testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 	})
@@ -223,7 +224,7 @@ func TestApplyRootfsDiff(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), nil, 0644); err != nil {
 			t.Fatalf("write empty rootfs diff: %v", err)
 		}
-		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), "tar", testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 	})
@@ -233,8 +234,20 @@ func TestApplyRootfsDiff(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), []byte("not a tar archive"), 0644); err != nil {
 			t.Fatalf("write invalid rootfs diff: %v", err)
 		}
-		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err == nil {
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), "tar", testr.New(t)); err == nil {
 			t.Fatal("ApplyRootfsDiff should fail for invalid non-empty archive")
+		}
+	})
+
+	t.Run("uses the provided tar binary", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), []byte("not a tar archive"), 0644); err != nil {
+			t.Fatalf("write invalid rootfs diff: %v", err)
+		}
+		tarBinary := filepath.Join(t.TempDir(), "missing-tar")
+		err := ApplyRootfsDiff(checkpointDir, t.TempDir(), tarBinary, testr.New(t))
+		if err == nil || !strings.Contains(err.Error(), tarBinary) {
+			t.Fatalf("ApplyRootfsDiff error = %v, want provided tar path %q", err, tarBinary)
 		}
 	})
 
@@ -246,7 +259,7 @@ func TestApplyRootfsDiff(t *testing.T) {
 			t.Fatalf("create temp file: %v", err)
 		}
 		f.Close()
-		if err := ApplyRootfsDiff(f.Name(), t.TempDir(), testr.New(t)); err == nil {
+		if err := ApplyRootfsDiff(f.Name(), t.TempDir(), "tar", testr.New(t)); err == nil {
 			t.Fatal("ApplyRootfsDiff should propagate non-ENOENT stat error")
 		}
 	})
@@ -265,7 +278,7 @@ func TestApplyRootfsDiff(t *testing.T) {
 		if err != nil {
 			t.Fatalf("glob staged copies: %v", err)
 		}
-		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), "tar", testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 		after, err := filepath.Glob(filepath.Join(os.TempDir(), rootfsDiffFilename+".*.tmp"))

--- a/agent/internal/runtime/overlay_test.go
+++ b/agent/internal/runtime/overlay_test.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,17 @@ import (
 
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
+
+// systemTar resolves the host tar to an absolute path; ApplyRootfsDiff
+// rejects relative tar paths so they cannot resolve through PATH.
+func systemTar(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("tar")
+	if err != nil {
+		t.Fatalf("resolve system tar: %v", err)
+	}
+	return path
+}
 
 func TestBuildExclusions(t *testing.T) {
 	tests := []struct {
@@ -180,7 +192,7 @@ func TestCaptureRootfsDiff(t *testing.T) {
 		}
 
 		targetRoot := t.TempDir()
-		if err := ApplyRootfsDiff(checkpointDir, targetRoot, "tar", testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(checkpointDir, targetRoot, systemTar(t), testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(targetRoot, "generated.txt"))
@@ -214,7 +226,7 @@ func TestCaptureRootfsDiff(t *testing.T) {
 
 func TestApplyRootfsDiff(t *testing.T) {
 	t.Run("missing archive is no-op", func(t *testing.T) {
-		if err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), "tar", testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), systemTar(t), testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 	})
@@ -224,7 +236,7 @@ func TestApplyRootfsDiff(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), nil, 0644); err != nil {
 			t.Fatalf("write empty rootfs diff: %v", err)
 		}
-		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), "tar", testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), systemTar(t), testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 	})
@@ -234,8 +246,15 @@ func TestApplyRootfsDiff(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), []byte("not a tar archive"), 0644); err != nil {
 			t.Fatalf("write invalid rootfs diff: %v", err)
 		}
-		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), "tar", testr.New(t)); err == nil {
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), systemTar(t), testr.New(t)); err == nil {
 			t.Fatal("ApplyRootfsDiff should fail for invalid non-empty archive")
+		}
+	})
+
+	t.Run("relative tar path is rejected", func(t *testing.T) {
+		err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), "tar", testr.New(t))
+		if err == nil || !strings.Contains(err.Error(), "not absolute") {
+			t.Fatalf("ApplyRootfsDiff error = %v, want rejection of relative tar path", err)
 		}
 	})
 
@@ -259,7 +278,7 @@ func TestApplyRootfsDiff(t *testing.T) {
 			t.Fatalf("create temp file: %v", err)
 		}
 		f.Close()
-		if err := ApplyRootfsDiff(f.Name(), t.TempDir(), "tar", testr.New(t)); err == nil {
+		if err := ApplyRootfsDiff(f.Name(), t.TempDir(), systemTar(t), testr.New(t)); err == nil {
 			t.Fatal("ApplyRootfsDiff should propagate non-ENOENT stat error")
 		}
 	})
@@ -278,7 +297,7 @@ func TestApplyRootfsDiff(t *testing.T) {
 		if err != nil {
 			t.Fatalf("glob staged copies: %v", err)
 		}
-		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), "tar", testr.New(t)); err != nil {
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), systemTar(t), testr.New(t)); err != nil {
 			t.Fatalf("ApplyRootfsDiff: %v", err)
 		}
 		after, err := filepath.Glob(filepath.Join(os.TempDir(), rootfsDiffFilename+".*.tmp"))

--- a/agent/scripts/build-gnu-tar.sh
+++ b/agent/scripts/build-gnu-tar.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the statically linked GNU tar used for restore-time rootfs-diff
+# extraction, assert it is fully static, and smoke-test the exact invocation
+# runtime.ApplyRootfsDiff uses. Installs the binary and its license text to
+# /out. Run from the unpacked GNU tar source directory.
+#
+# Usage: build-gnu-tar.sh
+set -eu
+
+# FORCE_UNSAFE_CONFIGURE: GNU tar's configure refuses to run as root otherwise.
+FORCE_UNSAFE_CONFIGURE=1 LDFLAGS=-static ./configure \
+    --disable-nls \
+    --without-posix-acls \
+    --without-selinux
+make -j"$(nproc)"
+
+mkdir -p /out
+cp src/tar /out/tar
+cp COPYING /out/COPYING
+chmod 0755 /out/tar
+strip /out/tar
+
+# A static binary has neither an ELF interpreter nor NEEDED entries; either
+# one means the placeholder's userspace would leak back into restore.
+if readelf -l /out/tar | grep -q 'INTERP'; then
+    echo "ERROR: restore tar has a dynamic ELF interpreter" >&2
+    exit 1
+fi
+if readelf -d /out/tar | grep -q '(NEEDED)'; then
+    echo "ERROR: restore tar has shared-library dependencies" >&2
+    exit 1
+fi
+
+# Smoke test mirroring the restore invocation in runtime.ApplyRootfsDiff —
+# keep these flags in sync with that call site.
+mkdir -p /tmp/tar-smoke/source /tmp/tar-smoke/target
+echo preserved > /tmp/tar-smoke/target/existing
+echo replaced > /tmp/tar-smoke/source/existing
+echo created > /tmp/tar-smoke/source/created
+setfattr -n user.snapshot-smoke -v smoke /tmp/tar-smoke/source/created
+/out/tar --xattrs -C /tmp/tar-smoke/source -cf /tmp/tar-smoke/archive.tar .
+/out/tar --skip-old-files --blocking-factor=2048 \
+    --xattrs --xattrs-include='user.*' --xattrs-include='security.*' \
+    -C /tmp/tar-smoke/target -xf /tmp/tar-smoke/archive.tar
+grep -qx preserved /tmp/tar-smoke/target/existing
+grep -qx created /tmp/tar-smoke/target/created
+test "$(getfattr --only-values -n user.snapshot-smoke /tmp/tar-smoke/target/created)" = smoke

--- a/agent/scripts/fetch-gnu-tar.sh
+++ b/agent/scripts/fetch-gnu-tar.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download and verify the pinned GNU tar source tarball, keep a pristine copy
+# at /gnu-tar-source.tar.xz for the image's corresponding-source staging, and
+# unpack the source into the current directory for the build.
+#
+# Usage: fetch-gnu-tar.sh <version> <sha256>
+set -eu
+
+VERSION="$1"
+SHA256="$2"
+
+curl -fsSLo gnu-tar.tar.xz "https://ftp.gnu.org/gnu/tar/tar-${VERSION}.tar.xz"
+echo "${SHA256}  gnu-tar.tar.xz" | sha256sum -c -
+cp gnu-tar.tar.xz /gnu-tar-source.tar.xz
+xz -d gnu-tar.tar.xz
+tar -xf gnu-tar.tar


### PR DESCRIPTION
### Problem

`ApplyRootfsDiff` extracts the rootfs diff inside the placeholder container by invoking `tar` through PATH. Until now the bundle shipped the agent image's dynamically linked tar, whose library closure is built from the agent base image (Ubuntu 24.04, glibc 2.39). Because tar resolves its ELF loader and glibc from the placeholder image, any placeholder based on an older userspace (e.g. Ubuntu 22.04) fails at restore with `version 'GLIBC_2.38' not found` — or silently falls back to the placeholder's own tar.

### Fix

Build GNU tar 1.35 statically against musl in a dedicated `tar-builder` stage and bundle it, so rootfs-diff extraction no longer depends on any userspace library in the placeholder image:

- New Alpine-based `tar-builder` stage downloads a SHA256-pinned GNU tar source tarball, builds it with `LDFLAGS=-static`, and verifies the result at build time: `readelf` asserts there is no ELF interpreter and no `NEEDED` entries, and a smoke test exercises the exact restore invocation.
- `ApplyRootfsDiff` now takes an explicit tar binary path and rejects a non-absolute one, so extraction can never fall back to the placeholder's tar via PATH; `nsrestore` passes the bundle path.
- Extraction now restores the xattrs the capture side archives (`--xattrs`), scoped to `user.*` and `security.*` — the archive is cut from the overlay upperdir and may carry `trusted.overlay.*` entries that must never be re-applied through the restored container's overlay mount. The smoke test sets a `user.*` xattr and asserts it survives the round trip, failing the build if xattr support was compiled out of the static tar.
- The bundle `ldd` closure check drops tar (static binaries have no shared deps to resolve).
- The glibc-compatibility constraint documented for `BASE_IMAGE` now applies only to CRIU, `ip`, and the CUDA tools — the restore tar is exempt.

### Compliance

- GNU tar source tarball is staged under `/legal/source/gnu-tar/` and documented in `README.source.txt`.
- The GPL license text (`COPYING`) is folded into the generated attribution file.
- The `attr` package added to the `tar-builder` stage is build-time test tooling only (`setfattr`/`getfattr` for the smoke test); it is not redistributed and does not change the image's license surface.

### Testing

- Unit tests updated for the new `ApplyRootfsDiff` signature, plus cases asserting the provided tar path is actually the one invoked and that a relative tar path is rejected.
- Build-time smoke test in the Dockerfile validates static linkage, the restore extraction flags, and xattr round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Restore operations now use a bundled, statically compiled archive tool for consistent extraction across environments.
  * Restore no longer depends on the system’s dynamically linked archive utility.

* **Bug Fixes**
  * Improved handling of extended attributes during root filesystem restoration.
  * Clearer errors are provided when the required restore archive tool is missing or misconfigured.

* **Documentation**
  * Updated compliance and compatibility documentation for the bundled archive tool and restore requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->