### PR TITLE
refactor(operator): one signal owner per SnapshotJob condition

### DIFF
--- a/operator/internal/controller/snapshotjob_completion_test.go
+++ b/operator/internal/controller/snapshotjob_completion_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -618,6 +619,61 @@ func TestSnapshotJobReconcileReadyCaptureWithDeadlineFails(t *testing.T) {
 	require.NotNil(t, failed)
 	assert.Equal(t, snapshotv1alpha1.ReasonDeadlineExceeded, failed.Reason,
 		"the deadline bounds the whole source lifecycle, helpers included, even after a successful capture")
+}
+
+func TestSnapshotJobReconcileCapturedKeepsCaptureReasonUnderDeadline(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := minimalSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+	job, err := buildSourceJob(sj)
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	pod := sourcePodForJob(job)
+	snap, err := buildPodSnapshot(sj, pod)
+	require.NoError(t, err)
+	meta.SetStatusCondition(&snap.Status.Conditions, metav1.Condition{
+		Type: snapshotv1alpha1.PodSnapshotConditionFailed, Status: metav1.ConditionTrue,
+		Reason: "CRIUDumpFailed", Message: "dump failed",
+	})
+	setJobFailureCondition(job, batchv1.JobFailureTarget, batchv1.JobReasonDeadlineExceeded, "Job was active longer than specified deadline")
+
+	r := makeSnapshotJobReconciler(s, sj, job, pod, snap)
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	// One owner per condition: the deadline is the aggregate root cause, but it
+	// must not rewrite the capture's own result.
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	failed := meta.FindStatusCondition(updated.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
+	require.NotNil(t, failed)
+	assert.Equal(t, snapshotv1alpha1.ReasonDeadlineExceeded, failed.Reason)
+	captured := meta.FindStatusCondition(updated.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionCaptured)
+	require.NotNil(t, captured)
+	assert.Equal(t, metav1.ConditionFalse, captured.Status)
+	assert.Equal(t, snapshotv1alpha1.ReasonCaptureFailed, captured.Reason,
+		"Captured is owned by PodSnapshot.status; the Job's deadline must not overwrite it")
+	assert.Contains(t, captured.Message, "dump failed")
+}
+
+func TestDeriveCapturedStatusDoesNotDowngradeCapturedTrue(t *testing.T) {
+	sj := minimalSnapshotJob()
+	now := metav1.Now()
+	setCondition(sj, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionTrue, now,
+		snapshotv1alpha1.ReasonCaptureCompleted, "CRIU dump of the target container is complete")
+
+	// The capture succeeded earlier; losing the PodSnapshot afterwards fails the
+	// SnapshotJob but must not rewrite the recorded capture success.
+	observed := terminalObservation(snapshotv1alpha1.ReasonPodSnapshotDeleted,
+		errors.New("PodSnapshot no longer exists"))
+	status := deriveSnapshotJobStatus(sj, observed, now)
+
+	captured := meta.FindStatusCondition(status.Conditions, snapshotv1alpha1.SnapshotJobConditionCaptured)
+	require.NotNil(t, captured)
+	assert.Equal(t, metav1.ConditionTrue, captured.Status)
+	failed := meta.FindStatusCondition(status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
+	require.NotNil(t, failed)
+	assert.Equal(t, snapshotv1alpha1.ReasonPodSnapshotDeleted, failed.Reason)
 }
 
 func TestSnapshotJobReconcileWaitsForCaptureWhenJobFailsDuringPendingCapture(t *testing.T) {

--- a/operator/internal/controller/snapshotjob_completion_test.go
+++ b/operator/internal/controller/snapshotjob_completion_test.go
@@ -656,6 +656,27 @@ func TestSnapshotJobReconcileCapturedKeepsCaptureReasonUnderDeadline(t *testing.
 	assert.Contains(t, captured.Message, "dump failed")
 }
 
+func TestSnapshotJobReconcileHelperVerificationCacheMissDoesNotFail(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj, job, pod, snap := helperSnapshotJob(t, s,
+		corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}})
+
+	// The pod exists on the API server but not in the informer yet. Helper
+	// verification must confirm the cached miss authoritatively instead of
+	// writing the sticky unverifiable failure.
+	r := makeSnapshotJobReconciler(s, sj, job, snap)
+	r.NonCacheReadClient = fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
+
+	_, err := r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	assert.False(t, snapshotv1alpha1.IsSnapshotJobFailed(updated),
+		"a pod hidden by informer lag must not fail helper verification")
+	assert.True(t, snapshotv1alpha1.IsSnapshotJobCompleted(updated))
+}
+
 func TestDeriveCapturedStatusDoesNotDowngradeCapturedTrue(t *testing.T) {
 	sj := minimalSnapshotJob()
 	now := metav1.Now()

--- a/operator/internal/controller/snapshotjob_completion_test.go
+++ b/operator/internal/controller/snapshotjob_completion_test.go
@@ -575,6 +575,35 @@ func TestSnapshotJobReconcileSidecarTerminatedNonZeroCompletes(t *testing.T) {
 	assert.False(t, snapshotv1alpha1.IsSnapshotJobFailed(updated))
 }
 
+func TestSnapshotJobReconcileSidecarRestartAfterCacheReadIsNotTrusted(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	// The cache observed the sidecar mid-restart-cycle Terminated; the kubelet
+	// has since brought it back up (native sidecars can cycle
+	// Terminated -> Running, unlike regular containers). A terminal-looking
+	// cache read is irreversible here (it drives Job deletion), so it must be
+	// re-confirmed against a live read rather than trusted outright.
+	sj, job, pod, snap := sidecarSnapshotJob(t, s,
+		&corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}})
+
+	livePod := pod.DeepCopy()
+	livePod.Status.InitContainerStatuses = []corev1.ContainerStatus{
+		{Name: "sidecar", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+	}
+
+	r := makeSnapshotJobReconciler(s, sj, job, pod, snap)
+	r.NonCacheReadClient = fake.NewClientBuilder().WithScheme(s).WithObjects(livePod).Build()
+
+	result, err := r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+	assert.Equal(t, captureResolutionBackstop, result.RequeueAfter)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	assert.False(t, snapshotv1alpha1.IsSnapshotJobCompleted(updated),
+		"a stale cached Terminated must not complete the SnapshotJob when the sidecar is actually still running")
+	assert.False(t, snapshotv1alpha1.IsSnapshotJobFailed(updated))
+}
+
 func TestSnapshotJobReconcileHelperUnverifiableFails(t *testing.T) {
 	s := snapshotJobReconcilerScheme()
 	sj, job, _, snap := helperSnapshotJob(t, s,

--- a/operator/internal/controller/snapshotjob_podsnapshot.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot.go
@@ -75,6 +75,28 @@ func findSourcePod(ctx context.Context, reader client.Reader, job *batchv1.Job) 
 	return controlledPodForJob(pods.Items, job)
 }
 
+// findSourcePodConfirmed resolves the source pod cache-first, only paying for
+// a live read when accept reports the cached result cannot be trusted for
+// what the caller does next. accept sees the cached (pod, found) and returns
+// whether that result is safe to act on as-is; returning false triggers one
+// authoritative re-read via nonCache, whose result is returned unconditionally
+// (accept is not consulted again — the live read is always trusted).
+func findSourcePodConfirmed(
+	ctx context.Context,
+	cache, nonCache client.Reader,
+	job *batchv1.Job,
+	accept func(pod *corev1.Pod, found bool) bool,
+) (*corev1.Pod, bool, error) {
+	pod, found, err := findSourcePod(ctx, cache, job)
+	if err != nil {
+		return nil, false, err
+	}
+	if accept(pod, found) {
+		return pod, found, nil
+	}
+	return findSourcePod(ctx, nonCache, job)
+}
+
 // controlledPodForJob selects the Pod controlled by job from the label-matched
 // candidates and rejects the invalid case where the Job controls multiple Pods.
 func controlledPodForJob(pods []corev1.Pod, job *batchv1.Job) (*corev1.Pod, bool, error) {

--- a/operator/internal/controller/snapshotjob_reconciler.go
+++ b/operator/internal/controller/snapshotjob_reconciler.go
@@ -36,6 +36,13 @@ import (
 
 // SnapshotJobReconciler reconciles a SnapshotJob.
 //
+// Each condition has one owner: PodSnapshot.status is the only capture signal
+// (Captured), Job.status is the only workload completion/failure signal, and
+// SnapshotJob publishes the aggregate Completed/Failed result. The source Pod
+// is read solely for the identity needed to construct the PodSnapshot and to
+// verify helper containers; SnapshotJob never reinterprets PodSnapshotContent
+// or Pod state into a capture result of its own.
+//
 // Resource helpers create, find, and classify the Job, source Pod, and
 // PodSnapshot without mutating SnapshotJob status. Reconcile then derives the
 // complete status from those observations and persists it once. Completion is
@@ -151,14 +158,17 @@ func (r *SnapshotJobReconciler) reconcileResources(ctx context.Context, sj *snap
 	}
 }
 
-// reconcilePodSnapshotResources drives the capture and arbitrates it against
-// the source Job. Once a PodSnapshot exists, its terminal result decides the
-// SnapshotJob: Ready completes it (regardless of the Job's state), Failed fails
-// it with the capture's own reason, and a pending capture is waited on with a
-// bounded requeue even when the Job is already terminal — the checkpoint
+// reconcilePodSnapshotResources implements the capture-boundary flow: look up
+// the deterministic PodSnapshot; if absent, consult the Job/source Pod only to
+// create it or determine that creation is no longer possible; if present, the
+// capture signal comes exclusively from PodSnapshot.status, and Job.status
+// supplies only the independent workload completion/failure gate. A pending
+// capture is waited on even when the Job is already terminal — the checkpoint
 // terminates the source process, so a Job failure racing a committed artifact
-// is the expected success sequence, not an error. Only before a capture exists
-// does a terminal source Job fail the SnapshotJob directly.
+// is the expected success sequence, not an error. Because a PodSnapshot
+// terminal status is sticky, stale cached status can only delay progress here,
+// never invent a competing result; direct API reads are limited to identity
+// and confirmed-absence checks immediately before an irreversible decision.
 func (r *SnapshotJobReconciler) reconcilePodSnapshotResources(ctx context.Context, sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Job) (snapshotJobObservation, ctrl.Result, error) {
 	observed := snapshotJobObservation{job: job}
 	snap, err := r.findOwnedPodSnapshot(ctx, sj)
@@ -186,14 +196,9 @@ func (r *SnapshotJobReconciler) reconcilePodSnapshotResources(ctx context.Contex
 			return observed, ctrl.Result{}, nil
 		}
 		if terminal.state != sourceJobComplete {
-			observed, result, err := r.createPodSnapshotForSourceJob(ctx, sj, job)
-			if err != nil {
-				return observed, result, err
-			}
-			if observed.failure == nil {
-				observed.failure = snapshotJobTerminalFailure(observed.job, observed.podSnapshot)
-			}
-			return observed, result, nil
+			// A capture created this pass is pending by definition; no terminal
+			// arbitration applies until its status reports a result.
+			return r.createPodSnapshotForSourceJob(ctx, sj, job)
 		}
 		// The source Job is complete, so a capture created now can never succeed.
 		// Confirm the capture's absence authoritatively before the sticky failure.
@@ -456,26 +461,41 @@ func deriveRunningStatus(next *snapshotv1alpha1.SnapshotJob, observed snapshotJo
 		snapshotv1alpha1.ReasonPodPending, message)
 }
 
+// deriveCapturedStatus is the single writer of the Captured condition, and
+// PodSnapshot.status is its only capture signal. A Failed capture stamps
+// Captured with the capture's own reason even when the source Job failed too:
+// the Job may decide the aggregate Failed reason, but never rewrites the
+// capture result. Without a capture, a terminal failure closes Captured with
+// that failure's reason (never downgrading an already-True Captured, which
+// survives even losing its PodSnapshot).
 func deriveCapturedStatus(next *snapshotv1alpha1.SnapshotJob, observed snapshotJobObservation, reconciliationTime metav1.Time) *snapshotJobFailure {
 	failure := observed.failure
-	if observed.podSnapshot != nil {
-		next.Status.PodSnapshotName = observed.podSnapshot.Name
-		if next.Status.PodSnapshotUID == "" {
-			next.Status.PodSnapshotUID = observed.podSnapshot.UID
-		}
-		switch {
-		case snapshotv1alpha1.IsPodSnapshotFailed(observed.podSnapshot):
-			if failure == nil {
-				reason, message := captureFailureReason(observed.podSnapshot)
-				failure = &snapshotJobFailure{reason: reason, cause: errors.New(message)}
-			}
-		case snapshotv1alpha1.IsPodSnapshotSucceeded(observed.podSnapshot):
-			setCondition(next, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionTrue, reconciliationTime,
-				snapshotv1alpha1.ReasonCaptureCompleted, "CRIU dump of the target container is complete")
-		default:
+	if observed.podSnapshot == nil {
+		if failure != nil && !meta.IsStatusConditionTrue(next.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionCaptured) {
 			setCondition(next, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionFalse, reconciliationTime,
-				snapshotv1alpha1.ReasonCaptureInProgress, "waiting for the node agent to capture the checkpoint")
+				failure.reason, "capture did not complete: "+failure.cause.Error())
 		}
+		return failure
+	}
+
+	next.Status.PodSnapshotName = observed.podSnapshot.Name
+	if next.Status.PodSnapshotUID == "" {
+		next.Status.PodSnapshotUID = observed.podSnapshot.UID
+	}
+	switch {
+	case snapshotv1alpha1.IsPodSnapshotFailed(observed.podSnapshot):
+		reason, message := captureFailureReason(observed.podSnapshot)
+		setCondition(next, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionFalse, reconciliationTime,
+			reason, message)
+		if failure == nil {
+			failure = &snapshotJobFailure{reason: reason, cause: errors.New(message)}
+		}
+	case snapshotv1alpha1.IsPodSnapshotSucceeded(observed.podSnapshot):
+		setCondition(next, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionTrue, reconciliationTime,
+			snapshotv1alpha1.ReasonCaptureCompleted, "CRIU dump of the target container is complete")
+	default:
+		setCondition(next, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionFalse, reconciliationTime,
+			snapshotv1alpha1.ReasonCaptureInProgress, "waiting for the node agent to capture the checkpoint")
 	}
 	return failure
 }
@@ -488,10 +508,7 @@ func deriveFailureStatus(next *snapshotv1alpha1.SnapshotJob, failure *snapshotJo
 		setCondition(next, snapshotv1alpha1.SnapshotJobConditionRunning, metav1.ConditionFalse, reconciliationTime,
 			failure.reason, "the SnapshotJob failed terminally; the source Job is preserved for debugging")
 	}
-	if !meta.IsStatusConditionTrue(next.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionCaptured) {
-		setCondition(next, snapshotv1alpha1.SnapshotJobConditionCaptured, metav1.ConditionFalse, reconciliationTime,
-			failure.reason, "capture did not complete: "+failure.cause.Error())
-	}
+	// Captured is not touched here: deriveCapturedStatus is its single writer.
 	if !meta.IsStatusConditionTrue(next.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionCompleted) {
 		setCondition(next, snapshotv1alpha1.SnapshotJobConditionCompleted, metav1.ConditionFalse, reconciliationTime,
 			failure.reason, "the SnapshotJob failed before completing: "+failure.cause.Error())

--- a/operator/internal/controller/snapshotjob_reconciler.go
+++ b/operator/internal/controller/snapshotjob_reconciler.go
@@ -309,15 +309,24 @@ func (r *SnapshotJobReconciler) classifyHelperContainers(ctx context.Context, sj
 	if len(helpers) == 0 && len(sidecars) == 0 {
 		return nil, false, nil // the target is the only container
 	}
-	pod, found, err := findSourcePod(ctx, r.NonCacheReadClient, job)
+	// Cache-first: terminated container states are immutable, so staleness can
+	// only report helpersStillRunning — a reversible requeue. Only the sticky
+	// absence failure below needs the cached miss confirmed against the API.
+	pod, found, err := findSourcePod(ctx, r.Client, job)
 	if err != nil {
 		return nil, false, fmt.Errorf("find source pod to verify helper containers: %w", err)
 	}
 	if !found {
-		return &snapshotJobFailure{
-			reason: snapshotv1alpha1.ReasonJobFailed,
-			cause:  errors.New("source pod is gone before its helper containers could be verified"),
-		}, false, nil
+		pod, found, err = findSourcePod(ctx, r.NonCacheReadClient, job)
+		if err != nil {
+			return nil, false, fmt.Errorf("confirm source pod absence for helper verification: %w", err)
+		}
+		if !found {
+			return &snapshotJobFailure{
+				reason: snapshotv1alpha1.ReasonJobFailed,
+				cause:  errors.New("source pod is gone before its helper containers could be verified"),
+			}, false, nil
+		}
 	}
 	for _, name := range helpers {
 		terminated := containerTerminatedState(pod.Status.ContainerStatuses, name)

--- a/operator/internal/controller/snapshotjob_reconciler.go
+++ b/operator/internal/controller/snapshotjob_reconciler.go
@@ -309,44 +309,57 @@ func (r *SnapshotJobReconciler) classifyHelperContainers(ctx context.Context, sj
 	if len(helpers) == 0 && len(sidecars) == 0 {
 		return nil, false, nil // the target is the only container
 	}
-	// Cache-first: terminated container states are immutable, so staleness can
-	// only report helpersStillRunning — a reversible requeue. Only the sticky
-	// absence failure below needs the cached miss confirmed against the API.
-	pod, found, err := findSourcePod(ctx, r.Client, job)
+	// Cache-first, but a cached result is only trustworthy for the reversible
+	// outcome (helpersStillRunning): a regular helper's terminated state is
+	// immutable, but a native sidecar's is not — the kubelet can restart it
+	// (Terminated -> Running) on a crash, so a cached Terminated can be stale.
+	// Any terminal-looking verdict (success or a helper failure) is therefore
+	// re-derived from a live read before it is trusted, since acting on it
+	// (deleting the Job) is irreversible.
+	pod, found, err := findSourcePodConfirmed(ctx, r.Client, r.NonCacheReadClient, job,
+		func(pod *corev1.Pod, found bool) bool {
+			if !found {
+				return false
+			}
+			_, stillRunning := classifyHelperPod(pod, helpers, sidecars)
+			return stillRunning
+		})
 	if err != nil {
 		return nil, false, fmt.Errorf("find source pod to verify helper containers: %w", err)
 	}
 	if !found {
-		pod, found, err = findSourcePod(ctx, r.NonCacheReadClient, job)
-		if err != nil {
-			return nil, false, fmt.Errorf("confirm source pod absence for helper verification: %w", err)
-		}
-		if !found {
-			return &snapshotJobFailure{
-				reason: snapshotv1alpha1.ReasonJobFailed,
-				cause:  errors.New("source pod is gone before its helper containers could be verified"),
-			}, false, nil
-		}
+		return &snapshotJobFailure{
+			reason: snapshotv1alpha1.ReasonJobFailed,
+			cause:  errors.New("source pod is gone before its helper containers could be verified"),
+		}, false, nil
 	}
+	failure, helpersStillRunning = classifyHelperPod(pod, helpers, sidecars)
+	return failure, helpersStillRunning, nil
+}
+
+// classifyHelperPod derives the helper/sidecar verdict from a single observed
+// pod. Pure over its input so the same logic can both produce a tentative,
+// cache-derived verdict and be re-run against an authoritative read.
+func classifyHelperPod(pod *corev1.Pod, helpers, sidecars []string) (failure *snapshotJobFailure, helpersStillRunning bool) {
 	for _, name := range helpers {
 		terminated := containerTerminatedState(pod.Status.ContainerStatuses, name)
 		if terminated == nil {
-			return nil, true, nil
+			return nil, true
 		}
 		if terminated.ExitCode != 0 {
 			return &snapshotJobFailure{
 				reason: snapshotv1alpha1.ReasonJobFailed,
 				cause: fmt.Errorf("helper container %q exited with code %d after the capture succeeded",
 					name, terminated.ExitCode),
-			}, false, nil
+			}, false
 		}
 	}
 	for _, name := range sidecars {
 		if containerTerminatedState(pod.Status.InitContainerStatuses, name) == nil {
-			return nil, true, nil
+			return nil, true
 		}
 	}
-	return nil, false, nil
+	return nil, false
 }
 
 // expectedHelperContainers splits the pod template's non-target containers into

--- a/operator/internal/controller/snapshotjob_source_job.go
+++ b/operator/internal/controller/snapshotjob_source_job.go
@@ -200,16 +200,12 @@ func classifySourceJobTerminal(job *batchv1.Job) sourceJobTerminalResult {
 	return sourceJobTerminalResult{state: sourceJobActive}
 }
 
-// snapshotJobTerminalFailure arbitrates the terminal signals. Once a capture
-// exists, its result is authoritative: Ready is success regardless of how the
-// source Job ended (the checkpoint terminates the source process, so a failed
-// source Job is the expected outcome of a successful capture), a Failed capture
-// keeps its specific reason even when the Job also failed, and a pending
-// capture is never failed on the source Job's word alone — the caller waits for
-// the agent's terminal result. Only before any capture exists does a source Job
-// failure fail the SnapshotJob immediately. One exception on the failure side:
-// an explicit deadline expiry is the root cause of a capture that died with it,
-// so DeadlineExceeded wins over the collateral capture failure.
+// snapshotJobTerminalFailure derives the aggregate failure only; Captured is
+// owned by deriveCapturedStatus. Once a capture exists its result decides: a
+// Failed capture keeps its own reason, a pending one is never failed on the
+// Job's word alone. Before any capture exists a Job failure fails the
+// SnapshotJob immediately. One exception: a deadline expiry is the root cause
+// of a capture that died with it, so DeadlineExceeded wins the aggregate.
 func snapshotJobTerminalFailure(job *batchv1.Job, snap *snapshotv1alpha1.PodSnapshot) *snapshotJobFailure {
 	if snap != nil {
 		if snapshotv1alpha1.IsPodSnapshotFailed(snap) {


### PR DESCRIPTION
### Summary

Aligns the SnapshotJob reconciler with the requested reconciliation model: each condition has exactly one signal owner, and once a PodSnapshot exists its status is the only capture signal SnapshotJob consumes.

- **PodSnapshot controls `Captured`.** `deriveCapturedStatus` is now the single writer of the `Captured` condition, fed exclusively by `PodSnapshot.status`. A Failed capture stamps `Captured` with the capture's own reason and message; the aggregate failure no longer rewrites it. When a capture failure coincides with a source Job deadline, `Failed` still reports `DeadlineExceeded` as the aggregate root cause, but `Captured` keeps the capture's result. An already-True `Captured` is never downgraded, so a recorded capture success survives losing its PodSnapshot.
- **Job controls the workload gate only.** `snapshotJobTerminalFailure` derives the aggregate failure alone and never feeds `Captured`. The defensive terminal arbitration after creating a PodSnapshot is removed — a capture created this pass is pending by definition.
- **Direct reads shrink to identity and confirmed-absence checks.** Helper-container verification is now cache-first: terminated container states are immutable, so staleness can only report a reversible `helpersStillRunning` requeue; the API read remains only to confirm a cached pod miss before the sticky unverifiable failure. Because a PodSnapshot terminal status is sticky, stale cached status can only delay progress at this layer — it cannot invent a competing terminal result.

### Validation

- Operator suite passes; new coverage: `Captured` keeps the capture's own reason under a Job deadline, helper verification tolerates an informer-lagged pod, and a True `Captured` is not downgraded by `PodSnapshotDeleted`.
- The remaining `NonCacheReadClient` uses are exactly the sanctioned set: recorded-child cache-miss confirmation (Job and PodSnapshot), capture-absence confirmation before `SourceCompletedWithoutCapture`, adoption identity, and helper-absence confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SnapshotJob status reporting so capture-specific failures remain visible when the source job fails or reaches its deadline.
  * Preserved successful capture status after related resources are removed.
  * Improved verification reliability when resources are temporarily missing or stale in the local cache.
  * Ensured newly initiated captures remain pending until capture status is available.
  * Improved handling of helper-container restarts and authoritative resource verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->