### PR TITLE
test(e2e): de-brand restore standby env

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -341,7 +341,7 @@ ENTRYPOINT ["/usr/local/bin/snapshot-agent"]
 # PATH search — and so must this placeholder image (same BASE_IMAGE).
 #
 # Backend entrypoints run a restore standby path when the operator
-# injects DYN_SNAPSHOT_RESTORE_STANDBY=1, then sleep while the
+# injects SNAPSHOT_RESTORE_STANDBY=1, then sleep while the
 # snapshot-agent restores into the container.
 # =============================================================================
 FROM ${BASE_IMAGE} AS placeholder

--- a/e2e/snapshot_e2e/workloads.py
+++ b/e2e/snapshot_e2e/workloads.py
@@ -144,6 +144,7 @@ def restore_pod(
         }
     }
     spec["containers"][0]["env"] = [
+        {"name": "SNAPSHOT_RESTORE_STANDBY", "value": "1"},
         {"name": "DYN_SNAPSHOT_RESTORE_STANDBY", "value": "1"},
         {"name": "SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
         {"name": RESTORE_TOKEN_ENV, "value": run.restore_token},
@@ -204,6 +205,7 @@ def multi_restore_pod(
                 }
             ],
             "env": [
+                {"name": "SNAPSHOT_RESTORE_STANDBY", "value": "1"},
                 {"name": "DYN_SNAPSHOT_RESTORE_STANDBY", "value": "1"},
                 {"name": "SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
                 {"name": RESTORE_TOKEN_ENV, "value": restore_tokens[destination]},


### PR DESCRIPTION
## Summary
- set SNAPSHOT_RESTORE_STANDBY in restore e2e fixtures while keeping the legacy DYN_SNAPSHOT_RESTORE_STANDBY alias
- update the placeholder image comment to reference the neutral restore standby env

Part of #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated restore-standby configuration guidance to use the current environment variable.

* **Bug Fixes**
  * Improved restore pod configurations by including the supported restore-standby setting alongside the existing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->