### PR TITLE
Add parallel multi-container restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Snapshots are portable across compatible machines and can be restored on any nod
 | `PodSnapshot` | Namespaced | Created by callers to request a capture or reference an artifact for restore. |
 | `PodSnapshotContent` | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapshot operator, never by the caller. |
 | `nvidia.com/restore-from` | Namespaced | Added as a pod annotation to trigger restore from a named `PodSnapshot` in the same namespace. |
+| `nvidia.com/restore-container-map` | Namespaced | Optional comma-separated `source=destination` mappings used to clone the single captured container into one or more restore containers. |
 
 &nbsp;
 
@@ -90,4 +91,3 @@ Clients interact exclusively through the Kubernetes API. No platform-specific AP
 ## Status
 
 The project is in early development. API types and control plane components are scaffolded but not yet feature-complete. Not ready for production use.
-

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -85,16 +85,34 @@ type NodeController struct {
 }
 
 type restoreArtifact struct {
-	SnapshotName  string
-	ContentUID    string
-	ContainerName string
-	Path          string
+	SnapshotName        string
+	ContentUID          string
+	SourceContainerName string
+	Path                string
 }
 
 type restoreTarget struct {
-	SnapshotName  string
-	ContentUID    string
-	ContainerName string
+	SnapshotName        string
+	ContentUID          string
+	SourceContainerName string
+}
+
+type restorePlan struct {
+	artifact *restoreArtifact
+	mappings []snapshotv1alpha1.RestoreContainerMapping
+}
+
+type restoreResultState int
+
+const (
+	restoreResultPending restoreResultState = iota
+	restoreResultSucceeded
+	restoreResultFailed
+)
+
+type restoreResult struct {
+	destination string
+	state       restoreResultState
 }
 
 type restorePendingError struct {
@@ -110,6 +128,7 @@ type restoreOperation struct {
 	controller  *NodeController
 	pod         *corev1.Pod
 	artifact    *restoreArtifact
+	destination string
 	containerID string
 	startedAt   time.Time
 	log         logr.Logger
@@ -121,8 +140,10 @@ const (
 	restoreContainerResolveTimeout     = 30 * time.Second
 	restoreFailedReason                = "RestoreFailed"
 	restoreInProgressReason            = "RestoreInProgress"
+	restorePartiallySucceededReason    = "RestorePartiallySucceeded"
 	restoreSucceededReason             = "RestoreSucceeded"
 	restoreAlreadyCompletedReason      = "RestoreAlreadyCompleted"
+	restoreAlreadyPartialReason        = "RestoreAlreadyPartiallySucceeded"
 	restoreAlreadyFailedReason         = "RestoreAlreadyFailed"
 	restoreFinalizerUpdateFailedReason = "RestoreFinalizerUpdateFailed"
 	restoreStatusUpdateFailedReason    = "RestoreStatusUpdateFailed"
@@ -410,26 +431,11 @@ func (w *NodeController) processRestoreQueueItem(ctx context.Context, key client
 		return
 	}
 	if isRestoreTerminal(pod) {
-		if isRestoreSucceeded(pod) {
-			emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeNormal, restoreAlreadyCompletedReason, "Pod restore already completed; no further action is required")
-		} else {
-			message := findRestoredCondition(pod).Message
-			if message == "" {
-				message = "Pod restore previously failed; create a new restore Pod to retry"
-			}
-			emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeWarning, restoreAlreadyFailedReason, message)
-		}
-		requeue = w.removeRestoreFinalizerWithEvent(ctx, pod)
+		requeue = w.handleTerminalRestorePod(ctx, pod)
 		return
 	}
 	if pod.DeletionTimestamp != nil {
 		requeue = w.removeRestoreFinalizerWithEvent(ctx, pod)
-		return
-	}
-	if err := w.addRestoreFinalizer(ctx, pod); err != nil {
-		w.log.Error(err, "Failed to protect restore Pod", "pod", key.String())
-		emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeWarning, restoreFinalizerUpdateFailedReason, err.Error())
-		requeue = true
 		return
 	}
 	if !isRestorePodActive(pod) {
@@ -439,22 +445,50 @@ func (w *NodeController) processRestoreQueueItem(ctx context.Context, key client
 	requeue = w.reconcileRestorePod(ctx, pod)
 }
 
+// handleTerminalRestorePod reports the previously recorded terminal outcome
+// and removes restore protection without replaying any worker.
+func (w *NodeController) handleTerminalRestorePod(ctx context.Context, pod *corev1.Pod) bool {
+	condition := findRestoredCondition(pod)
+	eventType := corev1.EventTypeWarning
+	reason := restoreAlreadyFailedReason
+	message := condition.Message
+
+	switch {
+	case isRestoreSucceeded(pod):
+		eventType = corev1.EventTypeNormal
+		reason = restoreAlreadyCompletedReason
+		message = "Pod restore already completed; no further action is required"
+	case isRestorePartiallySucceeded(pod):
+		reason = restoreAlreadyPartialReason
+		if message == "" {
+			message = "Pod restore partially succeeded; create a new restore Pod to retry failed destinations"
+		}
+	case message == "":
+		message = "Pod restore previously failed; create a new restore Pod to retry"
+	}
+
+	emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, eventType, reason, message)
+	return w.removeRestoreFinalizerWithEvent(ctx, pod)
+}
+
 func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Pod) bool {
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-	artifact, err := w.preflightRestore(ctx, pod)
+	plan, err := w.preflightRestore(ctx, pod)
 	if err != nil {
 		return w.handleRestorePreflightError(ctx, pod, err)
 	}
-	return w.restorePodContainer(ctx, pod, artifact, podKey)
+	if err := w.addRestoreFinalizer(ctx, pod); err != nil {
+		w.log.Error(err, "Failed to protect restore Pod", "pod", podKey)
+		emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeWarning, restoreFinalizerUpdateFailedReason, err.Error())
+		return true
+	}
+	return w.restorePodContainers(ctx, pod, plan, podKey)
 }
 
 // preflightRestore validates the restore Pod, its referenced PodSnapshot and
 // bound PodSnapshotContent, and the node-local artifact. Restore execution is
 // entered only when this method returns a complete artifact.
-func (w *NodeController) preflightRestore(ctx context.Context, pod *corev1.Pod) (*restoreArtifact, error) {
-	if w.config.CRIU.TcpEstablished && pod.Status.PodIP == "" {
-		return nil, newRestorePendingError("PodIPPending", fmt.Sprintf("Waiting for restore Pod %s/%s to receive an IP address", pod.Namespace, pod.Name))
-	}
+func (w *NodeController) preflightRestore(ctx context.Context, pod *corev1.Pod) (*restorePlan, error) {
 	snapshot, err := w.getPodSnapshotFromPod(ctx, pod)
 	if err != nil {
 		return nil, err
@@ -469,11 +503,18 @@ func (w *NodeController) preflightRestore(ctx context.Context, pod *corev1.Pod) 
 	if err := validatePodSnapshotContentForRestore(content); err != nil {
 		return nil, err
 	}
-	target, err := validateRestoreTarget(pod, snapshot, content)
+	target, mappings, err := validateRestoreTarget(pod, snapshot, content)
 	if err != nil {
 		return nil, err
 	}
-	return w.resolveRestoreArtifact(fmt.Sprintf("%s/%s", pod.Namespace, pod.Name), target)
+	artifact, err := w.resolveRestoreArtifact(fmt.Sprintf("%s/%s", pod.Namespace, pod.Name), target)
+	if err != nil {
+		return nil, err
+	}
+	if w.config.CRIU.TcpEstablished && pod.Status.PodIP == "" {
+		return nil, newRestorePendingError("PodIPPending", fmt.Sprintf("Waiting for restore Pod %s/%s to receive an IP address", pod.Namespace, pod.Name))
+	}
+	return &restorePlan{artifact: artifact, mappings: mappings}, nil
 }
 
 func (w *NodeController) getPodSnapshotFromPod(ctx context.Context, pod *corev1.Pod) (*snapshotv1alpha1.PodSnapshot, error) {
@@ -548,21 +589,81 @@ func validatePodSnapshotContentForRestore(content *snapshotv1alpha1.PodSnapshotC
 	return nil
 }
 
-func validateRestoreTarget(pod *corev1.Pod, snapshot *snapshotv1alpha1.PodSnapshot, content *snapshotv1alpha1.PodSnapshotContent) (*restoreTarget, error) {
+// validateRestoreTarget resolves the captured source and validates every
+// requested destination against the restore Pod.
+func validateRestoreTarget(pod *corev1.Pod, snapshot *snapshotv1alpha1.PodSnapshot, content *snapshotv1alpha1.PodSnapshotContent) (*restoreTarget, []snapshotv1alpha1.RestoreContainerMapping, error) {
 	containerName, err := singleTargetContainer(content)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if !podSpecHasContainer(&pod.Spec, containerName) {
-		return nil, fmt.Errorf("restore pod has no container named %q captured by PodSnapshot %s", containerName, snapshot.Name)
+	mappings, err := snapshotv1alpha1.RestoreContainerMappingsFromAnnotations(pod.Annotations, containerName)
+	if err != nil {
+		return nil, nil, err
 	}
-	return &restoreTarget{SnapshotName: snapshot.Name, ContentUID: string(content.UID), ContainerName: containerName}, nil
+	if err := validateRestoreMappingsForPod(&pod.Spec, mappings, containerName); err != nil {
+		return nil, nil, err
+	}
+	return &restoreTarget{SnapshotName: snapshot.Name, ContentUID: string(content.UID), SourceContainerName: containerName}, mappings, nil
+}
+
+// validateRestoreMappingsForPod validates the mapping contract and ensures
+// every destination exists in the restore Pod spec.
+func validateRestoreMappingsForPod(spec *corev1.PodSpec, mappings []snapshotv1alpha1.RestoreContainerMapping, capturedSource string) error {
+	if err := snapshotv1alpha1.ValidateRestoreContainerMappings(mappings, capturedSource); err != nil {
+		return err
+	}
+	if len(mappings) > 1 {
+		hasControlVolume := false
+		for _, volume := range spec.Volumes {
+			if volume.Name == snapshotv1alpha1.SnapshotControlVolumeName && volume.EmptyDir != nil {
+				hasControlVolume = true
+				break
+			}
+		}
+		if !hasControlVolume {
+			return fmt.Errorf("multi-container restore requires %s emptyDir volume", snapshotv1alpha1.SnapshotControlVolumeName)
+		}
+	}
+	for _, mapping := range mappings {
+		var destination *corev1.Container
+		for i := range spec.Containers {
+			if spec.Containers[i].Name == mapping.Destination {
+				destination = &spec.Containers[i]
+				break
+			}
+		}
+		if destination == nil {
+			return fmt.Errorf("restore pod has no destination container named %q", mapping.Destination)
+		}
+		if len(mappings) == 1 {
+			continue
+		}
+		validControlMount := false
+		for _, mount := range destination.VolumeMounts {
+			if mount.Name == snapshotv1alpha1.SnapshotControlVolumeName &&
+				mount.MountPath == snapshotv1alpha1.SnapshotControlMountPath &&
+				mount.SubPath == mapping.Destination {
+				validControlMount = true
+				break
+			}
+		}
+		if !validControlMount {
+			return fmt.Errorf(
+				"multi-container restore destination %q requires %s mounted at %s with subPath %q",
+				mapping.Destination,
+				snapshotv1alpha1.SnapshotControlVolumeName,
+				snapshotv1alpha1.SnapshotControlMountPath,
+				mapping.Destination,
+			)
+		}
+	}
+	return nil
 }
 
 // resolveRestoreArtifact resolves the validated restore target to its physical
 // checkpoint directory. A nil error always returns a complete artifact.
 func (w *NodeController) resolveRestoreArtifact(podKey string, target *restoreTarget) (*restoreArtifact, error) {
-	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, target.ContentUID, target.ContainerName)
+	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, target.ContentUID, target.SourceContainerName)
 	if err != nil {
 		return nil, err
 	}
@@ -579,54 +680,118 @@ func (w *NodeController) resolveRestoreArtifact(podKey string, target *restoreTa
 		return nil, newRestorePendingError("ArtifactPending", fmt.Sprintf("Waiting for artifact %s", path))
 	}
 	return &restoreArtifact{
-		SnapshotName:  target.SnapshotName,
-		ContentUID:    target.ContentUID,
-		ContainerName: target.ContainerName,
-		Path:          path,
+		SnapshotName:        target.SnapshotName,
+		ContentUID:          target.ContentUID,
+		SourceContainerName: target.SourceContainerName,
+		Path:                path,
 	}, nil
 }
 
-// restorePodContainer resolves the target container and runs the restore in the
-// current queue-item goroutine. Returning true schedules the safety requeue.
-func (w *NodeController) restorePodContainer(ctx context.Context, pod *corev1.Pod, artifact *restoreArtifact, podKey string) bool {
-	containerID, requeue := w.resolveRestoreContainerID(ctx, pod, artifact, podKey)
-	if containerID == "" {
-		if requeue {
-			return w.handleRestorePreflightError(ctx, pod, newRestorePendingError(
-				"ContainerPending",
-				fmt.Sprintf("Waiting for restore container %s in Pod %s", artifact.ContainerName, podKey),
-			))
+// restorePodContainers owns one restore pass for the Pod. Workers never write
+// Pod status; they report one result each and this coordinator publishes the
+// aggregate outcome.
+func (w *NodeController) restorePodContainers(ctx context.Context, pod *corev1.Pod, plan *restorePlan, podKey string) bool {
+	// Read the incoming state before persisting this pass. On agent restart,
+	// RestoreInProgress makes each worker check its completion sentinel before
+	// considering a CRIU replay.
+	recovering := restoreInProgress(pod)
+	message := fmt.Sprintf("Restoring %d destination container(s) from PodSnapshot %s", len(plan.mappings), plan.artifact.SnapshotName)
+	if err := w.applyRestoredCondition(ctx, pod, corev1.ConditionFalse, restoreInProgressReason, message); err != nil {
+		emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeWarning, restoreStatusUpdateFailedReason, err.Error())
+		return true
+	}
+
+	results := make([]restoreResult, len(plan.mappings))
+	var workers sync.WaitGroup
+	for i, mapping := range plan.mappings {
+		i, destination := i, mapping.Destination
+		workers.Go(func() {
+			results[i] = w.restoreDestination(ctx, pod, plan.artifact, destination, podKey, recovering)
+		})
+	}
+	workers.Wait()
+
+	return w.recordRestoreResults(ctx, pod, plan.artifact, results)
+}
+
+// recordRestoreResults publishes the aggregate Pod outcome after every worker
+// in the current pass has returned.
+func (w *NodeController) recordRestoreResults(ctx context.Context, pod *corev1.Pod, artifact *restoreArtifact, results []restoreResult) bool {
+	byState := make(map[restoreResultState][]string, 3)
+	for _, result := range results {
+		byState[result.state] = append(byState[result.state], result.destination)
+	}
+	succeeded := byState[restoreResultSucceeded]
+	failed := byState[restoreResultFailed]
+	pending := byState[restoreResultPending]
+
+	if len(pending) != 0 {
+		message := fmt.Sprintf(
+			"Restore from PodSnapshot %s remains in progress: %d succeeded, %d failed, %d pending (%s)",
+			artifact.SnapshotName, len(succeeded), len(failed), len(pending), strings.Join(pending, ", "),
+		)
+		if err := w.applyRestoredCondition(ctx, pod, corev1.ConditionFalse, restoreInProgressReason, message); err != nil {
+			emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeWarning, restoreStatusUpdateFailedReason, err.Error())
 		}
-		return false
+		return true
+	}
+
+	if len(failed) == 0 {
+		message := fmt.Sprintf("Restored %d destination container(s) from PodSnapshot %s: %s", len(succeeded), artifact.SnapshotName, strings.Join(succeeded, ", "))
+		return w.finishRestore(ctx, pod, corev1.ConditionTrue, restoreSucceededReason, message) != nil
+	}
+	if len(succeeded) != 0 {
+		message := fmt.Sprintf("Restored %d of %d destination containers from PodSnapshot %s; failed: %s", len(succeeded), len(results), artifact.SnapshotName, strings.Join(failed, ", "))
+		return w.finishRestore(ctx, pod, corev1.ConditionFalse, restorePartiallySucceededReason, message) != nil
+	}
+	message := fmt.Sprintf("Restore failed for all %d destination container(s) from PodSnapshot %s: %s", len(failed), artifact.SnapshotName, strings.Join(failed, ", "))
+	return w.finishRestore(ctx, pod, corev1.ConditionFalse, restoreFailedReason, message) != nil
+}
+
+// restoreDestination resolves and restores one destination independently of
+// its siblings, returning only its worker-local outcome to the coordinator.
+func (w *NodeController) restoreDestination(
+	ctx context.Context,
+	pod *corev1.Pod,
+	artifact *restoreArtifact,
+	destination, podKey string,
+	recovering bool,
+) restoreResult {
+	result := restoreResult{destination: destination, state: restoreResultPending}
+	containerID, _ := w.resolveRestoreContainerID(ctx, pod, destination, podKey)
+	if containerID == "" {
+		return result
 	}
 
 	startedAt := time.Now()
-	w.log.Info("Restore target detected, triggering external restore",
-		"pod", podKey,
-		"snapshot", artifact.SnapshotName,
+	log := w.log.WithValues("pod", podKey, "snapshot", artifact.SnapshotName, "destination", destination)
+	log.Info("Restore target detected, triggering external restore",
 		"content_uid", artifact.ContentUID,
-		"container", artifact.ContainerName,
+		"source_container", artifact.SourceContainerName,
+		"container_id", containerID,
 	)
-	requeue, err := w.runRestore(ctx, pod, artifact, containerID, startedAt)
-	if err == nil {
-		return requeue
+	emitPodEvent(ctx, w.clientset, log, pod, snapshotEventComponent, corev1.EventTypeNormal, restoreRequestedReason, fmt.Sprintf("Restore requested from PodSnapshot %s for destination %s", artifact.SnapshotName, destination))
+
+	if err := w.runRestore(ctx, pod, artifact, destination, containerID, startedAt, recovering); err != nil {
+		result.state = restoreResultFailed
+		log.Error(err, "Restore controller worker failed")
+		emitPodEvent(ctx, w.clientset, log, pod, snapshotEventComponent, corev1.EventTypeWarning, "RestoreWorkerFailed", err.Error())
+		return result
 	}
-	opLog := w.log.WithValues("pod", podKey, "snapshot", artifact.SnapshotName, "container", artifact.ContainerName)
-	opLog.Error(err, "Restore controller worker failed")
-	emitPodEvent(ctx, w.clientset, opLog, pod, snapshotEventComponent, corev1.EventTypeWarning, "RestoreWorkerFailed", err.Error())
-	return true
+	result.state = restoreResultSucceeded
+	return result
 }
 
 // resolveRestoreContainerID uses the kubelet-published status fast path, then
 // polls the node runtime inline while this Pod's queue key remains in progress.
-func (w *NodeController) resolveRestoreContainerID(ctx context.Context, pod *corev1.Pod, artifact *restoreArtifact, podKey string) (string, bool) {
-	if containerID := restoreContainerIDFromStatus(pod, artifact.ContainerName); containerID != "" {
+func (w *NodeController) resolveRestoreContainerID(ctx context.Context, pod *corev1.Pod, destination, podKey string) (string, bool) {
+	if containerID := restoreContainerIDFromStatus(pod, destination); containerID != "" {
 		return containerID, false
 	}
 
 	w.log.V(1).Info("Restore pod has no running container in Kubernetes status yet; polling node runtime",
 		"pod", podKey,
-		"container", artifact.ContainerName,
+		"container", destination,
 	)
 	deadlineAt := time.Now().Add(restoreContainerResolveTimeout)
 	deadline := time.NewTimer(time.Until(deadlineAt))
@@ -635,12 +800,12 @@ func (w *NodeController) resolveRestoreContainerID(ctx context.Context, pod *cor
 	defer tick.Stop()
 	for {
 		resolveCtx, cancel := restoreContainerResolveAttemptContext(ctx, deadlineAt)
-		containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, artifact.ContainerName)
+		containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, destination)
 		cancel()
 		if err == nil && containerID != "" {
 			w.log.V(1).Info("Resolved restore container via node runtime",
 				"pod", podKey,
-				"container", artifact.ContainerName,
+				"container", destination,
 				"container_id", containerID,
 			)
 			return containerID, false
@@ -650,7 +815,7 @@ func (w *NodeController) resolveRestoreContainerID(ctx context.Context, pod *cor
 		case <-deadline.C:
 			w.log.V(1).Info("Timed out polling node runtime for restore container",
 				"pod", podKey,
-				"container", artifact.ContainerName,
+				"container", destination,
 			)
 			return "", true
 		case <-ctx.Done():
@@ -660,24 +825,24 @@ func (w *NodeController) resolveRestoreContainerID(ctx context.Context, pod *cor
 	}
 }
 
-// runRestore runs the full restore workflow for one target container:
-//  1. Apply snapshot/Restored=False/RestoreInProgress to pod status
-//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace).
+// runRestore runs the full restore workflow for one destination container:
+//  1. Call executor.Restore (inspect placeholder → nsrestore inside namespace).
 //     nsrestore clears any stale restore-complete sentinel on the pod control
 //     volume before CRIU, so a prior incarnation cannot release the restored
 //     process early.
-//  3. Write a restore-complete sentinel: the CRIU-restored process resumes
+//  2. Write a restore-complete sentinel: the CRIU-restored process resumes
 //     inside the polling loop that waits on this file, exits quiescence,
 //     and resumes the engine
-//  4. Apply snapshot/Restored=True/RestoreSucceeded to pod status
-func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, artifact *restoreArtifact, containerID string, startedAt time.Time) (bool, error) {
-	op := w.newRestoreOperation(pod, artifact, containerID, startedAt)
-	completed, err := op.recoverCompletedRestore(ctx)
-	if err != nil {
-		return true, err
-	}
-	if completed {
-		return false, nil
+func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, artifact *restoreArtifact, destination, containerID string, startedAt time.Time, recovering bool) error {
+	op := w.newRestoreOperation(pod, artifact, destination, containerID, startedAt)
+	if recovering {
+		completed, err := op.recoverCompletedRestore(ctx)
+		if err != nil {
+			return err
+		}
+		if completed {
+			return nil
+		}
 	}
 
 	restoreCtx := ctx
@@ -687,28 +852,20 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, artifa
 		defer cancel()
 	}
 
-	if err := op.beginRestore(ctx); err != nil {
-		return true, err
-	}
-	emitPodEvent(ctx, w.clientset, op.log, pod, snapshotEventComponent, corev1.EventTypeNormal, restoreRequestedReason, fmt.Sprintf("Restore requested from PodSnapshot %s for container %s", artifact.SnapshotName, artifact.ContainerName))
 	placeholderHostPID, err := op.executeRestore(restoreCtx)
 	if err != nil {
 		var cleanupErr *executor.RestoreCleanupError
 		if !errors.As(err, &cleanupErr) {
-			err = op.failRestore(ctx, err)
-			return err != nil, err
+			return op.failRestore(ctx, err)
 		}
 		op.log.Error(cleanupErr, "Restore completed with cleanup errors")
 		emitPodEvent(ctx, w.clientset, op.log, pod, snapshotEventComponent, corev1.EventTypeWarning, "RestoreCleanupFailed", cleanupErr.Error())
 	}
-	err = op.completeRestore(ctx, placeholderHostPID)
-	return err != nil, err
+	return op.completeRestore(ctx, placeholderHostPID)
 }
 
-// recoverCompletedRestore finalizes an interrupted status update without
-// replaying CRIU. RestoreInProgress is normally retryable after an agent
-// restart, but the restore-complete sentinel proves that execution already
-// finished and only the snapshot/Restored=True status write remains.
+// recoverCompletedRestore avoids replaying CRIU when the destination-scoped
+// completion sentinel proves the operation already finished.
 func (op *restoreOperation) recoverCompletedRestore(ctx context.Context) (bool, error) {
 	condition := findRestoredCondition(op.pod)
 	if condition == nil || condition.Status != corev1.ConditionFalse || condition.Reason != restoreInProgressReason {
@@ -726,15 +883,13 @@ func (op *restoreOperation) recoverCompletedRestore(ctx context.Context) (bool, 
 	if !exists {
 		return false, nil
 	}
-	if err := op.markRestoreSucceeded(ctx); err != nil {
-		return true, fmt.Errorf("finalize completed restore: %w", err)
-	}
 	return true, nil
 }
 
 func (w *NodeController) newRestoreOperation(
 	pod *corev1.Pod,
 	artifact *restoreArtifact,
+	destination string,
 	containerID string,
 	startedAt time.Time,
 ) *restoreOperation {
@@ -743,31 +898,26 @@ func (w *NodeController) newRestoreOperation(
 		controller:  w,
 		pod:         pod,
 		artifact:    artifact,
+		destination: destination,
 		containerID: containerID,
 		startedAt:   startedAt,
-		log:         w.log.WithValues("pod", podKey, "snapshot", artifact.SnapshotName, "content_uid", artifact.ContentUID, "container_id", containerID),
+		log:         w.log.WithValues("pod", podKey, "snapshot", artifact.SnapshotName, "content_uid", artifact.ContentUID, "source_container", artifact.SourceContainerName, "destination_container", destination, "container_id", containerID),
 	}
-}
-
-func (op *restoreOperation) beginRestore(ctx context.Context) error {
-	if err := op.setRestoredCondition(ctx, corev1.ConditionFalse, restoreInProgressReason, "Restoring captured process state"); err != nil {
-		return fmt.Errorf("apply restore in-progress condition: %w", err)
-	}
-	return nil
 }
 
 func (op *restoreOperation) executeRestore(ctx context.Context) (int, error) {
 	w := op.controller
 	req := executor.RestoreRequest{
-		ContentUID:    op.artifact.ContentUID,
-		BasePath:      w.config.Storage.BasePath,
-		ContainerID:   op.containerID,
-		StartedAt:     op.startedAt,
-		PodName:       op.pod.Name,
-		PodNamespace:  op.pod.Namespace,
-		TargetPodIP:   op.pod.Status.PodIP,
-		ContainerName: op.artifact.ContainerName,
-		Clientset:     w.clientset,
+		ContentUID:               op.artifact.ContentUID,
+		BasePath:                 w.config.Storage.BasePath,
+		ContainerID:              op.containerID,
+		StartedAt:                op.startedAt,
+		PodName:                  op.pod.Name,
+		PodNamespace:             op.pod.Namespace,
+		TargetPodIP:              op.pod.Status.PodIP,
+		ArtifactContainerName:    op.artifact.SourceContainerName,
+		DestinationContainerName: op.destination,
+		Clientset:                w.clientset,
 	}
 	return w.restoreFn(ctx, w.runtime, op.log, req, w.injector)
 }
@@ -778,12 +928,12 @@ func (op *restoreOperation) failRestore(ctx context.Context, restoreErr error) e
 	// Re-resolve because restore may fail before discovering the placeholder PID.
 	placeholderHostPID, _, err := w.runtime.ResolveContainer(ctx, op.containerID)
 	if err != nil {
-		return fmt.Errorf("restore failed and placeholder PID could not be resolved: %w", err)
+		return errors.Join(restoreErr, fmt.Errorf("placeholder PID could not be resolved after restore failure: %w", err))
 	}
 	if err := w.sendSignalFn(op.log, placeholderHostPID, syscall.SIGKILL, "restore failed"); err != nil {
-		return fmt.Errorf("restore failed and placeholder could not be killed: %w", err)
+		return errors.Join(restoreErr, fmt.Errorf("placeholder could not be killed after restore failure: %w", err))
 	}
-	return op.markRestoreFailed(ctx, restoreErr)
+	return restoreErr
 }
 
 func (op *restoreOperation) completeRestore(ctx context.Context, placeholderHostPID int) error {
@@ -793,52 +943,16 @@ func (op *restoreOperation) completeRestore(ctx context.Context, placeholderHost
 	if err := w.writeControlSentinelFn(placeholderHostPID, snapshotv1alpha1.RestoreCompleteFile); err != nil {
 		op.log.Error(err, "Failed to write restore-complete sentinel")
 		if killErr := w.sendSignalFn(op.log, placeholderHostPID, syscall.SIGKILL, "restore sentinel failed"); killErr != nil {
-			return fmt.Errorf("write restore-complete sentinel failed and placeholder could not be killed: %w", killErr)
+			return errors.Join(fmt.Errorf("failed to write restore-complete sentinel: %w", err), fmt.Errorf("placeholder could not be killed: %w", killErr))
 		}
-		return op.markRestoreFailed(ctx, fmt.Errorf("failed to write restore-complete sentinel: %w", err))
+		return fmt.Errorf("failed to write restore-complete sentinel: %w", err)
 	}
-
-	return op.markRestoreSucceeded(ctx)
-}
-
-func (op *restoreOperation) markRestoreSucceeded(ctx context.Context) error {
-	message := fmt.Sprintf("Restored from PodSnapshot %s", op.artifact.SnapshotName)
-	return op.controller.finishRestore(
-		ctx,
-		op.pod,
-		corev1.ConditionTrue,
-		restoreSucceededReason,
-		message,
-		corev1.EventTypeNormal,
-		restoreSucceededReason,
-		fmt.Sprintf("Restore completed from PodSnapshot %s", op.artifact.SnapshotName),
-	)
-}
-
-func (op *restoreOperation) markRestoreFailed(ctx context.Context, cause error) error {
-	return op.controller.finishRestore(
-		ctx,
-		op.pod,
-		corev1.ConditionFalse,
-		restoreFailedReason,
-		cause.Error(),
-		corev1.EventTypeWarning,
-		restoreFailedReason,
-		cause.Error(),
-	)
-}
-
-func (op *restoreOperation) setRestoredCondition(ctx context.Context, status corev1.ConditionStatus, reason, message string) error {
-	err := op.controller.applyRestoredCondition(ctx, op.pod, status, reason, message)
-	if err != nil {
-		emitPodEvent(ctx, op.controller.clientset, op.log, op.pod, snapshotEventComponent, corev1.EventTypeWarning, restoreStatusUpdateFailedReason, fmt.Sprintf("Failed to record %s restore status: %v", reason, err))
-	}
-	return err
+	return nil
 }
 
 // applyRestoredCondition uses server-side apply against the status subresource.
 // Pod conditions are an associative list keyed by type, so this field manager
-// owns only snapshot/Restored and does not replace kubelet-owned conditions.
+// owns only nvidia.com/Restored and does not replace kubelet-owned conditions.
 func (w *NodeController) applyRestoredCondition(ctx context.Context, pod *corev1.Pod, status corev1.ConditionStatus, reason, message string) error {
 	setPodCondition(&pod.Status, corev1.PodCondition{
 		Type:    corev1.PodConditionType(snapshotv1alpha1.RestoredCondition),
@@ -925,14 +1039,18 @@ func (w *NodeController) finishRestore(
 	ctx context.Context,
 	pod *corev1.Pod,
 	status corev1.ConditionStatus,
-	reason, message, eventType, eventReason, eventMessage string,
+	reason, message string,
 ) error {
 	if err := w.applyRestoredCondition(ctx, pod, status, reason, message); err != nil {
 		emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, corev1.EventTypeWarning, restoreStatusUpdateFailedReason, fmt.Sprintf("Failed to record %s restore status: %v", reason, err))
 		return err
 	}
 	w.markRestoreHandled(pod)
-	emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, eventType, eventReason, eventMessage)
+	eventType := corev1.EventTypeWarning
+	if status == corev1.ConditionTrue {
+		eventType = corev1.EventTypeNormal
+	}
+	emitPodEvent(ctx, w.clientset, w.log, pod, snapshotEventComponent, eventType, reason, message)
 	finalizerErr := w.removeRestoreFinalizer(ctx, pod)
 	if finalizerErr != nil {
 		w.log.Error(finalizerErr, "Failed to remove restore protection finalizer", "pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
@@ -948,9 +1066,6 @@ func (w *NodeController) failRestorePod(ctx context.Context, pod *corev1.Pod, ca
 		ctx,
 		pod,
 		corev1.ConditionFalse,
-		restoreFailedReason,
-		cause.Error(),
-		corev1.EventTypeWarning,
 		restoreFailedReason,
 		cause.Error(),
 	)
@@ -1077,15 +1192,6 @@ func (w *NodeController) restoreArtifactReady(log logr.Logger, podKey, artifactP
 	return true, nil
 }
 
-func podSpecHasContainer(spec *corev1.PodSpec, name string) bool {
-	for i := range spec.Containers {
-		if spec.Containers[i].Name == name {
-			return true
-		}
-	}
-	return false
-}
-
 // restoreContainerIDFromStatus is the fast path when kubelet has already
 // published the target container ID. The restore controller polls the node
 // runtime when status publication lags container creation.
@@ -1126,9 +1232,15 @@ func isRestoreSucceeded(pod *corev1.Pod) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// isRestorePartiallySucceeded reports the terminal mixed worker outcome.
+func isRestorePartiallySucceeded(pod *corev1.Pod) bool {
+	condition := findRestoredCondition(pod)
+	return condition != nil && condition.Status == corev1.ConditionFalse && condition.Reason == restorePartiallySucceededReason
+}
+
 func isRestoreTerminal(pod *corev1.Pod) bool {
 	condition := findRestoredCondition(pod)
-	return isRestoreSucceeded(pod) ||
+	return isRestoreSucceeded(pod) || isRestorePartiallySucceeded(pod) ||
 		(condition != nil && condition.Status == corev1.ConditionFalse && condition.Reason == restoreFailedReason)
 }
 

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -6,9 +6,11 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -45,6 +47,7 @@ const (
 )
 
 type fakeRuntime struct {
+	mu                   sync.Mutex
 	containerIDByPod     string
 	resolvedContainerIDs []string
 	resolveContainerPID  int
@@ -53,6 +56,8 @@ type fakeRuntime struct {
 var _ snapshotruntime.Runtime = (*fakeRuntime)(nil)
 
 func (r *fakeRuntime) ResolveContainer(_ context.Context, id string) (int, *specs.Spec, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.resolvedContainerIDs = append(r.resolvedContainerIDs, id)
 	if r.resolveContainerPID > 0 {
 		return r.resolveContainerPID, &specs.Spec{}, nil
@@ -61,6 +66,8 @@ func (r *fakeRuntime) ResolveContainer(_ context.Context, id string) (int, *spec
 }
 
 func (r *fakeRuntime) ResolveContainerIDByPod(_ context.Context, _, _, _ string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.containerIDByPod != "" {
 		return r.containerIDByPod, nil
 	}
@@ -226,6 +233,40 @@ func restorePod(annotations map[string]string) *corev1.Pod {
 	}
 }
 
+func multiRestorePod() *corev1.Pod {
+	pod := restorePod(map[string]string{
+		snapshotv1alpha1.RestoreFromAnnotation:         "snapshot-a",
+		snapshotv1alpha1.RestoreContainerMapAnnotation: "main=engine-0,main=engine-1",
+	})
+	pod.Spec.Volumes = []corev1.Volume{{
+		Name:         snapshotv1alpha1.SnapshotControlVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}}
+	pod.Spec.Containers = []corev1.Container{
+		{
+			Name: "engine-0",
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      snapshotv1alpha1.SnapshotControlVolumeName,
+				MountPath: snapshotv1alpha1.SnapshotControlMountPath,
+				SubPath:   "engine-0",
+			}},
+		},
+		{
+			Name: "engine-1",
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      snapshotv1alpha1.SnapshotControlVolumeName,
+				MountPath: snapshotv1alpha1.SnapshotControlMountPath,
+				SubPath:   "engine-1",
+			}},
+		},
+	}
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{Name: "engine-0", ContainerID: "containerd://engine-0-id", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		{Name: "engine-1", ContainerID: "containerd://engine-1-id", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+	}
+	return pod
+}
+
 func processQueuedRestorePod(t *testing.T, w *NodeController, pod *corev1.Pod) {
 	t.Helper()
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
@@ -362,13 +403,172 @@ func TestPreflightRestore(t *testing.T) {
 		Artifact: types.ArtifactManifest{ContentUID: string(content.UID), ContainerName: "main"},
 	}))
 
-	artifact, err := w.preflightRestore(context.Background(), pod)
+	plan, err := w.preflightRestore(context.Background(), pod)
 	require.NoError(t, err)
-	require.NotNil(t, artifact)
-	assert.Equal(t, "snapshot-a", artifact.SnapshotName)
-	assert.Equal(t, string(content.UID), artifact.ContentUID)
-	assert.Equal(t, "main", artifact.ContainerName)
-	assert.Equal(t, path, artifact.Path)
+	require.NotNil(t, plan)
+	assert.Equal(t, "snapshot-a", plan.artifact.SnapshotName)
+	assert.Equal(t, string(content.UID), plan.artifact.ContentUID)
+	assert.Equal(t, "main", plan.artifact.SourceContainerName)
+	assert.Equal(t, path, plan.artifact.Path)
+	assert.Equal(t, []snapshotv1alpha1.RestoreContainerMapping{{Source: "main", Destination: "main"}}, plan.mappings)
+}
+
+func TestReconcileRestorePodRunsMappedDestinationsConcurrently(t *testing.T) {
+	pod := multiRestorePod()
+	snapshot, content := readySnapshotObjects()
+	w := makeTestController(t, pod, snapshot, content)
+	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, string(content.UID), "main")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path, 0o700))
+
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	w.restoreFn = func(_ context.Context, _ snapshotruntime.Runtime, _ logr.Logger, req executor.RestoreRequest, _ executor.RestoreMounter) (int, error) {
+		started <- req.DestinationContainerName
+		<-release
+		if req.DestinationContainerName == "engine-0" {
+			return 100, nil
+		}
+		return 101, nil
+	}
+	sentinels := make(chan int, 2)
+	w.writeControlSentinelFn = func(pid int, name string) error {
+		assert.Equal(t, snapshotv1alpha1.RestoreCompleteFile, name)
+		sentinels <- pid
+		return nil
+	}
+
+	done := make(chan bool, 1)
+	go func() { done <- w.reconcileRestorePod(context.Background(), pod) }()
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case destination := <-started:
+			seen[destination] = true
+		case <-time.After(time.Second):
+			t.Fatal("restore workers did not overlap")
+		}
+	}
+	assert.Equal(t, map[string]bool{"engine-0": true, "engine-1": true}, seen)
+	assert.Contains(t, string(lastPodStatusApply(t, w).GetPatch()), `"reason":"RestoreInProgress"`)
+	close(release)
+	assert.False(t, <-done)
+
+	assert.ElementsMatch(t, []int{100, 101}, []int{<-sentinels, <-sentinels})
+	payload := string(lastPodStatusApply(t, w).GetPatch())
+	assert.Contains(t, payload, `"status":"True"`)
+	assert.Contains(t, payload, `"reason":"RestoreSucceeded"`)
+}
+
+func TestReconcileRestorePodReportsPartialSuccess(t *testing.T) {
+	pod := multiRestorePod()
+	snapshot, content := readySnapshotObjects()
+	w := makeTestController(t, pod, snapshot, content)
+	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
+	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, string(content.UID), "main")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path, 0o700))
+
+	w.restoreFn = func(_ context.Context, _ snapshotruntime.Runtime, _ logr.Logger, req executor.RestoreRequest, _ executor.RestoreMounter) (int, error) {
+		if req.DestinationContainerName == "engine-1" {
+			return 0, errors.New("restore failed")
+		}
+		return 100, nil
+	}
+
+	requeue := w.reconcileRestorePod(context.Background(), pod)
+
+	assert.False(t, requeue)
+	payload := string(lastPodStatusApply(t, w).GetPatch())
+	assert.Contains(t, payload, `"status":"False"`)
+	assert.Contains(t, payload, `"reason":"RestorePartiallySucceeded"`)
+	assert.Contains(t, payload, "engine-1")
+	assert.True(t, isRestoreTerminal(pod))
+}
+
+func TestReconcileRestorePodReportsAllDestinationsFailed(t *testing.T) {
+	pod := multiRestorePod()
+	snapshot, content := readySnapshotObjects()
+	w := makeTestController(t, pod, snapshot, content)
+	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
+	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, string(content.UID), "main")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path, 0o700))
+	w.restoreFn = func(_ context.Context, _ snapshotruntime.Runtime, _ logr.Logger, req executor.RestoreRequest, _ executor.RestoreMounter) (int, error) {
+		return 0, fmt.Errorf("%s restore failed", req.DestinationContainerName)
+	}
+
+	requeue := w.reconcileRestorePod(context.Background(), pod)
+
+	assert.False(t, requeue)
+	payload := string(lastPodStatusApply(t, w).GetPatch())
+	assert.Contains(t, payload, `"status":"False"`)
+	assert.Contains(t, payload, `"reason":"RestoreFailed"`)
+	assert.Contains(t, payload, "engine-0")
+	assert.Contains(t, payload, "engine-1")
+}
+
+func TestRestorePodContainersKeepsAggregateInProgressWhileDestinationIsPending(t *testing.T) {
+	pod := multiRestorePod()
+	pod.Status.ContainerStatuses = pod.Status.ContainerStatuses[:1]
+	w := makeTestController(t, pod)
+	ctx, cancel := context.WithCancel(context.Background())
+	w.restoreFn = func(_ context.Context, _ snapshotruntime.Runtime, _ logr.Logger, req executor.RestoreRequest, _ executor.RestoreMounter) (int, error) {
+		assert.Equal(t, "engine-0", req.DestinationContainerName)
+		cancel()
+		return 100, nil
+	}
+	plan := &restorePlan{
+		artifact: &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", SourceContainerName: "main"},
+		mappings: []snapshotv1alpha1.RestoreContainerMapping{
+			{Source: "main", Destination: "engine-0"},
+			{Source: "main", Destination: "engine-1"},
+		},
+	}
+	requeue := w.restorePodContainers(ctx, pod, plan, "inference/restore-worker")
+
+	assert.True(t, requeue)
+	payload := string(lastPodStatusApply(t, w).GetPatch())
+	assert.Contains(t, payload, `"reason":"RestoreInProgress"`)
+	assert.Contains(t, payload, "1 succeeded")
+	assert.Contains(t, payload, "1 pending")
+}
+
+func TestPreflightRestoreRejectsInvalidMappingBeforeExecution(t *testing.T) {
+	pod := multiRestorePod()
+	pod.Annotations[snapshotv1alpha1.RestoreContainerMapAnnotation] = "worker=engine-0"
+	snapshot, content := readySnapshotObjects()
+	w := makeTestController(t, pod, snapshot, content)
+	restoreCalls := 0
+	w.restoreFn = func(context.Context, snapshotruntime.Runtime, logr.Logger, executor.RestoreRequest, executor.RestoreMounter) (int, error) {
+		restoreCalls++
+		return 0, nil
+	}
+
+	requeue := w.reconcileRestorePod(context.Background(), pod)
+
+	assert.False(t, requeue)
+	assert.Zero(t, restoreCalls)
+	assert.Contains(t, string(lastPodStatusApply(t, w).GetPatch()), `"reason":"RestoreFailed"`)
+	for _, action := range w.clientset.(*fake.Clientset).Actions() {
+		if patch, ok := action.(clientgotesting.PatchAction); ok && patch.GetSubresource() == "" {
+			t.Fatal("invalid mapping must not add a restore finalizer")
+		}
+	}
+}
+
+func TestPreflightRestoreRejectsSharedMultiDestinationControlMount(t *testing.T) {
+	pod := multiRestorePod()
+	pod.Spec.Containers[1].VolumeMounts[0].SubPath = "engine-0"
+	snapshot, content := readySnapshotObjects()
+	w := makeTestController(t, pod, snapshot, content)
+
+	plan, err := w.preflightRestore(context.Background(), pod)
+
+	assert.Nil(t, plan)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `subPath "engine-1"`)
 }
 
 func TestPreflightRestoreRetriesInProgressCondition(t *testing.T) {
@@ -382,11 +582,11 @@ func TestPreflightRestoreRetriesInProgressCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path, 0o700))
 
-	artifact, err := w.preflightRestore(context.Background(), pod)
+	plan, err := w.preflightRestore(context.Background(), pod)
 
 	require.NoError(t, err)
-	require.NotNil(t, artifact)
-	assert.Equal(t, path, artifact.Path)
+	require.NotNil(t, plan)
+	assert.Equal(t, path, plan.artifact.Path)
 }
 
 func TestPreflightRestorePendingStates(t *testing.T) {
@@ -491,8 +691,12 @@ func TestRestorePreflightAPIErrorsUseStablePendingMessages(t *testing.T) {
 
 func TestPreflightRestoreWaitsForPodIPBeforeTCPRestore(t *testing.T) {
 	pod := restorePod(map[string]string{snapshotv1alpha1.RestoreFromAnnotation: "snapshot-a"})
-	w := makeTestController(t, pod)
+	snapshot, content := readySnapshotObjects()
+	w := makeTestController(t, pod, snapshot, content)
 	w.config.CRIU.TcpEstablished = true
+	path, pathErr := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, string(content.UID), "main")
+	require.NoError(t, pathErr)
+	require.NoError(t, os.MkdirAll(path, 0o700))
 
 	artifact, err := w.preflightRestore(context.Background(), pod)
 
@@ -549,12 +753,12 @@ func TestContainerPollingDoesNotSetInProgressBeforeExecution(t *testing.T) {
 	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, string(content.UID), "main")
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path, 0o700))
-	artifact, err := w.preflightRestore(context.Background(), pod)
+	plan, err := w.preflightRestore(context.Background(), pod)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	containerID, requeue := w.resolveRestoreContainerID(ctx, pod, artifact, "inference/restore-worker")
+	containerID, requeue := w.resolveRestoreContainerID(ctx, pod, plan.mappings[0].Destination, "inference/restore-worker")
 
 	assert.Empty(t, containerID)
 	assert.False(t, requeue)
@@ -617,7 +821,7 @@ func TestPreflightRestoreTerminalStates(t *testing.T) {
 			mutatePod: func(target *corev1.Pod) {
 				target.Spec.Containers = []corev1.Container{{Name: "sidecar"}}
 			},
-			want: `has no container named "main"`,
+			want: `has no destination container named "main"`,
 		},
 	}
 	for name, tc := range tests {
@@ -753,11 +957,11 @@ func TestPreflightRestoreAllowsUnrelatedAnnotations(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path, 0o700))
 
-	artifact, err := w.preflightRestore(context.Background(), pod)
+	plan, err := w.preflightRestore(context.Background(), pod)
 	require.NoError(t, err)
-	require.NotNil(t, artifact)
-	assert.Equal(t, string(content.UID), artifact.ContentUID)
-	assert.Equal(t, "main", artifact.ContainerName)
+	require.NotNil(t, plan)
+	assert.Equal(t, string(content.UID), plan.artifact.ContentUID)
+	assert.Equal(t, "main", plan.artifact.SourceContainerName)
 }
 
 func TestReconcileRestorePodRunsPreflightOnce(t *testing.T) {
@@ -789,7 +993,7 @@ func TestReconcileRestorePodRunsPreflightOnce(t *testing.T) {
 	assert.Equal(t, 2, getCalls, "preflight should read PodSnapshot and PodSnapshotContent once")
 }
 
-func TestRestoreFinalizerIsPatchedBeforePreflight(t *testing.T) {
+func TestRestoreFinalizerIsNotAddedWhilePreflightIsPending(t *testing.T) {
 	pod := restorePod(map[string]string{snapshotv1alpha1.RestoreFromAnnotation: "missing-snapshot"})
 	w := makeTestController(t, pod)
 
@@ -797,18 +1001,16 @@ func TestRestoreFinalizerIsPatchedBeforePreflight(t *testing.T) {
 
 	live, err := w.clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.True(t, hasFinalizer(live, restorePodFinalizer))
+	assert.False(t, hasFinalizer(live, restorePodFinalizer))
 	for _, action := range w.clientset.(*fake.Clientset).Actions() {
 		if update, ok := action.(clientgotesting.UpdateAction); ok && update.GetResource().Resource == "pods" {
 			t.Fatal("restore finalizer must be patched, not updated")
 		}
 		patch, ok := action.(clientgotesting.PatchAction)
 		if ok && patch.GetSubresource() == "" {
-			assert.Equal(t, ktypes.MergePatchType, patch.GetPatchType())
-			return
+			t.Fatal("preflight-pending restore must not add a finalizer")
 		}
 	}
-	t.Fatal("no Pod finalizer patch found")
 }
 
 func TestRestoreFinalizerProtectsExecutionAndIsRemovedAfterSuccess(t *testing.T) {
@@ -819,8 +1021,10 @@ func TestRestoreFinalizerProtectsExecutionAndIsRemovedAfterSuccess(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path, 0o700))
 	restoreCalls := 0
-	w.restoreFn = func(ctx context.Context, _ snapshotruntime.Runtime, _ logr.Logger, _ executor.RestoreRequest, _ executor.RestoreMounter) (int, error) {
+	var request executor.RestoreRequest
+	w.restoreFn = func(ctx context.Context, _ snapshotruntime.Runtime, _ logr.Logger, got executor.RestoreRequest, _ executor.RestoreMounter) (int, error) {
 		restoreCalls++
+		request = got
 		live, getErr := w.clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		require.NoError(t, getErr)
 		assert.True(t, hasFinalizer(live, restorePodFinalizer))
@@ -830,6 +1034,8 @@ func TestRestoreFinalizerProtectsExecutionAndIsRemovedAfterSuccess(t *testing.T)
 	processQueuedRestorePod(t, w, pod)
 
 	assert.Equal(t, 1, restoreCalls)
+	assert.Equal(t, "main", request.ArtifactContainerName)
+	assert.Equal(t, "main", request.DestinationContainerName)
 	live, err := w.clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.False(t, hasFinalizer(live, restorePodFinalizer))
@@ -947,7 +1153,7 @@ func TestApplyRestoredConditionUsesServerSideApply(t *testing.T) {
 	patch := lastPodStatusApply(t, w)
 	assert.Equal(t, ktypes.ApplyPatchType, patch.GetPatchType())
 	payload := string(patch.GetPatch())
-	assert.Contains(t, payload, `"type":"snapshot/Restored"`)
+	assert.Contains(t, payload, `"type":"nvidia.com/Restored"`)
 	assert.Contains(t, payload, `"reason":"SnapshotPending"`)
 	assert.Contains(t, payload, `"message":"waiting"`)
 	assert.NotContains(t, payload, `"type":"Ready"`)
@@ -983,10 +1189,10 @@ func TestRunRestoreCleanupFailureStillCompletesRestore(t *testing.T) {
 	w := makeTestController(t, pod)
 	artifactPath := t.TempDir()
 	artifact := &restoreArtifact{
-		SnapshotName:  "snapshot-a",
-		ContentUID:    "content-uid",
-		ContainerName: "main",
-		Path:          artifactPath,
+		SnapshotName:        "snapshot-a",
+		ContentUID:          "content-uid",
+		SourceContainerName: "main",
+		Path:                artifactPath,
 	}
 
 	var request executor.RestoreRequest
@@ -1000,22 +1206,21 @@ func TestRunRestoreCleanupFailureStillCompletesRestore(t *testing.T) {
 		return nil
 	}
 
-	requeue, err := w.runRestore(context.Background(), pod, artifact, "ctr-abc", time.Time{})
+	err := w.runRestore(context.Background(), pod, artifact, "engine-0", "ctr-abc", time.Time{}, false)
 	require.NoError(t, err)
-	assert.False(t, requeue)
 	assert.Equal(t, "content-uid", request.ContentUID)
 	assert.Equal(t, w.config.Storage.BasePath, request.BasePath)
+	assert.Equal(t, "main", request.ArtifactContainerName)
+	assert.Equal(t, "engine-0", request.DestinationContainerName)
 	assert.Equal(t, 4242, sentinelPID)
 	assert.True(t, sawEventReason(w.clientset.(*fake.Clientset), "RestoreCleanupFailed"))
-
-	assert.Contains(t, string(lastPodStatusApply(t, w).GetPatch()), `"reason":"RestoreSucceeded"`)
 }
 
 func TestRunRestoreRetriesFullRestoreUntilFailureCleanupSucceeds(t *testing.T) {
 	pod := restorePod(map[string]string{snapshotv1alpha1.RestoreFromAnnotation: "snapshot-a"})
 	w := makeTestController(t, pod)
 	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
-	artifact := &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", ContainerName: "main"}
+	artifact := &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", SourceContainerName: "main"}
 	restoreCalls := 0
 	w.restoreFn = func(context.Context, snapshotruntime.Runtime, logr.Logger, executor.RestoreRequest, executor.RestoreMounter) (int, error) {
 		restoreCalls++
@@ -1030,47 +1235,35 @@ func TestRunRestoreRetriesFullRestoreUntilFailureCleanupSucceeds(t *testing.T) {
 		return nil
 	}
 
-	requeue, err := w.runRestore(context.Background(), pod, artifact, "ctr-abc", time.Time{})
+	err := w.runRestore(context.Background(), pod, artifact, "main", "ctr-abc", time.Time{}, true)
 	require.Error(t, err)
-	assert.True(t, requeue)
 	assert.Equal(t, 1, restoreCalls)
-	assert.False(t, w.restoreHandled(pod), "terminal failure must not be cached before cleanup succeeds")
 
-	requeue, err = w.runRestore(context.Background(), pod, artifact, "ctr-abc", time.Time{})
-	require.NoError(t, err)
-	assert.False(t, requeue)
+	err = w.runRestore(context.Background(), pod, artifact, "main", "ctr-abc", time.Time{}, false)
+	require.Error(t, err)
 	assert.Equal(t, 2, restoreCalls, "CRIU restore should retry when the previous cleanup did not finish")
-	assert.Contains(t, string(lastPodStatusApply(t, w).GetPatch()), `"reason":"RestoreFailed"`)
 }
 
-func TestRestoreFailureStatusErrorRemainsRetryableAfterCleanup(t *testing.T) {
+func TestRunRestoreFailureKillsPlaceholder(t *testing.T) {
 	pod := restorePod(map[string]string{snapshotv1alpha1.RestoreFromAnnotation: "snapshot-a"})
 	pod.Finalizers = []string{restorePodFinalizer}
 	w := makeTestController(t, pod)
 	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
-	artifact := &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", ContainerName: "main"}
+	artifact := &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", SourceContainerName: "main"}
 	restoreCalls := 0
 	w.restoreFn = func(context.Context, snapshotruntime.Runtime, logr.Logger, executor.RestoreRequest, executor.RestoreMounter) (int, error) {
 		restoreCalls++
 		return 0, errors.New("criu restore failed")
 	}
-	patches := 0
-	w.clientset.(*fake.Clientset).PrependReactor("patch", "pods", func(clientgotesting.Action) (bool, runtime.Object, error) {
-		patches++
-		if patches == 2 {
-			return true, nil, errors.New("terminal status failed")
-		}
-		return false, nil, nil
-	})
-
-	requeue, err := w.runRestore(context.Background(), pod, artifact, "ctr-abc", time.Time{})
+	signalCalls := 0
+	w.sendSignalFn = func(logr.Logger, int, syscall.Signal, string) error {
+		signalCalls++
+		return nil
+	}
+	err := w.runRestore(context.Background(), pod, artifact, "main", "ctr-abc", time.Time{}, true)
 	require.Error(t, err)
-	assert.True(t, requeue)
 	assert.Equal(t, 1, restoreCalls)
-	assert.False(t, w.restoreHandled(pod), "restore must remain retryable until terminal status is persisted")
-	live, getErr := w.clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-	require.NoError(t, getErr)
-	assert.True(t, hasFinalizer(live, restorePodFinalizer), "restore protection must remain until terminal status is persisted")
+	assert.Equal(t, 1, signalCalls)
 }
 
 func TestRunRestoreFinalizesExistingCompletionSentinelWithoutReplay(t *testing.T) {
@@ -1091,14 +1284,10 @@ func TestRunRestoreFinalizesExistingCompletionSentinelWithoutReplay(t *testing.T
 		t.Fatal("restore executor must not be replayed after the completion sentinel exists")
 		return 0, nil
 	}
-	artifact := &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", ContainerName: "main"}
+	artifact := &restoreArtifact{SnapshotName: "snapshot-a", ContentUID: "content-uid", SourceContainerName: "main"}
 
-	requeue, err := w.runRestore(context.Background(), pod, artifact, "ctr-abc", time.Time{})
+	err := w.runRestore(context.Background(), pod, artifact, "main", "ctr-abc", time.Time{}, true)
 	require.NoError(t, err)
-	assert.False(t, requeue)
-
-	assert.Contains(t, string(lastPodStatusApply(t, w).GetPatch()), `"reason":"RestoreSucceeded"`)
-	assert.True(t, sawEventReason(w.clientset.(*fake.Clientset), restoreSucceededReason))
 }
 
 func TestRestoreArtifactReady(t *testing.T) {

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -64,15 +64,16 @@ func cleanupRestoreMounts(ctx context.Context, mounts []restoreMount) error {
 
 // RestoreRequest holds the parameters for a restore operation.
 type RestoreRequest struct {
-	ContentUID    string
-	BasePath      string
-	ContainerID   string
-	StartedAt     time.Time
-	PodName       string
-	PodNamespace  string
-	TargetPodIP   string
-	ContainerName string
-	Clientset     kubernetes.Interface
+	ContentUID               string
+	BasePath                 string
+	ContainerID              string
+	StartedAt                time.Time
+	PodName                  string
+	PodNamespace             string
+	TargetPodIP              string
+	ArtifactContainerName    string
+	DestinationContainerName string
+	Clientset                kubernetes.Interface
 }
 
 // Restore performs external restore for the given request.
@@ -110,10 +111,11 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		"content_uid", req.ContentUID,
 		"pod", req.PodName,
 		"namespace", req.PodNamespace,
-		"container", req.ContainerName,
+		"source_container", req.ArtifactContainerName,
+		"destination_container", req.DestinationContainerName,
 	)
 
-	artifactPath, err := nsmount.ResolveArtifact(req.BasePath, req.ContentUID, req.ContainerName)
+	artifactPath, err := nsmount.ResolveArtifact(req.BasePath, req.ContentUID, req.ArtifactContainerName)
 	if err != nil {
 		return 0, fmt.Errorf("resolve checkpoint artifact: %w", err)
 	}
@@ -213,13 +215,13 @@ func validateRestoredProcess(targetRoot string, restoredPID int, log logr.Logger
 }
 
 func validateRestoreManifest(req RestoreRequest, manifest *types.CheckpointManifest) error {
-	if manifest.Artifact.ContentUID != req.ContentUID || manifest.Artifact.ContainerName != req.ContainerName {
+	if manifest.Artifact.ContentUID != req.ContentUID || manifest.Artifact.ContainerName != req.ArtifactContainerName {
 		return fmt.Errorf(
 			"checkpoint manifest artifact %s/%s does not match requested artifact %s/%s",
 			manifest.Artifact.ContentUID,
 			manifest.Artifact.ContainerName,
 			req.ContentUID,
-			req.ContainerName,
+			req.ArtifactContainerName,
 		)
 	}
 	return nil
@@ -239,7 +241,7 @@ func inspectRestore(
 	if req.ContainerID != "" {
 		placeholderPID, _, err = rt.ResolveContainer(ctx, req.ContainerID)
 	} else {
-		placeholderPID, _, err = rt.ResolveContainerByPod(ctx, req.PodName, req.PodNamespace, req.ContainerName)
+		placeholderPID, _, err = rt.ResolveContainerByPod(ctx, req.PodName, req.PodNamespace, req.DestinationContainerName)
 	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to resolve placeholder container: %w", err)
@@ -264,7 +266,7 @@ func inspectRestore(
 			req.Clientset,
 			req.PodName,
 			req.PodNamespace,
-			req.ContainerName,
+			req.DestinationContainerName,
 			snapshotruntime.HostProcPath,
 			placeholderPID,
 			log,
@@ -273,7 +275,7 @@ func inspectRestore(
 			return nil, 0, fmt.Errorf("failed to get target GPU UUIDs: %w", err)
 		}
 		if len(targetGPUUUIDs) == 0 {
-			return nil, 0, fmt.Errorf("missing target GPU UUIDs for %s/%s container %s", req.PodNamespace, req.PodName, req.ContainerName)
+			return nil, 0, fmt.Errorf("missing target GPU UUIDs for %s/%s container %s", req.PodNamespace, req.PodName, req.DestinationContainerName)
 		}
 		cudaDeviceMap, err = cuda.BuildDeviceMap(manifest.CUDA.SourceGPUUUIDs, targetGPUUUIDs, log)
 		gpuDeviceMapDuration = time.Since(gpuStart)

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -28,8 +28,9 @@ func (m testMountPoint) NsFd() *os.File                { return nil }
 var _ nsmount.MountPoint = testMountPoint{}
 
 type restoreFakeRuntime struct {
-	resolvedID      string
-	resolveByPodHit bool
+	resolvedID             string
+	resolvedByPodContainer string
+	resolveByPodHit        bool
 }
 
 func (r *restoreFakeRuntime) ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error) {
@@ -43,6 +44,7 @@ func (r *restoreFakeRuntime) ResolveContainerIDByPod(ctx context.Context, pod, n
 
 func (r *restoreFakeRuntime) ResolveContainerByPod(ctx context.Context, pod, ns, ctr string) (int, *specs.Spec, error) {
 	r.resolveByPodHit = true
+	r.resolvedByPodContainer = ctr
 	return 0, nil, errors.New("pod lookup should not be used")
 }
 
@@ -62,11 +64,12 @@ func TestInspectRestoreUsesContainerIDWhenProvided(t *testing.T) {
 		rt,
 		testr.New(t),
 		RestoreRequest{
-			ContentUID:    "content-uid-123",
-			ContainerID:   "placeholder-id",
-			PodName:       "virtual-pod-name",
-			PodNamespace:  "default",
-			ContainerName: "main",
+			ContentUID:               "content-uid-123",
+			ContainerID:              "placeholder-id",
+			PodName:                  "virtual-pod-name",
+			PodNamespace:             "default",
+			ArtifactContainerName:    "main",
+			DestinationContainerName: "engine-0",
 		},
 		manifest,
 	)
@@ -78,6 +81,36 @@ func TestInspectRestoreUsesContainerIDWhenProvided(t *testing.T) {
 	}
 	if rt.resolveByPodHit {
 		t.Fatal("ResolveContainerByPod should not be used when ContainerID is provided")
+	}
+}
+
+func TestInspectRestoreUsesDestinationNameForPodLookup(t *testing.T) {
+	manifest := types.NewCheckpointManifest(
+		"content-uid-123",
+		"main",
+		types.CRIUDumpManifest{},
+		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil),
+		types.OverlayManifest{},
+	)
+	rt := &restoreFakeRuntime{}
+	_, _, err := inspectRestore(
+		context.Background(),
+		rt,
+		testr.New(t),
+		RestoreRequest{
+			ContentUID:               "content-uid-123",
+			PodName:                  "virtual-pod-name",
+			PodNamespace:             "default",
+			ArtifactContainerName:    "main",
+			DestinationContainerName: "engine-0",
+		},
+		manifest,
+	)
+	if err == nil {
+		t.Fatal("inspectRestore should report the fake pod lookup error")
+	}
+	if rt.resolvedByPodContainer != "engine-0" {
+		t.Fatalf("ResolveContainerByPod called with container %q, want engine-0", rt.resolvedByPodContainer)
 	}
 }
 
@@ -107,15 +140,15 @@ func TestValidateRestoreManifest(t *testing.T) {
 		req  RestoreRequest
 		want string
 	}{
-		{name: "matching identity", req: RestoreRequest{ContentUID: "content-uid-123", ContainerName: "main"}},
+		{name: "matching identity", req: RestoreRequest{ContentUID: "content-uid-123", ArtifactContainerName: "main", DestinationContainerName: "engine-0"}},
 		{
 			name: "content UID mismatch",
-			req:  RestoreRequest{ContentUID: "other", ContainerName: "main"},
+			req:  RestoreRequest{ContentUID: "other", ArtifactContainerName: "main", DestinationContainerName: "engine-0"},
 			want: "does not match requested artifact",
 		},
 		{
 			name: "container mismatch",
-			req:  RestoreRequest{ContentUID: "content-uid-123", ContainerName: "worker"},
+			req:  RestoreRequest{ContentUID: "content-uid-123", ArtifactContainerName: "worker", DestinationContainerName: "engine-0"},
 			want: "does not match requested artifact",
 		},
 	} {

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -22,11 +22,17 @@ const (
 	SnapshotNodeLabel = "nvidia.com/snapshot-node"
 
 	// RestoreFromAnnotation names the PodSnapshot to restore in the pod's
-	// namespace. Other annotations are ignored by the snapshot protocol.
+	// namespace.
 	RestoreFromAnnotation = "nvidia.com/restore-from"
 
+	// RestoreContainerMapAnnotation optionally maps the single captured source
+	// container to one or more restore destinations. Its value is a comma-separated
+	// list of source=destination pairs. When absent, restore uses the captured
+	// container name as the destination.
+	RestoreContainerMapAnnotation = "nvidia.com/restore-container-map"
+
 	// RestoredCondition is the Pod status condition owned by the node agent.
-	RestoredCondition = "snapshot/Restored"
+	RestoredCondition = "nvidia.com/Restored"
 
 	CheckpointVolumeName           = "checkpoint-storage"
 	DefaultSeccompLocalhostProfile = "profiles/block-iouring.json"

--- a/api/v1alpha1/protocol.go
+++ b/api/v1alpha1/protocol.go
@@ -10,8 +10,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+// RestoreContainerMapping maps the one captured source container to a restore
+// destination in the target Pod.
+// +kubebuilder:object:generate=false
+type RestoreContainerMapping struct {
+	Source      string
+	Destination string
+}
+
 // GetRestoreFromSnapshotName returns the same-namespace PodSnapshot named by
-// the restore-from annotation. All other annotations are inert metadata.
+// the restore-from annotation.
 func GetRestoreFromSnapshotName(annotations map[string]string) (string, error) {
 	snapshotName := strings.TrimSpace(annotations[RestoreFromAnnotation])
 	if snapshotName == "" {
@@ -21,4 +29,58 @@ func GetRestoreFromSnapshotName(annotations map[string]string) (string, error) {
 		return "", fmt.Errorf("%s value %q is not a valid PodSnapshot name: %s", RestoreFromAnnotation, snapshotName, strings.Join(errs, "; "))
 	}
 	return snapshotName, nil
+}
+
+// RestoreContainerMappingsFromAnnotations parses the optional flat restore
+// mapping. Absence keeps the existing same-name restore behavior.
+func RestoreContainerMappingsFromAnnotations(annotations map[string]string, capturedSource string) ([]RestoreContainerMapping, error) {
+	raw, ok := annotations[RestoreContainerMapAnnotation]
+	if !ok {
+		capturedSource = strings.TrimSpace(capturedSource)
+		return []RestoreContainerMapping{{Source: capturedSource, Destination: capturedSource}}, nil
+	}
+	parts := strings.Split(strings.TrimSpace(raw), ",")
+	mappings := make([]RestoreContainerMapping, 0, len(parts))
+	for _, part := range parts {
+		pair := strings.Split(part, "=")
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("invalid %s entry %q: expected source=destination", RestoreContainerMapAnnotation, strings.TrimSpace(part))
+		}
+		mappings = append(mappings, RestoreContainerMapping{
+			Source:      strings.TrimSpace(pair[0]),
+			Destination: strings.TrimSpace(pair[1]),
+		})
+	}
+	return mappings, nil
+}
+
+// ValidateRestoreContainerMappings enforces the one-source-to-many-destinations
+// contract after parsing.
+func ValidateRestoreContainerMappings(mappings []RestoreContainerMapping, capturedSource string) error {
+	capturedSource = strings.TrimSpace(capturedSource)
+	if errs := validation.IsDNS1123Label(capturedSource); len(errs) != 0 {
+		return fmt.Errorf("captured source container %q is invalid: %s", capturedSource, strings.Join(errs, "; "))
+	}
+	if len(mappings) == 0 {
+		return fmt.Errorf("restore container mapping must contain at least one destination")
+	}
+	destinations := make(map[string]struct{}, len(mappings))
+	for _, mapping := range mappings {
+		source := mapping.Source
+		destination := mapping.Destination
+		if errs := validation.IsDNS1123Label(source); len(errs) != 0 {
+			return fmt.Errorf("invalid restore source container %q: %s", source, strings.Join(errs, "; "))
+		}
+		if errs := validation.IsDNS1123Label(destination); len(errs) != 0 {
+			return fmt.Errorf("invalid restore destination container %q: %s", destination, strings.Join(errs, "; "))
+		}
+		if source != capturedSource {
+			return fmt.Errorf("restore source container %q does not match captured container %q", source, capturedSource)
+		}
+		if _, duplicate := destinations[destination]; duplicate {
+			return fmt.Errorf("duplicate restore destination container %q", destination)
+		}
+		destinations[destination] = struct{}{}
+	}
+	return nil
 }

--- a/api/v1alpha1/protocol_test.go
+++ b/api/v1alpha1/protocol_test.go
@@ -4,6 +4,7 @@
 package v1alpha1
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -27,6 +28,81 @@ func TestGetRestoreFromSnapshotName(t *testing.T) {
 			_, err := GetRestoreFromSnapshotName(annotations)
 			if err == nil {
 				t.Fatal("GetRestoreFromSnapshotName() unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestRestoreContainerMappingsFromAnnotations(t *testing.T) {
+	t.Run("defaults to captured container", func(t *testing.T) {
+		got, err := RestoreContainerMappingsFromAnnotations(nil, "main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []RestoreContainerMapping{{Source: "main", Destination: "main"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("mappings = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("parses one source to many destinations", func(t *testing.T) {
+		got, err := RestoreContainerMappingsFromAnnotations(map[string]string{
+			RestoreContainerMapAnnotation: " main = engine-0,main=engine-1 ",
+		}, "main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []RestoreContainerMapping{
+			{Source: "main", Destination: "engine-0"},
+			{Source: "main", Destination: "engine-1"},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("mappings = %#v, want %#v", got, want)
+		}
+	})
+
+	for name, value := range map[string]string{
+		"empty":           "",
+		"missing equals":  "main",
+		"too many equals": "main=engine=0",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := RestoreContainerMappingsFromAnnotations(map[string]string{
+				RestoreContainerMapAnnotation: value,
+			}, "main")
+			if err == nil {
+				t.Fatal("RestoreContainerMappingsFromAnnotations() unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestValidateRestoreContainerMappings(t *testing.T) {
+	valid := []RestoreContainerMapping{
+		{Source: "main", Destination: "engine-0"},
+		{Source: "main", Destination: "engine-1"},
+	}
+	if err := ValidateRestoreContainerMappings(valid, "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		mappings []RestoreContainerMapping
+		source   string
+	}{
+		"empty":                 {source: "main"},
+		"empty source":          {mappings: []RestoreContainerMapping{{Source: "", Destination: "engine-0"}}, source: "main"},
+		"empty destination":     {mappings: []RestoreContainerMapping{{Source: "main", Destination: ""}}, source: "main"},
+		"invalid source":        {mappings: []RestoreContainerMapping{{Source: "Main", Destination: "engine-0"}}, source: "main"},
+		"invalid destination":   {mappings: []RestoreContainerMapping{{Source: "main", Destination: "Engine_0"}}, source: "main"},
+		"source mismatch":       {mappings: []RestoreContainerMapping{{Source: "worker", Destination: "engine-0"}}, source: "main"},
+		"multiple sources":      {mappings: []RestoreContainerMapping{{Source: "main", Destination: "engine-0"}, {Source: "worker", Destination: "engine-1"}}, source: "main"},
+		"duplicate destination": {mappings: []RestoreContainerMapping{{Source: "main", Destination: "engine-0"}, {Source: "main", Destination: "engine-0"}}, source: "main"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateRestoreContainerMappings(test.mappings, test.source); err == nil {
+				t.Fatal("ValidateRestoreContainerMappings() unexpectedly succeeded")
 			}
 		})
 	}

--- a/e2e/snapshot_e2e/k8s.py
+++ b/e2e/snapshot_e2e/k8s.py
@@ -97,12 +97,19 @@ def pod_logs(namespace: str, name: str, *, tail_lines: int = 120) -> str:
         return f"<logs unavailable: {api_error_detail(exc)}>"
 
 
-def exec_command(namespace: str, pod: str, command: str) -> str:
+def exec_command(
+    namespace: str,
+    pod: str,
+    command: str,
+    *,
+    container: str | None = None,
+) -> str:
     return stream(
         client.CoreV1Api().connect_get_namespaced_pod_exec,
         pod,
         namespace,
         command=["/bin/bash", "-lc", command],
+        container=container,
         stderr=True,
         stdin=False,
         stdout=True,

--- a/e2e/snapshot_e2e/lifecycle.py
+++ b/e2e/snapshot_e2e/lifecycle.py
@@ -20,6 +20,7 @@ from snapshot_e2e.workloads import RESTORE_DONE
 from snapshot_e2e.workloads import RESTORE_INITIAL_TOKEN
 from snapshot_e2e.workloads import SOURCE_READY
 from snapshot_e2e.workloads import TestRun
+from snapshot_e2e.workloads import multi_restore_pod
 from snapshot_e2e.workloads import restore_pod
 from snapshot_e2e.workloads import source_pod
 
@@ -289,12 +290,14 @@ def wait_for_restored_condition(
 ) -> client.V1Pod:
     def check() -> client.V1Pod | None:
         pod = k8s.read_pod(namespace, pod_name)
-        restored = pod_condition(pod, "snapshot/Restored")
+        restored = pod_condition(pod, "nvidia.com/Restored")
         if restored and restored.status == status and restored.reason == reason:
             return pod
-        if reason != "RestoreFailed" and restored and restored.reason == "RestoreFailed":
+        terminal_reasons = {"RestoreSucceeded", "RestorePartiallySucceeded", "RestoreFailed"}
+        if restored and restored.reason in terminal_reasons and restored.reason != reason:
             raise AssertionError(
-                f"restore failed for {namespace}/{pod_name}: {restored.message}"
+                f"restore reached unexpected terminal condition for "
+                f"{namespace}/{pod_name}: {restored.reason}: {restored.message}"
             )
         return None
 
@@ -303,11 +306,11 @@ def wait_for_restored_condition(
             pod = k8s.read_pod(namespace, pod_name)
         except ApiException as exc:
             return f"api_error={k8s.api_error_detail(exc)}"
-        restored = pod_condition(pod, "snapshot/Restored")
-        return f"snapshot/Restored={restored or '<unset>'}"
+        restored = pod_condition(pod, "nvidia.com/Restored")
+        return f"nvidia.com/Restored={restored or '<unset>'}"
 
     return wait_for(
-        f"snapshot/Restored={status}/{reason} on {namespace}/{pod_name}",
+        f"nvidia.com/Restored={status}/{reason} on {namespace}/{pod_name}",
         check,
         timeout,
         detail=detail,
@@ -387,6 +390,7 @@ def assert_restored_state(
     restore_token: str,
     checkpoint_observations: int,
     gpu: bool,
+    container: str | None = None,
 ) -> str:
     expected_gpu = source_token if gpu else "disabled"
     command = f"""
@@ -411,7 +415,7 @@ def assert_restored_state(
     test "$before" -ge "{checkpoint_observations}"
     test "$after" -gt "$before"
     """
-    return k8s.exec_command(namespace, pod, command)
+    return k8s.exec_command(namespace, pod, command, container=container)
 
 
 def debug_dump(config: k8s.E2EConfig, run: TestRun) -> None:

--- a/e2e/snapshot_e2e/workloads.py
+++ b/e2e/snapshot_e2e/workloads.py
@@ -126,6 +126,67 @@ def restore_pod(
     }
 
 
+def multi_restore_pod(
+    *,
+    config: k8s.E2EConfig,
+    run: TestRun,
+    source_node: str,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    destinations = ("engine-0", "engine-1")
+    restore_tokens = {
+        destination: f"{run.restore_token}-{destination}"
+        for destination in destinations
+    }
+    spec = base_pod_spec(config, run, restore_command(run.image, False), False)
+    spec["securityContext"] = {
+        "seccompProfile": {
+            "type": "Localhost",
+            "localhostProfile": "profiles/block-iouring.json",
+        }
+    }
+    template = spec["containers"][0]
+    containers = []
+    for destination in destinations:
+        container = {
+            **template,
+            "name": destination,
+            "volumeMounts": [
+                {
+                    "name": "snapshot-control",
+                    "mountPath": CONTROL_DIR,
+                    "subPath": destination,
+                }
+            ],
+            "env": [
+                {"name": "DYN_SNAPSHOT_RESTORE_STANDBY", "value": "1"},
+                {"name": "SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
+                {"name": RESTORE_TOKEN_ENV, "value": restore_tokens[destination]},
+            ],
+            "startupProbe": {
+                "exec": {"command": ["/bin/bash", "-lc", f"test -f {RESTORE_DONE}"]},
+                "periodSeconds": 1,
+                "failureThreshold": 1200,
+            },
+        }
+        containers.append(container)
+    spec["containers"] = containers
+    spec["affinity"] = same_node_affinity(source_node)
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": run.restore_pod,
+            "namespace": config.namespace,
+            "labels": {**run.labels},
+            "annotations": {
+                "nvidia.com/restore-from": run.snapshot_name,
+                "nvidia.com/restore-container-map": "main=engine-0,main=engine-1",
+            },
+        },
+        "spec": spec,
+    }, restore_tokens
+
+
 def base_pod_spec(
     config: k8s.E2EConfig,
     run: TestRun,

--- a/e2e/tests/test_snapshot_lifecycle.py
+++ b/e2e/tests/test_snapshot_lifecycle.py
@@ -120,6 +120,78 @@ def test_successful_restore_recovers_cpu_gpu_and_fs_from_snapshot(
         raise
 
 
+@pytest.mark.snapshot_success
+def test_one_cpu_snapshot_restores_into_two_containers(
+    config: k8s.E2EConfig,
+    run: snap.TestRun,
+) -> None:
+    try:
+        source, source_node = create_ready_source(config, run, gpu=False)
+        checkpoint_observations = snap.wait_for_state_observations(
+            config.namespace,
+            run.source_pod,
+            run.source_token,
+            gpu=False,
+            minimum=2,
+        )
+        snap.create_podsnapshot(
+            config.namespace,
+            run.snapshot_name,
+            run.source_pod,
+            source.metadata.uid,
+        )
+        snap.wait_for_snapshot_ready(config.namespace, run.snapshot_name)
+
+        k8s.delete_pod(config.namespace, run.source_pod)
+        snap.wait_for_pod_deleted(config.namespace, run.source_pod)
+
+        restore_pod, restore_tokens = snap.multi_restore_pod(
+            config=config,
+            run=run,
+            source_node=source_node,
+        )
+        k8s.create_pod(restore_pod)
+        restored_pod = snap.wait_for_restored_condition(
+            config.namespace, run.restore_pod, "True", "RestoreSucceeded"
+        )
+        assert snapshot_annotations(restored_pod) == {
+            "nvidia.com/restore-from": run.snapshot_name,
+            "nvidia.com/restore-container-map": "main=engine-0,main=engine-1",
+        }
+        snap.wait_for_pod_ready(config.namespace, run.restore_pod, timeout=300)
+
+        for destination in ("engine-0", "engine-1"):
+            output = snap.assert_restored_state(
+                config.namespace,
+                run.restore_pod,
+                source_token=run.source_token,
+                restore_token=restore_tokens[destination],
+                checkpoint_observations=checkpoint_observations,
+                gpu=False,
+                container=destination,
+            )
+            assert f"source_token={run.source_token}" in output
+            assert f"restore_token={restore_tokens[destination]}" in output
+
+        assert_restore_events(
+            config.namespace,
+            run.restore_pod,
+            {"RestoreRequested", "RestoreSucceeded"},
+        )
+        requested_messages = [
+            event.message or ""
+            for event in k8s.list_events(config.namespace)
+            if event.involved_object
+            and event.involved_object.name == run.restore_pod
+            and event.reason == "RestoreRequested"
+        ]
+        for destination in ("engine-0", "engine-1"):
+            assert any(destination in message for message in requested_messages)
+    except Exception:
+        snap.debug_dump(config, run)
+        raise
+
+
 @pytest.mark.snapshot_failure
 @pytest.mark.gpu
 def test_failed_restore_gpu_checkpoint_into_non_gpu_target(
@@ -153,7 +225,7 @@ def test_failed_restore_gpu_checkpoint_into_non_gpu_target(
         assert_restore_events(
             config.namespace,
             run.restore_pod,
-            {"RestoreFailed", "RestoreAlreadyFailed"},
+            {"RestoreFailed"},
         )
     except Exception:
         snap.debug_dump(config, run)

--- a/operator/cmd/snapshotctl/README.md
+++ b/operator/cmd/snapshotctl/README.md
@@ -65,19 +65,22 @@ Checkpoint targets are part of the `PodSnapshot` request, not pod annotations.
 `snapshotctl checkpoint` requires `--container <name>` and records that one
 container in `PodSnapshot.spec.source.podRef.containers`.
 
-Restore uses the single container captured by that `PodSnapshot`. The restore
-manifest must contain a container with the same name. `snapshotctl` shapes it
-for restore and adds only this snapshot-owned annotation:
+Restore uses the single container captured by that `PodSnapshot`. By default,
+the restore manifest must contain a container with the same name. To clone the
+same checkpoint into multiple containers, add a flat source-to-destination map:
 
 ```yaml
 metadata:
   annotations:
     nvidia.com/restore-from: worker-snapshot
+    nvidia.com/restore-container-map: main=engine-0,main=engine-1
 ```
 
-Capture pods must have no snapshot-owned annotations. Restore pods must have
-exactly one: `nvidia.com/restore-from`. Unrelated platform annotations are
-preserved.
+Every mapping source must match the one container captured by the
+`PodSnapshot`, and every destination must exist in the restore manifest.
+`snapshotctl` validates the full map before creating the Pod. Without the map,
+same-name single-container restore remains unchanged. Unrelated platform
+annotations are preserved.
 
 ## Commands
 
@@ -106,5 +109,8 @@ snapshotctl restore \
 - `restore` returns after the restore request is submitted; it does not wait for completion
 - observe restore progress through the pod's `Restored` status condition,
   readiness, events, and agent logs
+- `RestoreSucceeded` means every destination restored, `RestorePartiallySucceeded`
+  means only some restored, and `RestoreFailed` means none restored
+- partial and failed outcomes are terminal; retry them with a new restore Pod
 - `snapshotctl` is useful for debugging and lower-level validation, but it does
   not replace the operator-managed checkpoint flow

--- a/operator/cmd/snapshotctl/restore.go
+++ b/operator/cmd/snapshotctl/restore.go
@@ -54,7 +54,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 	}, snapshotprotocol.PodOptions{
 		Namespace:       namespace,
 		SnapshotName:    snapshotName,
-		TargetContainer: containers[0],
+		SourceContainer: containers[0],
 		SeccompProfile:  snapshotv1alpha1.DefaultSeccompLocalhostProfile,
 	})
 	if err != nil {

--- a/operator/internal/protocol/checkpoint.go
+++ b/operator/internal/protocol/checkpoint.go
@@ -27,8 +27,13 @@ type CheckpointJobOptions struct {
 
 func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOptions) (*batchv1.Job, error) {
 	podTemplate = podTemplate.DeepCopy()
-	if _, restoreRequested := podTemplate.Annotations[snapshotv1alpha1.RestoreFromAnnotation]; restoreRequested {
-		return nil, fmt.Errorf("checkpoint job pod template must not set %s", snapshotv1alpha1.RestoreFromAnnotation)
+	for _, annotation := range []string{
+		snapshotv1alpha1.RestoreFromAnnotation,
+		snapshotv1alpha1.RestoreContainerMapAnnotation,
+	} {
+		if _, restoreRequested := podTemplate.Annotations[annotation]; restoreRequested {
+			return nil, fmt.Errorf("checkpoint job pod template must not set %s", annotation)
+		}
 	}
 	if podTemplate.Labels == nil {
 		podTemplate.Labels = map[string]string{}

--- a/operator/internal/protocol/checkpoint_job_test.go
+++ b/operator/internal/protocol/checkpoint_job_test.go
@@ -263,12 +263,19 @@ func TestNewCheckpointJobRequiresTarget(t *testing.T) {
 	}
 }
 
-func TestNewCheckpointJobRejectsRestoreAnnotation(t *testing.T) {
-	for _, value := range []string{"snapshot-a", ""} {
-		t.Run(value, func(t *testing.T) {
+func TestNewCheckpointJobRejectsRestoreAnnotations(t *testing.T) {
+	for _, annotation := range []string{
+		snapshotv1alpha1.RestoreFromAnnotation,
+		snapshotv1alpha1.RestoreContainerMapAnnotation,
+	} {
+		t.Run(annotation, func(t *testing.T) {
+			value := ""
+			if annotation == snapshotv1alpha1.RestoreFromAnnotation {
+				value = "snapshot-a"
+			}
 			_, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{snapshotv1alpha1.RestoreFromAnnotation: value},
+					Annotations: map[string]string{annotation: value},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "main", Command: []string{"python3"}}},
@@ -279,7 +286,7 @@ func TestNewCheckpointJobRejectsRestoreAnnotation(t *testing.T) {
 				Name:            "test-job",
 			})
 
-			if err == nil || !strings.Contains(err.Error(), snapshotv1alpha1.RestoreFromAnnotation) {
+			if err == nil || !strings.Contains(err.Error(), annotation) {
 				t.Fatalf("expected restore annotation rejection, got %v", err)
 			}
 		})

--- a/operator/internal/protocol/restore.go
+++ b/operator/internal/protocol/restore.go
@@ -15,7 +15,7 @@ import (
 type PodOptions struct {
 	Namespace       string
 	SnapshotName    string
-	TargetContainer string
+	SourceContainer string
 	SeccompProfile  string
 }
 
@@ -38,7 +38,14 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) (*corev1.Pod, error) {
 	if _, err := snapshotv1alpha1.GetRestoreFromSnapshotName(pod.Annotations); err != nil {
 		return nil, err
 	}
-	if err := PrepareRestorePodSpec(&pod.Spec, opts.TargetContainer, opts.SeccompProfile, true); err != nil {
+	mappings, err := snapshotv1alpha1.RestoreContainerMappingsFromAnnotations(pod.Annotations, opts.SourceContainer)
+	if err != nil {
+		return nil, err
+	}
+	if err := snapshotv1alpha1.ValidateRestoreContainerMappings(mappings, opts.SourceContainer); err != nil {
+		return nil, err
+	}
+	if err := PrepareRestorePodSpec(&pod.Spec, mappings, opts.SeccompProfile, true); err != nil {
 		return nil, err
 	}
 	pod.Namespace = opts.Namespace
@@ -53,28 +60,33 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) (*corev1.Pod, error) {
 // still provide their own inert restore command.
 func PrepareRestorePodSpec(
 	podSpec *corev1.PodSpec,
-	targetContainer string,
+	mappings []snapshotv1alpha1.RestoreContainerMapping,
 	seccompProfile string,
 	isCheckpointReady bool,
 ) error {
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	if targetContainer == "" {
+	if len(mappings) == 0 {
 		return fmt.Errorf("restore target container is required")
 	}
-	EnsureLocalhostSeccompProfile(podSpec, seccompProfile)
-	for _, name := range []string{targetContainer} {
+	containers := make([]*corev1.Container, 0, len(mappings))
+	for _, mapping := range mappings {
 		var container *corev1.Container
 		for i := range podSpec.Containers {
-			if podSpec.Containers[i].Name == name {
+			if podSpec.Containers[i].Name == mapping.Destination {
 				container = &podSpec.Containers[i]
 				break
 			}
 		}
 		if container == nil {
-			return fmt.Errorf("restore target container %q not found in pod spec", name)
+			return fmt.Errorf("restore destination container %q not found in pod spec", mapping.Destination)
 		}
+		containers = append(containers, container)
+	}
+
+	EnsureLocalhostSeccompProfile(podSpec, seccompProfile)
+	for _, container := range containers {
 		EnsureControlVolume(podSpec, container)
 		if isCheckpointReady {
 			// Standby-aware entrypoints honor this env by writing restore
@@ -139,13 +151,13 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 // ValidateRestorePodSpec verifies the target containers are restore-shaped.
 func ValidateRestorePodSpec(
 	podSpec *corev1.PodSpec,
-	targetContainer string,
+	mappings []snapshotv1alpha1.RestoreContainerMapping,
 	seccompProfile string,
 ) error {
 	if podSpec == nil {
 		return fmt.Errorf("pod spec is nil")
 	}
-	if targetContainer == "" {
+	if len(mappings) == 0 {
 		return fmt.Errorf("restore target container is required")
 	}
 	hasControlVolume := false
@@ -158,7 +170,8 @@ func ValidateRestorePodSpec(
 	if !hasControlVolume {
 		return fmt.Errorf("missing %s emptyDir volume; add it via snapshotprotocol.EnsureControlVolume", snapshotv1alpha1.SnapshotControlVolumeName)
 	}
-	for _, name := range []string{targetContainer} {
+	for _, mapping := range mappings {
+		name := mapping.Destination
 		var container *corev1.Container
 		for i := range podSpec.Containers {
 			if podSpec.Containers[i].Name == name {

--- a/operator/internal/protocol/restore_test.go
+++ b/operator/internal/protocol/restore_test.go
@@ -38,7 +38,7 @@ func TestNewRestorePodSetsRestoreFromAnnotation(t *testing.T) {
 	pod, err := NewRestorePod(restorePodFixture(), PodOptions{
 		Namespace:       "inference",
 		SnapshotName:    "snapshot-a",
-		TargetContainer: "main",
+		SourceContainer: "main",
 		SeccompProfile:  snapshotv1alpha1.DefaultSeccompLocalhostProfile,
 	})
 	require.NoError(t, err)
@@ -46,6 +46,7 @@ func TestNewRestorePodSetsRestoreFromAnnotation(t *testing.T) {
 	assert.Equal(t, "inference", pod.Namespace)
 	assert.Equal(t, corev1.RestartPolicyNever, pod.Spec.RestartPolicy)
 	assert.Equal(t, "snapshot-a", pod.Annotations[snapshotv1alpha1.RestoreFromAnnotation])
+	assert.NotContains(t, pod.Annotations, snapshotv1alpha1.RestoreContainerMapAnnotation)
 	assert.Equal(t, "inference", pod.Annotations["example.com/team"])
 
 	main := &pod.Spec.Containers[0]
@@ -60,21 +61,21 @@ func TestNewRestorePodSetsRestoreFromAnnotation(t *testing.T) {
 	assert.Empty(t, sidecar.VolumeMounts)
 	assert.Empty(t, sidecar.Env)
 	assert.Nil(t, sidecar.StartupProbe)
-	require.NoError(t, ValidateRestorePodSpec(&pod.Spec, "main", snapshotv1alpha1.DefaultSeccompLocalhostProfile))
+	require.NoError(t, ValidateRestorePodSpec(&pod.Spec, restoreMappings("main"), snapshotv1alpha1.DefaultSeccompLocalhostProfile))
 }
 
 func TestPrepareRestorePodSpecRequiresCapturedContainer(t *testing.T) {
 	spec := restorePodFixture().Spec
-	require.Error(t, PrepareRestorePodSpec(&spec, "", "", true))
-	err := PrepareRestorePodSpec(&spec, "missing", "", true)
+	require.Error(t, PrepareRestorePodSpec(&spec, nil, "", true))
+	err := PrepareRestorePodSpec(&spec, restoreMappings("missing"), "", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `container "missing"`)
 }
 
 func TestPrepareRestorePodSpecIsIdempotent(t *testing.T) {
 	spec := restorePodFixture().Spec
-	require.NoError(t, PrepareRestorePodSpec(&spec, "main", "", true))
-	require.NoError(t, PrepareRestorePodSpec(&spec, "main", "", true))
+	require.NoError(t, PrepareRestorePodSpec(&spec, restoreMappings("main"), "", true))
+	require.NoError(t, PrepareRestorePodSpec(&spec, restoreMappings("main"), "", true))
 
 	main := &spec.Containers[0]
 	assert.Len(t, spec.Volumes, 1)
@@ -90,7 +91,7 @@ func TestPrepareRestorePodSpecReusesExistingProbe(t *testing.T) {
 		PeriodSeconds:       10,
 		FailureThreshold:    3,
 	}
-	require.NoError(t, PrepareRestorePodSpec(&spec, "main", "", true))
+	require.NoError(t, PrepareRestorePodSpec(&spec, restoreMappings("main"), "", true))
 	startup := spec.Containers[0].StartupProbe
 	require.NotNil(t, startup)
 	require.NotNil(t, startup.HTTPGet)
@@ -102,7 +103,7 @@ func TestPrepareRestorePodSpecReusesExistingProbe(t *testing.T) {
 
 func TestValidateRestorePodSpecFailures(t *testing.T) {
 	spec := restorePodFixture().Spec
-	require.NoError(t, PrepareRestorePodSpec(&spec, "main", snapshotv1alpha1.DefaultSeccompLocalhostProfile, true))
+	require.NoError(t, PrepareRestorePodSpec(&spec, restoreMappings("main"), snapshotv1alpha1.DefaultSeccompLocalhostProfile, true))
 
 	tests := map[string]func(*corev1.PodSpec){
 		"volume": func(s *corev1.PodSpec) { s.Volumes = nil },
@@ -119,9 +120,46 @@ func TestValidateRestorePodSpecFailures(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			bad := spec.DeepCopy()
 			mutate(bad)
-			require.Error(t, ValidateRestorePodSpec(bad, "main", snapshotv1alpha1.DefaultSeccompLocalhostProfile))
+			require.Error(t, ValidateRestorePodSpec(bad, restoreMappings("main"), snapshotv1alpha1.DefaultSeccompLocalhostProfile))
 		})
 	}
+}
+
+func TestNewRestorePodShapesMappedDestinations(t *testing.T) {
+	pod := restorePodFixture()
+	pod.Annotations[snapshotv1alpha1.RestoreContainerMapAnnotation] = "main=main,main=sidecar"
+	restored, err := NewRestorePod(pod, PodOptions{
+		Namespace:       "inference",
+		SnapshotName:    "snapshot-a",
+		SourceContainer: "main",
+	})
+	require.NoError(t, err)
+
+	for i, name := range []string{"main", "sidecar"} {
+		container := &restored.Spec.Containers[i]
+		require.Equal(t, name, container.Name)
+		require.Len(t, container.VolumeMounts, 1)
+		assert.Equal(t, name, container.VolumeMounts[0].SubPath)
+		assert.Equal(t, "1", envValue(container.Env, RestoreStandbyModeEnv))
+		require.NotNil(t, container.StartupProbe)
+	}
+}
+
+func TestPrepareRestorePodSpecValidatesBeforeMutation(t *testing.T) {
+	spec := restorePodFixture().Spec
+	err := PrepareRestorePodSpec(&spec, restoreMappings("main", "missing"), snapshotv1alpha1.DefaultSeccompLocalhostProfile, true)
+	require.Error(t, err)
+	assert.Nil(t, spec.SecurityContext)
+	assert.Empty(t, spec.Volumes)
+	assert.Empty(t, spec.Containers[0].VolumeMounts)
+}
+
+func restoreMappings(destinations ...string) []snapshotv1alpha1.RestoreContainerMapping {
+	mappings := make([]snapshotv1alpha1.RestoreContainerMapping, 0, len(destinations))
+	for _, destination := range destinations {
+		mappings = append(mappings, snapshotv1alpha1.RestoreContainerMapping{Source: "main", Destination: destination})
+	}
+	return mappings
 }
 
 func envValue(env []corev1.EnvVar, name string) string {


### PR DESCRIPTION
## Summary

- add `nvidia.com/restore-container-map` for cloning one captured container into multiple restore destinations
- validate the complete map before Pod shaping and before agent workers start
- restore destinations concurrently while a single coordinator publishes the Pod-level aggregate result, including `RestorePartiallySucceeded`
- add a CPU-only one-to-two restore E2E scenario

## Validation

- `go test ./api/... ./operator/...`
- Linux container: `go test ./...` from `agent/`
- Linux container: `go test -race ./internal/controller` from `agent/`
- Python compile and E2E test collection (5 tests)

The cluster-backed E2E scenario was added but not executed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restore one captured container into multiple destination containers using an optional mapping annotation.
  * Destinations restore concurrently with success, partial-success, pending, and failure outcomes.
  * Added validation for container names, source matching, nonempty mappings, and duplicate destinations.
  * Added destination-specific restore tokens, artifacts, readiness checks, and status reporting.

* **Documentation**
  * Updated API and command-line documentation with multi-container restore configuration and outcome details.

* **Tests**
  * Added lifecycle, validation, retry, and failure-handling coverage for multi-container restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->