### PR TITLE
fix(e2e): stop requiring the unreachable RestoreAlreadyFailed event

### DIFF
--- a/e2e/tests/test_snapshot_lifecycle.py
+++ b/e2e/tests/test_snapshot_lifecycle.py
@@ -150,10 +150,16 @@ def test_failed_restore_gpu_checkpoint_into_non_gpu_target(
         )
         assert snap.condition(pod_snapshot, "Ready")["status"] == "True"
         assert snap.condition(content, "Ready")["status"] == "True"
+        # RestoreAlreadyFailed is deliberately not asserted: the agent marks a
+        # failed restore as handled in-process, so that event only fires when a
+        # fresh agent process re-encounters the already-failed pod (e.g. after
+        # an agent restart) — unreachable in this single-agent flow. The sticky
+        # failure itself is covered by the Restored=False/RestoreFailed
+        # condition asserted above.
         assert_restore_events(
             config.namespace,
             run.restore_pod,
-            {"RestoreFailed", "RestoreAlreadyFailed"},
+            {"RestoreFailed"},
         )
     except Exception:
         snap.debug_dump(config, run)


### PR DESCRIPTION
### What

`test_failed_restore_gpu_checkpoint_into_non_gpu_target` no longer requires the `RestoreAlreadyFailed` event — only `RestoreFailed`. The sticky failure itself stays covered by the `Restored=False/RestoreFailed` condition assertion.

### Why

The event and the assertion landed together in #66, and the assertion has failed deterministically on every e2e run since: the agent marks a failed restore as handled in its process-local `handledRestores` map, so every later reconcile of the same pod short-circuits before the branch that emits `RestoreAlreadyFailed`. That event only fires when a fresh agent process re-encounters an already-failed restore pod (e.g. after an agent restart) — unreachable in the single-agent e2e flow. The suppression is deliberate in the agent (it prevents re-emitting the terminal event on every informer resync), so the test expectation is the wrong side.

This failure also skips the SnapshotJob suite step on every run, so the 13 tests in `test_snapshotjob.py` have never executed in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GPU restore failure validation to reliably recognize the expected failure event.
  * Clarified test behavior for restore attempts that have already failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->