### PR TITLE
Ignore .vscode/ and disable placeholder SIGKILL on restore failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ e2e/.venv/
 e2e/__pycache__/
 e2e/**/*.py[cod]
 e2e/.pytest_cache/
+
+# Editor config (personal debug setups, remote-debug ports, etc.)
+.vscode/

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -923,7 +923,7 @@ func (op *restoreOperation) executeRestore(ctx context.Context) (int, error) {
 }
 
 func (op *restoreOperation) failRestore(ctx context.Context, restoreErr error) error {
-	w := op.controller
+	//w := op.controller
 	op.log.Error(restoreErr, "External restore failed")
 	// Re-resolve because restore may fail before discovering the placeholder PID.
 	//placeholderHostPID, _, err := w.runtime.ResolveContainer(ctx, op.containerID)

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -926,10 +926,10 @@ func (op *restoreOperation) failRestore(ctx context.Context, restoreErr error) e
 	w := op.controller
 	op.log.Error(restoreErr, "External restore failed")
 	// Re-resolve because restore may fail before discovering the placeholder PID.
-	placeholderHostPID, _, err := w.runtime.ResolveContainer(ctx, op.containerID)
-	if err != nil {
-		return errors.Join(restoreErr, fmt.Errorf("placeholder PID could not be resolved after restore failure: %w", err))
-	}
+	//placeholderHostPID, _, err := w.runtime.ResolveContainer(ctx, op.containerID)
+	//if err != nil {
+	//	return errors.Join(restoreErr, fmt.Errorf("placeholder PID could not be resolved after restore failure: %w", err))
+	//}
 	//if err := w.sendSignalFn(op.log, placeholderHostPID, syscall.SIGKILL, "restore failed"); err != nil {
 	//	return errors.Join(restoreErr, fmt.Errorf("placeholder could not be killed after restore failure: %w", err))
 	//}

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -930,9 +930,9 @@ func (op *restoreOperation) failRestore(ctx context.Context, restoreErr error) e
 	if err != nil {
 		return errors.Join(restoreErr, fmt.Errorf("placeholder PID could not be resolved after restore failure: %w", err))
 	}
-	if err := w.sendSignalFn(op.log, placeholderHostPID, syscall.SIGKILL, "restore failed"); err != nil {
-		return errors.Join(restoreErr, fmt.Errorf("placeholder could not be killed after restore failure: %w", err))
-	}
+	//if err := w.sendSignalFn(op.log, placeholderHostPID, syscall.SIGKILL, "restore failed"); err != nil {
+	//	return errors.Join(restoreErr, fmt.Errorf("placeholder could not be killed after restore failure: %w", err))
+	//}
 	return restoreErr
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restore-failure handling to avoid forcibly terminating the placeholder process.
  - Restore errors are now reported without the additional termination attempt.

- **Chores**
  - Added Visual Studio Code settings to the ignored development files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->