### PR TITLE
fix(agent): fail the checkpoint when overlay rootfs-diff capture fails

### DIFF
--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -326,19 +326,32 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 	}
 	timings.CRIUDumpDuration = criuDumpDuration
 
-	// Overlay rootfs diff capture is best-effort. Failures are logged but not
-	// propagated — a checkpoint without overlay diffs is still valid for restore
-	// (the base container image provides the filesystem).
-	if state.UpperDir != "" {
-		overlayCaptureStart := time.Now()
-		if _, err := snapshotruntime.CaptureRootfsDiff(state.UpperDir, checkpointDir, data.Overlay.Exclusions, data.Overlay.BindMountDests); err != nil {
-			log.Error(err, "Failed to capture rootfs diff")
-		}
-		if _, err := snapshotruntime.CaptureDeletedFiles(state.UpperDir, checkpointDir); err != nil {
-			log.Error(err, "Failed to capture deleted files")
-		}
-		timings.OverlayCaptureDuration = time.Since(overlayCaptureStart)
+	overlayCaptureDuration, err := captureOverlay(state.UpperDir, checkpointDir, data)
+	if err != nil {
+		return nil, err
 	}
+	timings.OverlayCaptureDuration = overlayCaptureDuration
 
 	return timings, nil
+}
+
+// captureOverlay writes the container's rootfs diff and whiteout list into the staged
+// checkpoint directory.
+//
+// Failures are returned, not logged and dropped: an artifact missing rootfs-diff.tar
+// restores with every container-created file silently absent, and the caller has no way
+// to tell that from a complete checkpoint. Failing here keeps the staged directory from
+// being promoted, so the work order lands CheckpointFailed instead of Captured.
+func captureOverlay(upperDir, checkpointDir string, data *types.CheckpointManifest) (time.Duration, error) {
+	if upperDir == "" {
+		return 0, nil
+	}
+	start := time.Now()
+	if _, err := snapshotruntime.CaptureRootfsDiff(upperDir, checkpointDir, data.Overlay.Exclusions, data.Overlay.BindMountDests); err != nil {
+		return 0, fmt.Errorf("failed to capture rootfs diff: %w", err)
+	}
+	if _, err := snapshotruntime.CaptureDeletedFiles(upperDir, checkpointDir); err != nil {
+		return 0, fmt.Errorf("failed to capture deleted files: %w", err)
+	}
+	return time.Since(start), nil
 }

--- a/agent/internal/executor/checkpoint_test.go
+++ b/agent/internal/executor/checkpoint_test.go
@@ -69,3 +69,18 @@ func TestCheckpointNeedsSourceKill(t *testing.T) {
 	assert.False(t, CheckpointNeedsSourceKill(errors.New("prepare failed")))
 	assert.False(t, CheckpointNeedsSourceKill(fmt.Errorf("commit PageBroker checkpoint: %w", errors.New("failed"))))
 }
+
+// A rootfs-diff capture failure must fail the checkpoint. Swallowing it publishes an
+// artifact whose restore silently drops every container-created file.
+func TestCaptureOverlayFailsCheckpointOnRootfsDiffError(t *testing.T) {
+	manifest := &types.CheckpointManifest{}
+
+	// Absent upperdir: nothing to capture, no failure.
+	duration, err := captureOverlay("", t.TempDir(), manifest)
+	require.NoError(t, err)
+	assert.Zero(t, duration)
+
+	// Unreadable upperdir: tar fails and the error must propagate.
+	_, err = captureOverlay(filepath.Join(t.TempDir(), "missing-upperdir"), t.TempDir(), manifest)
+	require.ErrorContains(t, err, "failed to capture rootfs diff")
+}


### PR DESCRIPTION
The overlay rootfs-diff step logged its failures and dropped them, so a capture that failed to produce `rootfs-diff.tar` still promoted its staged directory and landed `Ready=True reason=Captured`. Nothing in the CR said otherwise; the only way to find out was to list the PVC.

That artifact is not a degraded checkpoint — it restores with every container-created file silently absent, and the caller cannot tell it from a complete one. The project already treats the file as required: `test_successful_snapshot_captures_cpu_gpu_and_fs` asserts it is in the listing, so a run could report `Captured` and fail that assertion.

**Change:** both errors propagate out of `captureCheckpoint`. The staged directory is never promoted, so the existing `CheckpointFailed` path fires. The step is extracted into `captureOverlay` only so a unit test can reach it without a CRIU dump.

The old comment justified the best-effort handling with "the base container image provides the filesystem". That holds only for a container that wrote nothing, which is not knowable at that point.

**Tests:** `go test ./internal/executor/` on linux (go 1.26) → `ok 0.136s`. Adds `TestCaptureOverlayFailsCheckpointOnRootfsDiffError`.

Observed on RKE2 + A10, driver 580.173.02, against v0.1.0-alpha.1. Evidence in #142.

Fixes #142
