### PR TITLE
fix(operator): wait for CRD establishment in crd-installer

### DIFF
--- a/charts/snapshot/templates/operator-rbac.yaml
+++ b/charts/snapshot/templates/operator-rbac.yaml
@@ -51,10 +51,6 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   {{- if .Values.crdUpgrade.enabled }}
-  # RBAC cannot match resourceNames on create, and list/watch requests are
-  # only authorized against resourceNames on servers with the
-  # AuthorizeWithSelectors feature, so these three are granted unscoped.
-  # The installer watches each applied CRD until it is Established.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch"]

--- a/charts/snapshot/templates/operator-rbac.yaml
+++ b/charts/snapshot/templates/operator-rbac.yaml
@@ -51,10 +51,13 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   {{- if .Values.crdUpgrade.enabled }}
-  # RBAC cannot match resourceNames on create, so only get/patch are scoped.
+  # RBAC cannot match resourceNames on create, and list/watch requests are
+  # only authorized against resourceNames on servers with the
+  # AuthorizeWithSelectors feature, so these three are granted unscoped.
+  # The installer watches each applied CRD until it is Established.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["create"]
+    verbs: ["create", "list", "watch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     resourceNames:

--- a/e2e/tests/test_snapshot_lifecycle.py
+++ b/e2e/tests/test_snapshot_lifecycle.py
@@ -150,10 +150,16 @@ def test_failed_restore_gpu_checkpoint_into_non_gpu_target(
         )
         assert snap.condition(pod_snapshot, "Ready")["status"] == "True"
         assert snap.condition(content, "Ready")["status"] == "True"
+        # RestoreAlreadyFailed is deliberately not asserted: the agent marks a
+        # failed restore as handled in-process, so that event only fires when a
+        # fresh agent process re-encounters the already-failed pod (e.g. after
+        # an agent restart) — unreachable in this single-agent flow. The sticky
+        # failure itself is covered by the Restored=False/RestoreFailed
+        # condition asserted above.
         assert_restore_events(
             config.namespace,
             run.restore_pod,
-            {"RestoreFailed", "RestoreAlreadyFailed"},
+            {"RestoreFailed"},
         )
     except Exception:
         snap.debug_dump(config, run)

--- a/operator/cmd/crdinstaller/main.go
+++ b/operator/cmd/crdinstaller/main.go
@@ -10,6 +10,7 @@ package main
 import (
 	"os"
 
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,8 +34,14 @@ func main() {
 		log.Error(err, "unable to create API client")
 		os.Exit(1)
 	}
+	cs, err := apiextensionsclientset.NewForConfig(cfg)
+	if err != nil {
+		log.Error(err, "unable to create apiextensions client")
+		os.Exit(1)
+	}
 
-	results, err := crdinstaller.InstallCRDs(ctrl.SetupSignalHandler(), cl, log, crds.All())
+	results, err := crdinstaller.InstallCRDs(ctrl.SetupSignalHandler(), cl,
+		cs.ApiextensionsV1().CustomResourceDefinitions(), log, crds.All())
 	if err != nil {
 		log.Error(err, "CRD installation failed")
 		os.Exit(1)

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	k8s.io/api v0.36.3
+	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
@@ -57,7 +58,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -155,6 +155,9 @@ func waitForEstablished(ctx context.Context, cl Client, log logr.Logger, gvk sch
 	switch {
 	case err == nil:
 		return nil
+	case lastErr != nil && len(lastConditions) > 0:
+		return fmt.Errorf("%w (last error: %w; last observed conditions: %s)",
+			err, lastErr, formatConditions(lastConditions))
 	case lastErr != nil:
 		return fmt.Errorf("%w (last error: %w)", err, lastErr)
 	case len(lastConditions) > 0:

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -7,6 +7,7 @@ package crdinstaller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -64,7 +65,7 @@ func (r Results) Changed() bool {
 func InstallCRDs(ctx context.Context, cl Client, log logr.Logger, manifests []string) (Results, error) {
 	results := make(Results, 0, len(manifests))
 	for _, manifest := range manifests {
-		res, err := applyCRD(ctx, cl, manifest)
+		res, err := applyCRD(ctx, cl, log, manifest)
 		if err != nil {
 			return results, err
 		}
@@ -74,7 +75,7 @@ func InstallCRDs(ctx context.Context, cl Client, log logr.Logger, manifests []st
 	return results, nil
 }
 
-func applyCRD(ctx context.Context, cl Client, manifest string) (Result, error) {
+func applyCRD(ctx context.Context, cl Client, log logr.Logger, manifest string) (Result, error) {
 	obj := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(manifest), &obj.Object); err != nil {
 		return Result{}, fmt.Errorf("unmarshal CRD manifest: %w", err)
@@ -106,7 +107,7 @@ func applyCRD(ctx context.Context, cl Client, manifest string) (Result, error) {
 		return Result{Name: name}, fmt.Errorf("apply CRD %q: %w", name, err)
 	}
 
-	if err := waitForEstablished(ctx, cl, obj.GroupVersionKind(), name); err != nil {
+	if err := waitForEstablished(ctx, cl, log, obj.GroupVersionKind(), name); err != nil {
 		return Result{Name: name}, fmt.Errorf("wait for CRD %q to become established: %w", name, err)
 	}
 
@@ -123,8 +124,10 @@ func applyCRD(ctx context.Context, cl Client, manifest string) (Result, error) {
 // waitForEstablished blocks until the CRD's Established condition is True,
 // so callers never observe a CRD that the API server has accepted but isn't
 // serving yet.
-func waitForEstablished(ctx context.Context, cl Client, gvk schema.GroupVersionKind, name string) error {
+func waitForEstablished(ctx context.Context, cl Client, log logr.Logger, gvk schema.GroupVersionKind, name string) error {
 	var lastErr error
+	var lastConditions []any
+	waiting := false
 	err := wait.PollUntilContextTimeout(ctx, establishedPollInterval, establishedTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			current := &unstructured.Unstructured{}
@@ -136,19 +139,32 @@ func waitForEstablished(ctx context.Context, cl Client, gvk schema.GroupVersionK
 				return false, nil
 			}
 			lastErr = nil
-			return crdEstablished(current), nil
+			lastConditions, _, _ = unstructured.NestedSlice(current.Object, "status", "conditions")
+			if crdEstablished(lastConditions) {
+				return true, nil
+			}
+			if !waiting {
+				log.Info("Waiting for CRD to become established", "name", name)
+				waiting = true
+			}
+			return false, nil
 		})
-	if err != nil && lastErr != nil {
+	// The bare timeout says nothing about the cause; the last observation
+	// distinguishes a flaky API server from e.g. a NamesAccepted conflict
+	// that will never resolve.
+	switch {
+	case err == nil:
+		return nil
+	case lastErr != nil:
 		return fmt.Errorf("%w (last error: %w)", err, lastErr)
+	case len(lastConditions) > 0:
+		return fmt.Errorf("%w (last observed conditions: %s)", err, formatConditions(lastConditions))
+	default:
+		return err
 	}
-	return err
 }
 
-func crdEstablished(obj *unstructured.Unstructured) bool {
-	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
-	if err != nil || !found {
-		return false
-	}
+func crdEstablished(conditions []any) bool {
 	for _, c := range conditions {
 		condition, ok := c.(map[string]any)
 		if !ok {
@@ -159,4 +175,12 @@ func crdEstablished(obj *unstructured.Unstructured) bool {
 		}
 	}
 	return false
+}
+
+func formatConditions(conditions []any) string {
+	b, err := json.Marshal(conditions)
+	if err != nil {
+		return fmt.Sprintf("%v", conditions)
+	}
+	return string(b)
 }

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -13,11 +13,16 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -27,11 +32,8 @@ const FieldManager = "snapshot-crd-installer"
 const crdKind = "CustomResourceDefinition"
 
 // Apply only persists the CRD; the API server registers it asynchronously.
-// Vars, not consts, so tests can shrink them.
-var (
-	establishedPollInterval = 200 * time.Millisecond
-	establishedTimeout      = 30 * time.Second
-)
+// A var, not a const, so tests can shrink it.
+var establishedTimeout = 30 * time.Second
 
 type Client interface {
 	Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
@@ -62,10 +64,10 @@ func (r Results) Changed() bool {
 	return false
 }
 
-func InstallCRDs(ctx context.Context, cl Client, log logr.Logger, manifests []string) (Results, error) {
+func InstallCRDs(ctx context.Context, cl Client, crdClient apiextensionsv1client.CustomResourceDefinitionInterface, log logr.Logger, manifests []string) (Results, error) {
 	results := make(Results, 0, len(manifests))
 	for _, manifest := range manifests {
-		res, err := applyCRD(ctx, cl, log, manifest)
+		res, err := applyCRD(ctx, cl, crdClient, log, manifest)
 		if err != nil {
 			return results, err
 		}
@@ -75,7 +77,7 @@ func InstallCRDs(ctx context.Context, cl Client, log logr.Logger, manifests []st
 	return results, nil
 }
 
-func applyCRD(ctx context.Context, cl Client, log logr.Logger, manifest string) (Result, error) {
+func applyCRD(ctx context.Context, cl Client, crdClient apiextensionsv1client.CustomResourceDefinitionInterface, log logr.Logger, manifest string) (Result, error) {
 	obj := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(manifest), &obj.Object); err != nil {
 		return Result{}, fmt.Errorf("unmarshal CRD manifest: %w", err)
@@ -107,7 +109,7 @@ func applyCRD(ctx context.Context, cl Client, log logr.Logger, manifest string) 
 		return Result{Name: name}, fmt.Errorf("apply CRD %q: %w", name, err)
 	}
 
-	if err := waitForEstablished(ctx, cl, log, obj.GroupVersionKind(), name); err != nil {
+	if err := waitForEstablished(ctx, crdClient, log, name); err != nil {
 		return Result{Name: name}, fmt.Errorf("wait for CRD %q to become established: %w", name, err)
 	}
 
@@ -121,26 +123,43 @@ func applyCRD(ctx context.Context, cl Client, log logr.Logger, manifest string) 
 	}
 }
 
-// waitForEstablished blocks until the CRD's Established condition is True,
-// so callers never observe a CRD that the API server has accepted but isn't
-// serving yet.
-func waitForEstablished(ctx context.Context, cl Client, log logr.Logger, gvk schema.GroupVersionKind, name string) error {
-	var lastErr error
-	var lastConditions []any
+// waitForEstablished blocks until the CRD's Established condition is True, so
+// callers never observe a CRD that the API server has accepted but isn't
+// serving yet. It watches rather than polls: the initial list delivers the
+// current state, updates arrive as watch events, and the underlying informer
+// relists after disconnections or expired resource versions.
+func waitForEstablished(ctx context.Context, crdClient apiextensionsv1client.CustomResourceDefinitionInterface, log logr.Logger, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, establishedTimeout)
+	defer cancel()
+
+	selector := fields.OneTermEqualSelector("metadata.name", name).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = selector
+			return crdClient.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = selector
+			return crdClient.Watch(ctx, opts)
+		},
+	}
+
+	// On timeout the bare error says nothing about the cause; the last
+	// observation distinguishes a slow apiserver from e.g. a NamesAccepted
+	// conflict that will never resolve.
+	var lastConditions []apiextensionsv1.CustomResourceDefinitionCondition
 	waiting := false
-	err := wait.PollUntilContextTimeout(ctx, establishedPollInterval, establishedTimeout, true,
-		func(ctx context.Context) (bool, error) {
-			current := &unstructured.Unstructured{}
-			current.SetGroupVersionKind(gvk)
-			// A transient Get failure must not abort the wait; the timeout is
-			// the only terminal condition.
-			if err := cl.Get(ctx, client.ObjectKey{Name: name}, current); err != nil {
-				lastErr = err
+	_, err := watchtools.UntilWithSync(ctx, lw, &apiextensionsv1.CustomResourceDefinition{}, nil,
+		func(event watch.Event) (bool, error) {
+			if event.Type == watch.Deleted {
+				return false, fmt.Errorf("CRD %q was deleted while waiting", name)
+			}
+			crd, ok := event.Object.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok || crd.Name != name {
 				return false, nil
 			}
-			lastErr = nil
-			lastConditions, _, _ = unstructured.NestedSlice(current.Object, "status", "conditions")
-			if crdEstablished(lastConditions) {
+			lastConditions = crd.Status.Conditions
+			if crdEstablished(crd.Status.Conditions) {
 				return true, nil
 			}
 			if !waiting {
@@ -149,38 +168,25 @@ func waitForEstablished(ctx context.Context, cl Client, log logr.Logger, gvk sch
 			}
 			return false, nil
 		})
-	// The bare timeout says nothing about the cause; the last observation
-	// distinguishes a flaky API server from e.g. a NamesAccepted conflict
-	// that will never resolve.
-	switch {
-	case err == nil:
+	if err == nil {
 		return nil
-	case lastErr != nil && len(lastConditions) > 0:
-		return fmt.Errorf("%w (last error: %w; last observed conditions: %s)",
-			err, lastErr, formatConditions(lastConditions))
-	case lastErr != nil:
-		return fmt.Errorf("%w (last error: %w)", err, lastErr)
-	case len(lastConditions) > 0:
-		return fmt.Errorf("%w (last observed conditions: %s)", err, formatConditions(lastConditions))
-	default:
-		return err
 	}
+	if len(lastConditions) > 0 {
+		return fmt.Errorf("%w (last observed conditions: %s)", err, formatConditions(lastConditions))
+	}
+	return err
 }
 
-func crdEstablished(conditions []any) bool {
+func crdEstablished(conditions []apiextensionsv1.CustomResourceDefinitionCondition) bool {
 	for _, c := range conditions {
-		condition, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-		if condition["type"] == "Established" && condition["status"] == "True" {
+		if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
 			return true
 		}
 	}
 	return false
 }
 
-func formatConditions(conditions []any) string {
+func formatConditions(conditions []apiextensionsv1.CustomResourceDefinitionCondition) string {
 	b, err := json.Marshal(conditions)
 	if err != nil {
 		return fmt.Sprintf("%v", conditions)

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -132,15 +133,44 @@ func waitForEstablished(ctx context.Context, crdClient apiextensionsv1client.Cus
 	ctx, cancel := context.WithTimeout(ctx, establishedTimeout)
 	defer cancel()
 
+	// UntilWithSync retries list/watch failures internally and would surface
+	// them only as a bare timeout. Record the most recent failure for the
+	// timeout diagnostics, and abort the wait outright on an authorization
+	// error, which retrying cannot resolve.
+	var (
+		reflectorMu  sync.Mutex
+		reflectorErr error
+		failFast     error
+	)
+	observe := func(err error) {
+		if err == nil {
+			return
+		}
+		reflectorMu.Lock()
+		reflectorErr = err
+		if failFast == nil && (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err)) {
+			failFast = err
+		}
+		abort := failFast != nil
+		reflectorMu.Unlock()
+		if abort {
+			cancel()
+		}
+	}
+
 	selector := fields.OneTermEqualSelector("metadata.name", name).String()
 	lw := &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = selector
-			return crdClient.List(ctx, opts)
+			list, err := crdClient.List(ctx, opts)
+			observe(err)
+			return list, err
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = selector
-			return crdClient.Watch(ctx, opts)
+			w, err := crdClient.Watch(ctx, opts)
+			observe(err)
+			return w, err
 		},
 	}
 
@@ -171,8 +201,16 @@ func waitForEstablished(ctx context.Context, crdClient apiextensionsv1client.Cus
 	if err == nil {
 		return nil
 	}
+	reflectorMu.Lock()
+	defer reflectorMu.Unlock()
+	if failFast != nil {
+		return fmt.Errorf("list/watch CRDs: %w", failFast)
+	}
+	if reflectorErr != nil {
+		err = fmt.Errorf("%w (last list/watch error: %v)", err, reflectorErr)
+	}
 	if len(lastConditions) > 0 {
-		return fmt.Errorf("%w (last observed conditions: %s)", err, formatConditions(lastConditions))
+		err = fmt.Errorf("%w (last observed conditions: %s)", err, formatConditions(lastConditions))
 	}
 	return err
 }

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -9,11 +9,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -21,6 +24,13 @@ import (
 const FieldManager = "snapshot-crd-installer"
 
 const crdKind = "CustomResourceDefinition"
+
+// Apply only persists the CRD; the API server registers it asynchronously.
+// Vars, not consts, so tests can shrink them.
+var (
+	establishedPollInterval = 200 * time.Millisecond
+	establishedTimeout      = 30 * time.Second
+)
 
 type Client interface {
 	Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
@@ -96,6 +106,10 @@ func applyCRD(ctx context.Context, cl Client, manifest string) (Result, error) {
 		return Result{Name: name}, fmt.Errorf("apply CRD %q: %w", name, err)
 	}
 
+	if err := waitForEstablished(ctx, cl, obj.GroupVersionKind(), name); err != nil {
+		return Result{Name: name}, fmt.Errorf("wait for CRD %q to become established: %w", name, err)
+	}
+
 	switch {
 	case !existed:
 		return Result{Name: name, Action: ActionCreated}, nil
@@ -104,4 +118,45 @@ func applyCRD(ctx context.Context, cl Client, manifest string) (Result, error) {
 	default:
 		return Result{Name: name, Action: ActionUpdated}, nil
 	}
+}
+
+// waitForEstablished blocks until the CRD's Established condition is True,
+// so callers never observe a CRD that the API server has accepted but isn't
+// serving yet.
+func waitForEstablished(ctx context.Context, cl Client, gvk schema.GroupVersionKind, name string) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(ctx, establishedPollInterval, establishedTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			current := &unstructured.Unstructured{}
+			current.SetGroupVersionKind(gvk)
+			// A transient Get failure must not abort the wait; the timeout is
+			// the only terminal condition.
+			if err := cl.Get(ctx, client.ObjectKey{Name: name}, current); err != nil {
+				lastErr = err
+				return false, nil
+			}
+			lastErr = nil
+			return crdEstablished(current), nil
+		})
+	if err != nil && lastErr != nil {
+		return fmt.Errorf("%w (last error: %w)", err, lastErr)
+	}
+	return err
+}
+
+func crdEstablished(obj *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, c := range conditions {
+		condition, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if condition["type"] == "Established" && condition["status"] == "True" {
+			return true
+		}
+	}
+	return false
 }

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -133,10 +133,6 @@ func waitForEstablished(ctx context.Context, crdClient apiextensionsv1client.Cus
 	ctx, cancel := context.WithTimeout(ctx, establishedTimeout)
 	defer cancel()
 
-	// UntilWithSync retries list/watch failures internally and would surface
-	// them only as a bare timeout. Record the most recent failure for the
-	// timeout diagnostics, and abort the wait outright on an authorization
-	// error, which retrying cannot resolve.
 	var (
 		reflectorMu  sync.Mutex
 		reflectorErr error
@@ -158,21 +154,7 @@ func waitForEstablished(ctx context.Context, crdClient apiextensionsv1client.Cus
 		}
 	}
 
-	selector := fields.OneTermEqualSelector("metadata.name", name).String()
-	lw := &cache.ListWatch{
-		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			opts.FieldSelector = selector
-			list, err := crdClient.List(ctx, opts)
-			observe(err)
-			return list, err
-		},
-		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			opts.FieldSelector = selector
-			w, err := crdClient.Watch(ctx, opts)
-			observe(err)
-			return w, err
-		},
-	}
+	lw := newCRDListWatch(crdClient, name, observe)
 
 	// On timeout the bare error says nothing about the cause; the last
 	// observation distinguishes a slow apiserver from e.g. a NamesAccepted
@@ -213,6 +195,26 @@ func waitForEstablished(ctx context.Context, crdClient apiextensionsv1client.Cus
 		err = fmt.Errorf("%w (last observed conditions: %s)", err, formatConditions(lastConditions))
 	}
 	return err
+}
+
+// newCRDListWatch lists and watches the single named CRD, reporting every
+// list/watch error to observe.
+func newCRDListWatch(crdClient apiextensionsv1client.CustomResourceDefinitionInterface, name string, observe func(error)) *cache.ListWatch {
+	selector := fields.OneTermEqualSelector("metadata.name", name).String()
+	return &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = selector
+			list, err := crdClient.List(ctx, opts)
+			observe(err)
+			return list, err
+		},
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = selector
+			w, err := crdClient.Watch(ctx, opts)
+			observe(err)
+			return w, err
+		},
+	}
 }
 
 func crdEstablished(conditions []apiextensionsv1.CustomResourceDefinitionCondition) bool {

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgotesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -261,6 +262,45 @@ func TestInstallCRDsTimesOutWaitingForEstablished(t *testing.T) {
 	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
 	assert.Contains(t, err.Error(), "last observed conditions")
 	assert.Contains(t, err.Error(), `"status":"False"`)
+}
+
+func TestInstallCRDsFailsFastOnForbiddenListWatch(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	fcs := apiextensionsfake.NewSimpleClientset()
+	forbidden := apierrors.NewForbidden(schema.GroupResource{
+		Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions",
+	}, "", errors.New("crd-installer lacks list/watch RBAC"))
+	fcs.PrependReactor("list", "customresourcedefinitions", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, forbidden
+	})
+
+	start := time.Now()
+	_, err := InstallCRDs(t.Context(), cl, fcs.ApiextensionsV1().CustomResourceDefinitions(), logr.Discard(),
+		[]string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsForbidden(err), "underlying Forbidden must survive wrapping, got: %v", err)
+	assert.Contains(t, err.Error(), "lacks list/watch RBAC")
+	assert.Less(t, time.Since(start), establishedTimeout,
+		"an authorization error must fail the wait immediately, not ride out the timeout")
+}
+
+func TestInstallCRDsTimeoutIncludesLastListWatchError(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	fcs := apiextensionsfake.NewSimpleClientset()
+	fcs.PrependReactor("list", "customresourcedefinitions", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	_, err := InstallCRDs(t.Context(), cl, fcs.ApiextensionsV1().CustomResourceDefinitions(), logr.Discard(),
+		[]string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
+	assert.Contains(t, err.Error(), "last list/watch error")
+	assert.Contains(t, err.Error(), "connection refused")
 }
 
 func TestInstallCRDsFailsWhenCRDDeletedWhileWaiting(t *testing.T) {

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -61,6 +61,7 @@ type fakeClient struct {
 	applyErr             error
 	getErr               error
 	transientGetErrs     int // fail this many Gets of stored CRDs, then succeed
+	failStoredGetsAfter  int // >0: fail Gets of stored CRDs after this many succeeded
 	getsUntilEstablished int // 0 means "established from the first Get"
 	gets                 map[string]int
 }
@@ -84,6 +85,11 @@ func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 	// errors land in the establishment wait.
 	if f.transientGetErrs > 0 {
 		f.transientGetErrs--
+		return errors.New("transient: connection reset")
+	}
+	// f.gets counts successful Gets, so this fails every Get once the first
+	// failStoredGetsAfter have gone through.
+	if f.failStoredGetsAfter > 0 && f.gets[key.Name] >= f.failStoredGetsAfter {
 		return errors.New("transient: connection reset")
 	}
 	obj.SetName(key.Name)
@@ -256,6 +262,20 @@ func TestInstallCRDsTimeoutReportsLastGetError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
 	assert.Contains(t, err.Error(), "transient: connection reset")
+}
+
+func TestInstallCRDsTimeoutReportsConditionsAndLastGetError(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	cl.getsUntilEstablished = 1 << 30 // never establishes
+	cl.failStoredGetsAfter = 2        // two polls observe Established=False, then Gets fail
+
+	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last error: transient: connection reset")
+	assert.Contains(t, err.Error(), `last observed conditions`)
+	assert.Contains(t, err.Error(), `"status":"False"`)
 }
 
 func TestEmbeddedCRDsApplyCleanly(t *testing.T) {

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -90,10 +90,13 @@ func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 	obj.SetResourceVersion(rv)
 
 	f.gets[key.Name]++
-	established := f.gets[key.Name] > f.getsUntilEstablished
-	if u, ok := obj.(*unstructured.Unstructured); ok && established {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		status := "False"
+		if f.gets[key.Name] > f.getsUntilEstablished {
+			status = "True"
+		}
 		_ = unstructured.SetNestedSlice(u.Object, []any{
-			map[string]any{"type": "Established", "status": "True"},
+			map[string]any{"type": "Established", "status": status},
 		}, "status", "conditions")
 	}
 	return nil
@@ -228,6 +231,8 @@ func TestInstallCRDsTimesOutWaitingForEstablished(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
+	assert.Contains(t, err.Error(), "last observed conditions")
+	assert.Contains(t, err.Error(), `"status":"False"`)
 }
 
 func TestInstallCRDsToleratesTransientGetErrorsWhileWaiting(t *testing.T) {

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -7,13 +7,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -24,10 +29,16 @@ import (
 )
 
 func init() {
-	// Real intervals would make the establishment-wait tests slow; polling
-	// faster than the fake client can possibly change state is safe in tests.
-	establishedPollInterval = time.Millisecond
-	establishedTimeout = 200 * time.Millisecond
+	// client-go's WatchListClient feature makes reflectors fetch initial state
+	// through the watch (SendInitialEvents) instead of list+watch. The fake
+	// clientset's watch ignores SendInitialEvents, so an informer never syncs
+	// against it — force the legacy list+watch protocol in tests. Must be set
+	// before client-go first reads its feature gates.
+	os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+
+	// The real timeout would make the establishment-timeout tests slow; the
+	// fake clientset delivers watch events in milliseconds.
+	establishedTimeout = 2 * time.Second
 }
 
 func crdManifest(name string) string {
@@ -39,6 +50,31 @@ spec:
   group: nvidia.com
   scope: Namespaced
 `
+}
+
+func crdWithEstablished(name string, established bool) *apiextensionsv1.CustomResourceDefinition {
+	status := apiextensionsv1.ConditionFalse
+	if established {
+		status = apiextensionsv1.ConditionTrue
+	}
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{Type: apiextensionsv1.Established, Status: status},
+			},
+		},
+	}
+}
+
+// establishedCRDClient returns a CRD watch client whose tracker already holds
+// an Established CRD for every given name, so waits succeed immediately.
+func establishedCRDClient(names ...string) apiextensionsv1client.CustomResourceDefinitionInterface {
+	objs := make([]runtime.Object, 0, len(names))
+	for _, name := range names {
+		objs = append(objs, crdWithEstablished(name, true))
+	}
+	return apiextensionsfake.NewSimpleClientset(objs...).ApiextensionsV1().CustomResourceDefinitions()
 }
 
 // client.ApplyConfigurationFromUnstructured wraps the object in an unexported
@@ -53,21 +89,17 @@ type applyConfigUnstructured interface {
 // stand in, because its Apply bumps on every call including an identical
 // re-apply, inverting the no-op case this installer exists to detect.
 type fakeClient struct {
-	stored               map[string]string // CRD name -> resource version
-	nextRV               map[string]string // CRD name -> resource version the apply should yield
-	applied              []string
-	fieldMgr             string
-	forced               bool
-	applyErr             error
-	getErr               error
-	transientGetErrs     int // fail this many Gets of stored CRDs, then succeed
-	failStoredGetsAfter  int // >0: fail Gets of stored CRDs after this many succeeded
-	getsUntilEstablished int // 0 means "established from the first Get"
-	gets                 map[string]int
+	stored   map[string]string // CRD name -> resource version
+	nextRV   map[string]string // CRD name -> resource version the apply should yield
+	applied  []string
+	fieldMgr string
+	forced   bool
+	applyErr error
+	getErr   error
 }
 
 func newFakeClient() *fakeClient {
-	return &fakeClient{stored: map[string]string{}, nextRV: map[string]string{}, gets: map[string]int{}}
+	return &fakeClient{stored: map[string]string{}, nextRV: map[string]string{}}
 }
 
 func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
@@ -80,31 +112,8 @@ func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 			Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions",
 		}, key.Name)
 	}
-	// Only Gets of stored CRDs fail, so the pre-apply existence check (which
-	// hits the NotFound branch above for new CRDs) is unaffected and these
-	// errors land in the establishment wait.
-	if f.transientGetErrs > 0 {
-		f.transientGetErrs--
-		return errors.New("transient: connection reset")
-	}
-	// f.gets counts successful Gets, so this fails every Get once the first
-	// failStoredGetsAfter have gone through.
-	if f.failStoredGetsAfter > 0 && f.gets[key.Name] >= f.failStoredGetsAfter {
-		return errors.New("transient: connection reset")
-	}
 	obj.SetName(key.Name)
 	obj.SetResourceVersion(rv)
-
-	f.gets[key.Name]++
-	if u, ok := obj.(*unstructured.Unstructured); ok {
-		status := "False"
-		if f.gets[key.Name] > f.getsUntilEstablished {
-			status = "True"
-		}
-		_ = unstructured.SetNestedSlice(u.Object, []any{
-			map[string]any{"type": "Established", "status": status},
-		}, "status", "conditions")
-	}
 	return nil
 }
 
@@ -137,8 +146,9 @@ func (f *fakeClient) Apply(_ context.Context, obj runtime.ApplyConfiguration, op
 func TestInstallCRDsCreatesMissingDefinition(t *testing.T) {
 	cl := newFakeClient()
 	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	crdClient := establishedCRDClient("podsnapshots.nvidia.com")
 
-	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	results, err := InstallCRDs(t.Context(), cl, crdClient, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
 
 	require.NoError(t, err)
 	assert.Equal(t, Results{{Name: "podsnapshots.nvidia.com", Action: ActionCreated}}, results)
@@ -151,8 +161,9 @@ func TestInstallCRDsUpdatesChangedDefinition(t *testing.T) {
 	cl := newFakeClient()
 	cl.stored["podsnapshots.nvidia.com"] = "7"
 	cl.nextRV["podsnapshots.nvidia.com"] = "8"
+	crdClient := establishedCRDClient("podsnapshots.nvidia.com")
 
-	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	results, err := InstallCRDs(t.Context(), cl, crdClient, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
 
 	require.NoError(t, err)
 	assert.Equal(t, Results{{Name: "podsnapshots.nvidia.com", Action: ActionUpdated}}, results)
@@ -163,12 +174,13 @@ func TestInstallCRDsIsNoOpWhenUpToDate(t *testing.T) {
 	cl := newFakeClient()
 	cl.stored["podsnapshots.nvidia.com"] = "7"
 	cl.stored["podsnapshotcontents.nvidia.com"] = "9"
+	crdClient := establishedCRDClient("podsnapshots.nvidia.com", "podsnapshotcontents.nvidia.com")
 
 	manifests := []string{
 		crdManifest("podsnapshots.nvidia.com"),
 		crdManifest("podsnapshotcontents.nvidia.com"),
 	}
-	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), manifests)
+	results, err := InstallCRDs(t.Context(), cl, crdClient, logr.Discard(), manifests)
 
 	require.NoError(t, err)
 	assert.Equal(t, Results{
@@ -182,7 +194,7 @@ func TestInstallCRDsRejectsNonCRDManifest(t *testing.T) {
 	cl := newFakeClient()
 	manifest := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nope\n"
 
-	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{manifest})
+	_, err := InstallCRDs(t.Context(), cl, establishedCRDClient(), logr.Discard(), []string{manifest})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected kind CustomResourceDefinition")
@@ -197,7 +209,7 @@ func TestInstallCRDsStopsOnApplyError(t *testing.T) {
 		crdManifest("podsnapshots.nvidia.com"),
 		crdManifest("podsnapshotcontents.nvidia.com"),
 	}
-	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), manifests)
+	_, err := InstallCRDs(t.Context(), cl, establishedCRDClient(), logr.Discard(), manifests)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `apply CRD "podsnapshots.nvidia.com"`)
@@ -208,7 +220,7 @@ func TestInstallCRDsPropagatesGetError(t *testing.T) {
 	cl := newFakeClient()
 	cl.getErr = errors.New("api unreachable")
 
-	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	_, err := InstallCRDs(t.Context(), cl, establishedCRDClient(), logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "api unreachable")
@@ -218,22 +230,32 @@ func TestInstallCRDsPropagatesGetError(t *testing.T) {
 func TestInstallCRDsWaitsForEstablished(t *testing.T) {
 	cl := newFakeClient()
 	cl.nextRV["podsnapshots.nvidia.com"] = "1"
-	cl.getsUntilEstablished = 3 // first three post-apply Gets report not-yet-established
+	fcs := apiextensionsfake.NewSimpleClientset(crdWithEstablished("podsnapshots.nvidia.com", false))
+	crdClient := fcs.ApiextensionsV1().CustomResourceDefinitions()
 
-	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	// Flip Established to True after the wait has started; the update arrives
+	// as a watch event.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_, err := crdClient.Update(context.Background(), crdWithEstablished("podsnapshots.nvidia.com", true), metav1.UpdateOptions{})
+		if err != nil {
+			t.Errorf("update CRD status: %v", err)
+		}
+	}()
+
+	results, err := InstallCRDs(t.Context(), cl, crdClient, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
 
 	require.NoError(t, err)
 	assert.Equal(t, Results{{Name: "podsnapshots.nvidia.com", Action: ActionCreated}}, results)
-	assert.Greater(t, cl.gets["podsnapshots.nvidia.com"], 3,
-		"installer should have polled past the not-established responses")
 }
 
 func TestInstallCRDsTimesOutWaitingForEstablished(t *testing.T) {
 	cl := newFakeClient()
 	cl.nextRV["podsnapshots.nvidia.com"] = "1"
-	cl.getsUntilEstablished = 1 << 30 // never reports Established within the test timeout
+	fcs := apiextensionsfake.NewSimpleClientset(crdWithEstablished("podsnapshots.nvidia.com", false))
 
-	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	_, err := InstallCRDs(t.Context(), cl, fcs.ApiextensionsV1().CustomResourceDefinitions(), logr.Discard(),
+		[]string{crdManifest("podsnapshots.nvidia.com")})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
@@ -241,41 +263,23 @@ func TestInstallCRDsTimesOutWaitingForEstablished(t *testing.T) {
 	assert.Contains(t, err.Error(), `"status":"False"`)
 }
 
-func TestInstallCRDsToleratesTransientGetErrorsWhileWaiting(t *testing.T) {
+func TestInstallCRDsFailsWhenCRDDeletedWhileWaiting(t *testing.T) {
 	cl := newFakeClient()
 	cl.nextRV["podsnapshots.nvidia.com"] = "1"
-	cl.transientGetErrs = 2 // first two polls of the establishment wait fail
+	fcs := apiextensionsfake.NewSimpleClientset(crdWithEstablished("podsnapshots.nvidia.com", false))
+	crdClient := fcs.ApiextensionsV1().CustomResourceDefinitions()
 
-	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		if err := crdClient.Delete(context.Background(), "podsnapshots.nvidia.com", metav1.DeleteOptions{}); err != nil {
+			t.Errorf("delete CRD: %v", err)
+		}
+	}()
 
-	require.NoError(t, err)
-	assert.Equal(t, Results{{Name: "podsnapshots.nvidia.com", Action: ActionCreated}}, results)
-}
-
-func TestInstallCRDsTimeoutReportsLastGetError(t *testing.T) {
-	cl := newFakeClient()
-	cl.nextRV["podsnapshots.nvidia.com"] = "1"
-	cl.transientGetErrs = 1 << 30 // every poll fails until the wait times out
-
-	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+	_, err := InstallCRDs(t.Context(), cl, crdClient, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
-	assert.Contains(t, err.Error(), "transient: connection reset")
-}
-
-func TestInstallCRDsTimeoutReportsConditionsAndLastGetError(t *testing.T) {
-	cl := newFakeClient()
-	cl.nextRV["podsnapshots.nvidia.com"] = "1"
-	cl.getsUntilEstablished = 1 << 30 // never establishes
-	cl.failStoredGetsAfter = 2        // two polls observe Established=False, then Gets fail
-
-	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "last error: transient: connection reset")
-	assert.Contains(t, err.Error(), `last observed conditions`)
-	assert.Contains(t, err.Error(), `"status":"False"`)
+	assert.Contains(t, err.Error(), "was deleted while waiting")
 }
 
 func TestEmbeddedCRDsApplyCleanly(t *testing.T) {
@@ -295,7 +299,7 @@ func TestEmbeddedCRDsApplyCleanly(t *testing.T) {
 	}
 
 	cl := newFakeClient()
-	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), manifests)
+	results, err := InstallCRDs(t.Context(), cl, establishedCRDClient(wantNames...), logr.Discard(), manifests)
 
 	require.NoError(t, err)
 	require.Len(t, results, len(manifests), "expected one result per embedded CRD manifest")

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,13 @@ import (
 
 	"github.com/ai-dynamo/snapshot/api/v1alpha1/crds"
 )
+
+func init() {
+	// Real intervals would make the establishment-wait tests slow; polling
+	// faster than the fake client can possibly change state is safe in tests.
+	establishedPollInterval = time.Millisecond
+	establishedTimeout = 200 * time.Millisecond
+}
 
 func crdManifest(name string) string {
 	return `apiVersion: apiextensions.k8s.io/v1
@@ -45,17 +53,20 @@ type applyConfigUnstructured interface {
 // stand in, because its Apply bumps on every call including an identical
 // re-apply, inverting the no-op case this installer exists to detect.
 type fakeClient struct {
-	stored   map[string]string // CRD name -> resource version
-	nextRV   map[string]string // CRD name -> resource version the apply should yield
-	applied  []string
-	fieldMgr string
-	forced   bool
-	applyErr error
-	getErr   error
+	stored               map[string]string // CRD name -> resource version
+	nextRV               map[string]string // CRD name -> resource version the apply should yield
+	applied              []string
+	fieldMgr             string
+	forced               bool
+	applyErr             error
+	getErr               error
+	transientGetErrs     int // fail this many Gets of stored CRDs, then succeed
+	getsUntilEstablished int // 0 means "established from the first Get"
+	gets                 map[string]int
 }
 
 func newFakeClient() *fakeClient {
-	return &fakeClient{stored: map[string]string{}, nextRV: map[string]string{}}
+	return &fakeClient{stored: map[string]string{}, nextRV: map[string]string{}, gets: map[string]int{}}
 }
 
 func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
@@ -68,8 +79,23 @@ func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 			Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions",
 		}, key.Name)
 	}
+	// Only Gets of stored CRDs fail, so the pre-apply existence check (which
+	// hits the NotFound branch above for new CRDs) is unaffected and these
+	// errors land in the establishment wait.
+	if f.transientGetErrs > 0 {
+		f.transientGetErrs--
+		return errors.New("transient: connection reset")
+	}
 	obj.SetName(key.Name)
 	obj.SetResourceVersion(rv)
+
+	f.gets[key.Name]++
+	established := f.gets[key.Name] > f.getsUntilEstablished
+	if u, ok := obj.(*unstructured.Unstructured); ok && established {
+		_ = unstructured.SetNestedSlice(u.Object, []any{
+			map[string]any{"type": "Established", "status": "True"},
+		}, "status", "conditions")
+	}
 	return nil
 }
 
@@ -178,6 +204,53 @@ func TestInstallCRDsPropagatesGetError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "api unreachable")
 	assert.Empty(t, cl.applied)
+}
+
+func TestInstallCRDsWaitsForEstablished(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	cl.getsUntilEstablished = 3 // first three post-apply Gets report not-yet-established
+
+	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.NoError(t, err)
+	assert.Equal(t, Results{{Name: "podsnapshots.nvidia.com", Action: ActionCreated}}, results)
+	assert.Greater(t, cl.gets["podsnapshots.nvidia.com"], 3,
+		"installer should have polled past the not-established responses")
+}
+
+func TestInstallCRDsTimesOutWaitingForEstablished(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	cl.getsUntilEstablished = 1 << 30 // never reports Established within the test timeout
+
+	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
+}
+
+func TestInstallCRDsToleratesTransientGetErrorsWhileWaiting(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	cl.transientGetErrs = 2 // first two polls of the establishment wait fail
+
+	results, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.NoError(t, err)
+	assert.Equal(t, Results{{Name: "podsnapshots.nvidia.com", Action: ActionCreated}}, results)
+}
+
+func TestInstallCRDsTimeoutReportsLastGetError(t *testing.T) {
+	cl := newFakeClient()
+	cl.nextRV["podsnapshots.nvidia.com"] = "1"
+	cl.transientGetErrs = 1 << 30 // every poll fails until the wait times out
+
+	_, err := InstallCRDs(t.Context(), cl, logr.Discard(), []string{crdManifest("podsnapshots.nvidia.com")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `wait for CRD "podsnapshots.nvidia.com" to become established`)
+	assert.Contains(t, err.Error(), "transient: connection reset")
 }
 
 func TestEmbeddedCRDsApplyCleanly(t *testing.T) {


### PR DESCRIPTION
### Problem

Installing the operator sometimes left a CRD (observed with `PodSnapshot`) unusable until the operator pod restarted. The `crd-installer` init container exits as soon as the API server accepts the apply, but CRD registration is asynchronous — the manager container could start before the CRD was Established, fail to build its informer, and crash. It only recovered because the container restart happened after registration finished.

### Fix

After applying each CRD, `crdinstaller` now polls `status.conditions[type=Established]` until it is `True` before reporting success (200ms interval, 30s timeout):

- Transient `Get` errors during the wait do not abort it — the timeout is the only terminal condition, and the last error is attached to the timeout message.
- On timeout, the last-observed CRD conditions are included in the error, so a terminal cause (e.g. a `NamesAccepted` conflict) is distinguishable from a slow API server.
- A log line is emitted once when a CRD is found not yet established, so the init container is not silent while waiting.

### Testing

- New unit tests cover the wait, the timeout path, transient-error tolerance, and error-message contents.
- Full `crdinstaller` package suite passes (`go test ./internal/crdinstaller/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CRD installation now waits until each custom resource definition is established before reporting success.
  * Temporary API server errors and interrupted watches are retried.
  * Installation detects CRD deletion and authorization failures.
  * Timeout errors include the latest observed status or error details.
  * Updated permissions support monitoring CRD establishment.
  * Added logging when establishment waiting begins.
  * Corrected GPU restore test expectations for failed restores.

* **Tests**
  * Added coverage for delayed establishment, transient failures, authorization errors, timeouts, deletion, and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->