### PR TITLE
feat(chart): add runtime.storageDir for non-default containerd layouts

### DIFF
--- a/charts/snapshot/README.md
+++ b/charts/snapshot/README.md
@@ -79,6 +79,25 @@ helm upgrade --install snapshot ./charts/snapshot \
   --set openshift.enabled=true
 ```
 
+## RKE2 and k3s
+
+RKE2 and k3s relocate both the CRI socket and containerd's snapshotter storage,
+so set both values together:
+
+```bash
+helm upgrade --install snapshot ./charts/snapshot \
+  --namespace "${NAMESPACE}" --create-namespace \
+  --set runtime.socketPath=/run/k3s/containerd/containerd.sock \
+  --set runtime.storageDir=/var/lib/rancher/rke2/agent/containerd
+```
+
+For k3s use `--set runtime.storageDir=/var/lib/rancher/k3s/agent/containerd`.
+
+`runtime.storageDir` is mounted into the agent container at the identical
+absolute path it has on the host. The agent tars the overlay `upperDir` read
+verbatim out of containerd's own metadata, so the path must resolve unchanged
+inside the agent's mount namespace — it is not a relocatable prefix.
+
 ## Minimal install
 
 Create the checkpoint PVC and the agent:
@@ -172,6 +191,7 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=snapshot -o wide
 | `seccomp.deploy` | Deploy the CRIU seccomp profile ConfigMap and init container. Use this field name; `seccomp.enabled` is not a chart value | `true` |
 | `runtime.type` | CRI backend: `containerd` or `crio` | `containerd` |
 | `runtime.socketPath` | CRI socket (empty = default for `runtime.type`) | `""` |
+| `runtime.storageDir` | Host per-container storage dir, mounted at the identical path in the agent (empty = default for `runtime.type`) | `""` |
 | `crdUpgrade.enabled` | Install and upgrade the CRDs from an operator init container (see below) | `true` |
 | `crdUpgrade.logLevel` | Init container log level | `info` |
 | `rbac.create` | Create agent and operator RBAC | `true` |

--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -99,7 +99,9 @@ Host directory holding per-container storage (overlay upperdirs the agent
 reads for rootfs-diff capture, and CRI-O config.json fallback).
 */}}
 {{- define "snapshot.runtimeStorageDir" -}}
-{{- if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
+{{- if .Values.runtime.storageDir -}}
+{{- .Values.runtime.storageDir -}}
+{{- else if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
 {{- end }}
 
 {{- define "snapshot.pageBrokerControlPath" -}}/pagebroker/control{{- end -}}

--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -78,6 +78,9 @@ Fail fast on unsupported runtime.type values. Called once from daemonset.yaml.
 {{- if not (has .Values.runtime.type (list "containerd" "crio")) }}
 {{- fail (printf "runtime.type must be 'containerd' or 'crio', got %q" .Values.runtime.type) }}
 {{- end }}
+{{- if and .Values.runtime.storageDir (not (hasPrefix "/" .Values.runtime.storageDir)) }}
+{{- fail (printf "runtime.storageDir must be an absolute path, got %q" .Values.runtime.storageDir) }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -99,9 +99,13 @@ Host directory holding per-container storage (overlay upperdirs the agent
 reads for rootfs-diff capture, and CRI-O config.json fallback).
 */}}
 {{- define "snapshot.runtimeStorageDir" -}}
-{{- if .Values.runtime.storageDir -}}
-{{- .Values.runtime.storageDir -}}
-{{- else if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
+{{- if .Values.runtime.storageDir }}
+{{- .Values.runtime.storageDir }}
+{{- else if eq .Values.runtime.type "crio" }}
+{{- "/var/lib/containers" }}
+{{- else }}
+{{- "/var/lib/containerd" }}
+{{- end }}
 {{- end }}
 
 {{- define "snapshot.pageBrokerControlPath" -}}/pagebroker/control{{- end -}}

--- a/charts/snapshot/tests/runtime_storage_test.yaml
+++ b/charts/snapshot/tests/runtime_storage_test.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: runtime storage directory
+templates:
+  - templates/daemonset.yaml
+tests:
+  - it: defaults the runtime-storage volume to the containerd path on host and in container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: runtime-storage
+            mountPath: /var/lib/containerd
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: runtime-storage
+            hostPath:
+              path: /var/lib/containerd
+              type: Directory
+
+  # The agent tars the overlay upperDir read verbatim out of containerd
+  # metadata, so an override must land at the identical path on both sides.
+  - it: mounts an overridden runtime.storageDir at the identical host path
+    set:
+      runtime.storageDir: /var/lib/rancher/rke2/agent/containerd
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: runtime-storage
+            mountPath: /var/lib/rancher/rke2/agent/containerd
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: runtime-storage
+            hostPath:
+              path: /var/lib/rancher/rke2/agent/containerd
+              type: Directory

--- a/charts/snapshot/tests/runtime_storage_test.yaml
+++ b/charts/snapshot/tests/runtime_storage_test.yaml
@@ -40,3 +40,13 @@ tests:
             hostPath:
               path: /var/lib/rancher/rke2/agent/containerd
               type: Directory
+
+  # hostPath.path and the agent's volumeMount.mountPath both take this value
+  # verbatim, and Kubernetes rejects a relative mountPath at Pod admission --
+  # far from the value that caused it. Fail at template time instead.
+  - it: rejects a relative runtime.storageDir
+    set:
+      runtime.storageDir: relative/containerd
+    asserts:
+      - failedTemplate:
+          errorPattern: "runtime.storageDir must be an absolute path"

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -58,14 +58,11 @@ crdUpgrade:
 runtime:
   type: containerd  # containerd | crio
   socketPath: ""
-  # Host directory holding per-container storage (the overlay upperdirs the
-  # agent tars for rootfs-diff capture, and the CRI-O config.json fallback).
-  # The agent reads these paths verbatim out of runtime metadata, so the
-  # volume is mounted at this same absolute path inside the agent container.
+  # Host directory holding per-container storage. Mounted into the agent at
+  # this same absolute path, because runtime metadata reports it verbatim.
   # Defaults: /var/lib/containerd (containerd), /var/lib/containers (crio).
-  # RKE2/k3s: /var/lib/rancher/rke2/agent/containerd
-  #           (k3s: /var/lib/rancher/k3s/agent/containerd), with
-  #           socketPath: /run/k3s/containerd/containerd.sock
+  # RKE2: /var/lib/rancher/rke2/agent/containerd, with
+  #       socketPath: /run/k3s/containerd/containerd.sock
   storageDir: ""
 
 # Gates the OCP RBAC template and the DS required-scc annotation. Keep false

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -58,11 +58,9 @@ crdUpgrade:
 runtime:
   type: containerd  # containerd | crio
   socketPath: ""
-  # Host directory holding per-container storage. Mounted into the agent at
-  # this same absolute path, because runtime metadata reports it verbatim.
+  # Host per-container storage, mounted into the agent at the same absolute path.
   # Defaults: /var/lib/containerd (containerd), /var/lib/containers (crio).
-  # RKE2: /var/lib/rancher/rke2/agent/containerd, with
-  #       socketPath: /run/k3s/containerd/containerd.sock
+  # RKE2: /var/lib/rancher/rke2/agent/containerd + socketPath /run/k3s/containerd/containerd.sock
   storageDir: ""
 
 # Gates the OCP RBAC template and the DS required-scc annotation. Keep false

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -53,11 +53,20 @@ crdUpgrade:
       cpu: 50m
       memory: 64Mi
 
-# Container runtime backend. Leave socketPath empty to use the conventional
-# path for the chosen type.
+# Container runtime backend. Leave socketPath/storageDir empty to use the
+# conventional paths for the chosen type.
 runtime:
   type: containerd  # containerd | crio
   socketPath: ""
+  # Host directory holding per-container storage (the overlay upperdirs the
+  # agent tars for rootfs-diff capture, and the CRI-O config.json fallback).
+  # The agent reads these paths verbatim out of runtime metadata, so the
+  # volume is mounted at this same absolute path inside the agent container.
+  # Defaults: /var/lib/containerd (containerd), /var/lib/containers (crio).
+  # RKE2/k3s: /var/lib/rancher/rke2/agent/containerd
+  #           (k3s: /var/lib/rancher/k3s/agent/containerd), with
+  #           socketPath: /run/k3s/containerd/containerd.sock
+  storageDir: ""
 
 # Gates the OCP RBAC template and the DS required-scc annotation. Keep false
 # on vanilla Kubernetes (it references an OCP-only built-in SCC).


### PR DESCRIPTION
`runtime.socketPath` is a chart value but the containerd snapshotter **storage** directory was not — `snapshot.runtimeStorageDir` hardcoded `/var/lib/containerd`.

RKE2 and k3s relocate that directory under `/var/lib/rancher/<distro>/agent/containerd`. On such a cluster the agent cannot resolve containers with chart defaults; after patching only the socket, resolution works but capture cannot produce a correct `rootfs-diff.tar` — the agent tars the overlay `upperDir` read verbatim out of containerd's metadata, so that host path must resolve **unchanged inside the agent's mount namespace**. The only workaround was a direct DaemonSet JSON patch of both the volume and the volumeMount (#143).

**Change:** chart-only.

- `runtime.storageDir`, empty by default, so current per-runtime defaults are unchanged.
- `snapshot.runtimeStorageDir` honours it, following the existing `snapshot.runtimeSocket` pattern.
- Rejects a non-absolute value at template time: it lands in both `hostPath.path` and the agent's `volumeMount.mountPath`, and Kubernetes rejects a relative `mountPath` at Pod admission — an error that names the mount rather than the value behind it.
- README section and a values-table row.

No template rewiring: `daemonset.yaml` already renders both the `hostPath.path` and the container `mountPath` from `$storageDir`. Deriving both from one value keeps them equal by construction, which is the point — the path is metadata-derived, not a relocatable prefix.

```yaml
# rendered with runtime.storageDir=/var/lib/rancher/rke2/agent/containerd
      mountPath: "/var/lib/rancher/rke2/agent/containerd"   # container
        path: "/var/lib/rancher/rke2/agent/containerd"      # host
```

**Tests:** `helm unittest charts/snapshot` → 10 passed, 4 suites. `helm lint` passes. Both new cases red-proofed — removing the override branch fails the override case; disabling the absolute-path guard fails exactly the rejection case (1 failed, 9 passed), each on its own assertion.

Observed on RKE2 + A10, driver 580.173.02, against v0.1.0-alpha.1.

Fixes #143
