### PR TITLE
docs(readme): add SnapshotJob to APIs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ Snapshots are portable across compatible machines and can be restored on any nod
 &nbsp;
 
 ## APIs
-| Resource | Scope | Role |
-|----------|-------|------|
-| `PodSnapshot` | Namespaced | Created by callers to request a capture or reference an artifact for restore. |
-| `PodSnapshotContent` | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapshot operator, never by the caller. |
-| `nvidia.com/restore-from` | Namespaced | Added as a pod annotation to trigger restore from a named `PodSnapshot` in the same namespace. |
-| `nvidia.com/restore-container-map` | Namespaced | Optional comma-separated `source=destination` mappings used to clone the single captured container into one or more restore containers. |
+| Resource                           | Scope          | Role                                                                                                                                    |
+|------------------------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `PodSnapshot`                      | Namespaced     | Created by callers to request a capture or reference an artifact for restore.                                                           |
+| `PodSnapshotContent`               | Cluster-scoped | System-managed record of the physical artifact, bound to a `PodSnapshot`. Created by the Snapshot operator, never by the caller.        |
+| `SnapshotJob`                      | Namespaced     | Created by callers to run a workload pod from a template and capture it into a `PodSnapshot` in one declarative, one-shot object.       |
+| `nvidia.com/restore-from`          | Namespaced     | Added as a pod annotation to trigger restore from a named `PodSnapshot` in the same namespace.                                          |
+| `nvidia.com/restore-container-map` | Namespaced     | Optional comma-separated `source=destination` mappings used to clone the single captured container into one or more restore containers. |
 
 &nbsp;
 


### PR DESCRIPTION
### Summary
- Adds `SnapshotJob` to the README APIs table — it was missing despite being a shipped, namespaced API for running a workload pod and capturing it into a `PodSnapshot` in one one-shot object.

### Test plan
- Manual review of the rendered table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the APIs table with expanded formatting.
  * Added documentation for the namespaced `SnapshotJob` resource, which runs a templated workload and captures the result as a `PodSnapshot`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->