### PR TITLE
fix(agent): validate a pre-existing artifact before adopting it

### DIFF
--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -83,7 +83,8 @@ func (w *NodeController) reconcilePodSnapshotContent(ctx context.Context, name s
 			// race. The dump kills the source, so deletion can also trail a successful capture
 			// (Job cleanup, eviction): only a gone pod with neither an in-flight capture nor a
 			// committed artifact fails the work order terminally.
-			if !w.deferToCommittedCapture(ctx, content) {
+			// nil pod: there is nothing left to validate a committed artifact against.
+			if !w.deferToCommittedCapture(ctx, content, nil) {
 				w.failContentFromGate(ctx, content, "SourcePodNotFound", fmt.Errorf("source pod %q not found", key.String()))
 			}
 			return
@@ -99,7 +100,7 @@ func (w *NodeController) reconcilePodSnapshotContent(ctx context.Context, name s
 		// The dump terminates the source process, so a terminal pod may mean a
 		// capture just succeeded. Only a dead source with neither an in-flight
 		// capture nor a committed artifact is a failure.
-		if !w.deferToCommittedCapture(ctx, content) {
+		if !w.deferToCommittedCapture(ctx, content, pod) {
 			w.failContentFromGate(ctx, content, reason, errors.New(msg))
 		}
 		return
@@ -116,7 +117,11 @@ func (w *NodeController) reconcilePodSnapshotContent(ctx context.Context, name s
 // that already succeeded or is still in flight: a capture goroutine owning the in-flight guard or
 // the shared Lease owns the outcome, and a committed artifact only needs its Ready write, which is
 // performed here. A false return means none exist and the caller owns the failure.
-func (w *NodeController) deferToCommittedCapture(ctx context.Context, content *snapshotv1alpha1.PodSnapshotContent) bool {
+//
+// pod is the live source pod, or nil when it is already gone. When present, the committed
+// artifact is validated against it exactly as the adoption path does: this is a terminal write,
+// so reconcileSourcePod will not run afterwards to catch an incompatible artifact.
+func (w *NodeController) deferToCommittedCapture(ctx context.Context, content *snapshotv1alpha1.PodSnapshotContent, pod *corev1.Pod) bool {
 	// The UID keys the artifact path and the in-flight guard; empty must not
 	// alias onto a shared path (same invariant as MissingContentUID).
 	contentUID := string(content.UID)
@@ -132,9 +137,11 @@ func (w *NodeController) deferToCommittedCapture(ctx context.Context, content *s
 	}
 	path, err := nsmount.ResolveArtifactPath(w.config.Storage.BasePath, contentUID, containerName)
 	if err == nil && artifactPresent(path, contentUID, containerName) {
-		if err := w.markCheckpointReady(ctx, content); err != nil {
+		// This branch is terminal either way, so reconcileSourcePod never runs to
+		// validate afterwards: the artifact must be refused here or not at all.
+		if err := w.refuseOrAdoptArtifact(ctx, content, pod, path, containerName); err != nil {
 			// Not terminal, so the content informer resync retries the recovery.
-			logr.FromContextOrDiscard(ctx).Error(err, "Failed to recover committed artifact to Ready", "content", content.Name)
+			logr.FromContextOrDiscard(ctx).Error(err, "Failed to recover committed artifact", "content", content.Name)
 		}
 		return true
 	}
@@ -257,7 +264,7 @@ func (w *NodeController) reconcileSourcePod(ctx context.Context, pod *corev1.Pod
 		return w.setSnapshotContentFailed(ctx, content, "InvalidDestination", err)
 	}
 	if artifactPresent(artifactPath, contentUID, containerName) {
-		return w.markCheckpointReady(ctx, content)
+		return w.refuseOrAdoptArtifact(ctx, content, pod, artifactPath, containerName)
 	}
 
 	// The in-flight guard held above is process-local; overlapping agent instances arbitrate
@@ -593,6 +600,7 @@ func (w *NodeController) executorCheckpoint(ctx context.Context, params Checkpoi
 		PodName:             params.Pod.Name,
 		PodNamespace:        params.Pod.Namespace,
 		PodIP:               params.Pod.Status.PodIP,
+		MountPlan:           buildMountPlan(params.Pod, params.ContainerName),
 		Clientset:           w.clientset,
 		PageBrokerRequested: params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
 	}
@@ -668,6 +676,55 @@ func artifactPresent(destination, contentUID, containerName string) bool {
 	return err == nil &&
 		manifest.Artifact.ContentUID == contentUID &&
 		manifest.Artifact.ContainerName == containerName
+}
+
+// adoptedArtifactMountDiff reports how a pre-existing artifact's recorded mount plan differs
+// from the current source pod's, as "-stored"/"+current" entries. Empty means compatible.
+//
+// An artifact written before the mount plan was recorded carries none, and is treated as
+// compatible: there is nothing to compare it against, and refusing every such artifact would
+// break in-flight recovery for checkpoints captured by an older agent. That is a nil plan
+// only — an artifact recording an explicitly empty plan was captured from a container with
+// no mounts, and is still compared, so a pod that has since gained one is refused.
+//
+// A manifest that cannot be read is neither: the error is returned so the caller retries,
+// because "unreadable" must not be indistinguishable from "verified compatible".
+func adoptedArtifactMountDiff(artifactPath string, pod *corev1.Pod, containerName string) ([]string, error) {
+	manifest, err := types.ReadManifest(artifactPath)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest of existing artifact at %s: %w", artifactPath, err)
+	}
+	if manifest.K8s.MountPlan == nil {
+		return nil, nil
+	}
+	return types.DiffMountPlan(manifest.K8s.MountPlan, buildMountPlan(pod, containerName)), nil
+}
+
+// refuseOrAdoptArtifact writes the outcome for a committed artifact this reconcile did not
+// produce: Failed=ArtifactIncompatible when its recorded mount plan no longer matches the
+// source pod, Ready otherwise. Every path that adopts an artifact routes through here, so
+// that a validated adoption cannot be reintroduced as an unvalidated markCheckpointReady.
+//
+// Adopting skips the dump entirely, so the stored CRIU mount table is what a restore will
+// replay. If the pod's mount shape moved since the capture, that table names paths this pod
+// does not have, and the mismatch would otherwise surface only as a CRIU bind-mount failure
+// at restore, far from its cause. A nil pod means the source is already gone and there is
+// nothing to compare against, so the artifact is adopted.
+func (w *NodeController) refuseOrAdoptArtifact(ctx context.Context, content *snapshotv1alpha1.PodSnapshotContent, pod *corev1.Pod, artifactPath, containerName string) error {
+	if pod != nil {
+		diff, err := adoptedArtifactMountDiff(artifactPath, pod, containerName)
+		if err != nil {
+			// Unverified, so neither adopt nor fail terminally: returning the error
+			// leaves the work order for the next resync, which retries the read.
+			return err
+		}
+		if len(diff) > 0 {
+			return w.setSnapshotContentFailed(ctx, content, "ArtifactIncompatible",
+				fmt.Errorf("existing artifact at %s was captured with a different mount plan than pod %s/%s container %q (-stored/+current): %s",
+					artifactPath, pod.Namespace, pod.Name, containerName, strings.Join(diff, ", ")))
+		}
+	}
+	return w.markCheckpointReady(ctx, content)
 }
 
 // contentNameFromInformerObj extracts the object name from a dynamic informer object,

--- a/agent/internal/controller/podsnapshotcontent_test.go
+++ b/agent/internal/controller/podsnapshotcontent_test.go
@@ -413,6 +413,262 @@ func TestReconcileSnapshotContent_ResumeWritesReady(t *testing.T) {
 	require.NotNil(t, cond)
 }
 
+// writeAdoptableArtifact stages a pre-existing artifact carrying mountPlan, so the resume
+// path finds something to adopt.
+func writeAdoptableArtifact(t *testing.T, w *NodeController, contentUID string, mountPlan []string) {
+	t.Helper()
+	dest := filepath.Join(w.config.Storage.BasePath, "artifacts", contentUID, "containers", "main")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, snapshottypes.WriteManifest(dest, &snapshottypes.CheckpointManifest{
+		Artifact: snapshottypes.ArtifactManifest{ContentUID: contentUID, ContainerName: "main"},
+		K8s:      snapshottypes.SourcePodManifest{MountPlan: mountPlan},
+	}))
+}
+
+// mountEntry builds one stored mount-plan entry through buildMountPlan itself, so these
+// tests pin the adoption behaviour rather than the encoding buildMountPlan happens to use.
+func mountEntry(t *testing.T, mount corev1.VolumeMount) string {
+	t.Helper()
+	plan := buildMountPlan(&corev1.Pod{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main", VolumeMounts: []corev1.VolumeMount{mount}}},
+	}}, "main")
+	require.Len(t, plan, 1)
+	return plan[0]
+}
+
+// podWithMount returns a source pod whose target container mounts one emptyDir at path.
+func podWithMount(path string) *corev1.Pod {
+	pod := makeSourcePod()
+	pod.Spec.Containers = []corev1.Container{{
+		Name:         "main",
+		VolumeMounts: []corev1.VolumeMount{{Name: "scratch", MountPath: path}},
+	}}
+	return pod
+}
+
+// podWithSubPathExpr returns a source pod whose target container mounts one volume through
+// a kubelet-expanded subPathExpr.
+func podWithSubPathExpr(expr string) *corev1.Pod {
+	pod := makeSourcePod()
+	pod.Spec.Containers = []corev1.Container{{
+		Name:         "main",
+		VolumeMounts: []corev1.VolumeMount{{Name: "scratch", MountPath: "/run/dynamo-snapshot", SubPathExpr: expr}},
+	}}
+	return pod
+}
+
+// kubelet expands subPathExpr per pod, so a changed expression selects a different mounted
+// subpath while name and mountPath are unchanged. It must read as a difference, or an
+// incompatible artifact is adopted on an exact-looking match.
+func TestReconcileSourcePod_RefusesArtifactWithChangedSubPathExpr(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithSubPathExpr("$(POD_NAME)")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	stored := mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot", SubPathExpr: "$(POD_NAMESPACE)"})
+	writeAdoptableArtifact(t, w, string(content.UID), []string{stored})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	cond := meta.FindStatusCondition(getContent(t, w, content.Name).Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.Contains(t, cond.Message, "$(POD_NAME)")
+}
+
+// A mount path may legally contain the delimiter of any flat encoding, so two different
+// mount sets must not serialize to the same entry — that would report a match and adopt an
+// incompatible artifact. Here the stored plan puts "tenant" in the subPath and the pod puts
+// it in the path, which an unescaped "name:path:sub" encoding renders identically.
+func TestReconcileSourcePod_RefusesArtifactWhenColonShiftsBetweenPathAndSubPath(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/cache:tenant")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	stored := mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/cache", SubPath: "tenant"})
+	writeAdoptableArtifact(t, w, string(content.UID), []string{stored})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	cond := meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
+// ReadOnly decides whether the replayed bind mount carries MS_RDONLY, so an artifact
+// captured read-only is not interchangeable with a read-write pod spec even though every
+// name and path matches.
+func TestReconcileSourcePod_RefusesArtifactWhenReadOnlyFlips(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/dynamo-snapshot") // ReadOnly false
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	stored := mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot", ReadOnly: true})
+	writeAdoptableArtifact(t, w, string(content.UID), []string{stored})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	cond := meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
+// MountPropagation decides whether the restored mount shares a propagation group with the
+// host, so a Bidirectional artifact is not interchangeable with a pod spec that takes the
+// None default even though every name, path and flag matches.
+func TestReconcileSourcePod_RefusesArtifactWhenMountPropagationChanges(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/dynamo-snapshot") // MountPropagation nil == None
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	bidirectional := corev1.MountPropagationBidirectional
+	stored := mountEntry(t, corev1.VolumeMount{
+		Name: "scratch", MountPath: "/run/dynamo-snapshot", MountPropagation: &bidirectional,
+	})
+	writeAdoptableArtifact(t, w, string(content.UID), []string{stored})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	cond := meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
+// RecursiveReadOnly decides whether the read-only attribute reaches the whole mount subtree
+// rather than only its root, so a change is a real incompatibility. A nil field means the
+// Disabled default and must compare equal to a spec that spells that default out.
+func TestReconcileSourcePod_RefusesArtifactWhenRecursiveReadOnlyChanges(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := makeSourcePod()
+	disabled := corev1.RecursiveReadOnlyDisabled
+	pod.Spec.Containers = []corev1.Container{{
+		Name: "main",
+		VolumeMounts: []corev1.VolumeMount{{
+			Name: "scratch", MountPath: "/run/dynamo-snapshot", ReadOnly: true, RecursiveReadOnly: &disabled,
+		}},
+	}}
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	enabled := corev1.RecursiveReadOnlyEnabled
+	stored := mountEntry(t, corev1.VolumeMount{
+		Name: "scratch", MountPath: "/run/dynamo-snapshot", ReadOnly: true, RecursiveReadOnly: &enabled,
+	})
+	writeAdoptableArtifact(t, w, string(content.UID), []string{stored})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	cond := meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
+// A spec that spells out the API defaults for the two optional mount fields describes the
+// same mount as one that leaves them nil, so normalization must let it adopt — otherwise
+// every artifact captured before an unrelated spec edit is refused for no reason.
+func TestReconcileSourcePod_AdoptsArtifactWhenOptionalMountFieldsSpellOutDefaults(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	none := corev1.MountPropagationNone
+	disabled := corev1.RecursiveReadOnlyDisabled
+	pod := makeSourcePod()
+	pod.Spec.Containers = []corev1.Container{{
+		Name: "main",
+		VolumeMounts: []corev1.VolumeMount{{
+			Name: "scratch", MountPath: "/run/dynamo-snapshot",
+			MountPropagation: &none, RecursiveReadOnly: &disabled,
+		}},
+	}}
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	stored := mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot"})
+	writeAdoptableArtifact(t, w, string(content.UID), []string{stored})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed))
+	assert.True(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
+// An artifact recording an explicitly empty plan was captured from a container with no
+// mounts, which is a fact worth comparing — unlike a nil plan from an agent that recorded
+// none. A pod that has since gained a mount must be refused, not adopted.
+func TestReconcileSourcePod_RefusesEmptyStoredPlanAgainstMountedPod(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/dynamo-snapshot")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	writeAdoptableArtifact(t, w, string(content.UID), []string{})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	cond := meta.FindStatusCondition(getContent(t, w, content.Name).Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.Contains(t, cond.Message, "+"+mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot"}))
+}
+
+// A terminal source pod routes recovery through deferToCommittedCapture, which writes Ready
+// and returns — reconcileSourcePod never runs afterwards. The artifact must therefore be
+// validated on that path too, or the mount check is simply bypassed.
+func TestReconcilePodSnapshotContent_RefusesIncompatibleArtifactForTerminalPod(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/moved")
+	pod.Status.Phase = corev1.PodFailed
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	writeAdoptableArtifact(t, w, string(content.UID), []string{mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot"})})
+
+	w.reconcilePodSnapshotContent(context.Background(), content.Name)
+	got := getContent(t, w, content.Name)
+	cond := meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
+// Adopting a pre-existing artifact skips the dump, so its stored mount table is what a
+// restore replays. A matching pod spec adopts; a moved mount must be refused here rather
+// than surfacing as a CRIU bind-mount failure at restore time.
+func TestReconcileSourcePod_AdoptsArtifactWithMatchingMountPlan(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/dynamo-snapshot")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	writeAdoptableArtifact(t, w, string(content.UID), []string{mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot"})})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	assert.True(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed))
+}
+
+func TestReconcileSourcePod_RefusesArtifactWithMovedMount(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := podWithMount("/run/moved")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	writeAdoptableArtifact(t, w, string(content.UID), []string{mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot"})})
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	cond := meta.FindStatusCondition(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ArtifactIncompatible", cond.Reason)
+	assert.Contains(t, cond.Message, "-"+mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/dynamo-snapshot"}))
+	assert.Contains(t, cond.Message, "+"+mountEntry(t, corev1.VolumeMount{Name: "scratch", MountPath: "/run/moved"}))
+	assert.False(t, meta.IsStatusConditionTrue(got.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+}
+
 // TestReconcileSourcePod_ArtifactRecoveryPrecedesLivenessFailures covers the crash window:
 // the dump committed the artifact and terminated the source (pod Failed, target container
 // exited 137, PID unresolvable), but the agent died before the Ready write. Recovery must

--- a/agent/internal/controller/util.go
+++ b/agent/internal/controller/util.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -61,6 +62,52 @@ func isContainerReady(pod *corev1.Pod, containerName string) bool {
 		}
 	}
 	return false
+}
+
+// buildMountPlan returns the target container's pod-spec mount set as sorted
+// "name=<n> path=<p> sub=<s> subExpr=<e> ro=<b> prop=<p> rro=<r>" entries,
+// string values %q-quoted. This is what the CRIU images bake a mount table for,
+// so it is the shape an adopted artifact must still match — including ReadOnly,
+// which decides whether the replayed bind mount carries MS_RDONLY, and the two
+// optional fields that change the restored mount's namespace propagation and
+// recursive read-only state. Returns nil when the container is absent from the
+// spec.
+//
+// Every field is named and quoted because none of them is delimiter-safe: a
+// mount path or subPath may legally contain any byte except NUL, so a plain
+// separator lets two different mount sets encode identically and compare equal.
+// SubPath and SubPathExpr are mutually exclusive in the Kubernetes API but hold
+// separate keys here, so swapping one for the other is a difference rather than
+// a match — kubelet expands the expression per pod, and a changed expression can
+// select a different mounted subpath while every other field is unchanged.
+//
+// MountPropagation and RecursiveReadOnly are pointers whose nil means the API
+// default, so they are normalized to that default before encoding: an artifact
+// captured from a spec that spelled the default out must still match a spec
+// that left it unset.
+func buildMountPlan(pod *corev1.Pod, containerName string) []string {
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		if c.Name != containerName {
+			continue
+		}
+		plan := make([]string, 0, len(c.VolumeMounts))
+		for _, m := range c.VolumeMounts {
+			prop := corev1.MountPropagationNone
+			if m.MountPropagation != nil {
+				prop = *m.MountPropagation
+			}
+			rro := corev1.RecursiveReadOnlyDisabled
+			if m.RecursiveReadOnly != nil {
+				rro = *m.RecursiveReadOnly
+			}
+			plan = append(plan, fmt.Sprintf("name=%q path=%q sub=%q subExpr=%q ro=%t prop=%q rro=%q",
+				m.Name, m.MountPath, m.SubPath, m.SubPathExpr, m.ReadOnly, prop, rro))
+		}
+		slices.Sort(plan)
+		return plan
+	}
+	return nil
 }
 
 // checkpointLeaseName returns a DNS-safe Lease name derived from the immutable

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -45,14 +45,18 @@ func CheckpointNeedsSourceKill(err error) bool {
 
 // CheckpointRequest holds the content-owned inputs for a checkpoint operation.
 type CheckpointRequest struct {
-	ContainerID         string
-	ContainerName       string
-	ContentUID          string
-	StartedAt           time.Time
-	NodeName            string
-	PodName             string
-	PodNamespace        string
-	PodIP               string
+	ContainerID   string
+	ContainerName string
+	ContentUID    string
+	StartedAt     time.Time
+	NodeName      string
+	PodName       string
+	PodNamespace  string
+	PodIP         string
+	// MountPlan is the target container's pod-spec mount set, recorded in the
+	// manifest so a later adoption can reject an artifact whose mount table no
+	// longer matches the pod it would be restored into.
+	MountPlan           []string
 	Clientset           kubernetes.Interface
 	PageBrokerRequested bool
 }
@@ -294,7 +298,7 @@ func configureCheckpoint(
 		req.ContentUID,
 		req.ContainerName,
 		types.NewCRIUDumpManifest(criuOpts, cfg.CRIU),
-		types.NewSourcePodManifest(req.ContainerID, state.PID, req.NodeName, req.PodName, req.PodNamespace, req.PodIP, state.StdioFDs),
+		types.NewSourcePodManifest(req.ContainerID, state.PID, req.NodeName, req.PodName, req.PodNamespace, req.PodIP, state.StdioFDs, req.MountPlan),
 		types.NewOverlayManifest(cfg.Overlay, state.UpperDir, state.OCISpec),
 	)
 	if len(state.CUDANSPIDs) > 0 {

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -55,7 +55,7 @@ func TestInspectRestoreUsesContainerIDWhenProvided(t *testing.T) {
 		"content-uid-123",
 		"main",
 		types.CRIUDumpManifest{},
-		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil),
+		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil, nil),
 		types.OverlayManifest{},
 	)
 	rt := &restoreFakeRuntime{}
@@ -89,7 +89,7 @@ func TestInspectRestoreUsesDestinationNameForPodLookup(t *testing.T) {
 		"content-uid-123",
 		"main",
 		types.CRIUDumpManifest{},
-		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil),
+		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil, nil),
 		types.OverlayManifest{},
 	)
 	rt := &restoreFakeRuntime{}
@@ -131,7 +131,7 @@ func TestValidateRestoreManifest(t *testing.T) {
 		"content-uid-123",
 		"main",
 		types.CRIUDumpManifest{},
-		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "team-a", "10.0.0.11", nil),
+		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "team-a", "10.0.0.11", nil, nil),
 		types.OverlayManifest{},
 	)
 
@@ -170,7 +170,7 @@ func TestRestoreInNamespaceRejectsMultiGPUCheckpointWithoutLaunchJobState(t *tes
 		"content-uid-123",
 		"main",
 		types.CRIUDumpManifest{},
-		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil),
+		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil, nil),
 		types.OverlayManifest{},
 	)
 	manifest.CUDA = types.NewCUDAManifest([]int{42, 43}, []string{"GPU-aaa", "GPU-bbb"})

--- a/agent/internal/types/manifest.go
+++ b/agent/internal/types/manifest.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -94,9 +95,25 @@ type SourcePodManifest struct {
 
 	// StdioFDs holds readlink targets for FDs 0, 1, 2 (e.g. "pipe:[12345]").
 	StdioFDs []string `yaml:"stdioFDs,omitempty"`
+
+	// MountPlan is the target container's pod-spec mount set at dump time, as
+	// sorted `name=%q path=%q sub=%q subExpr=%q ro=%t prop=%q rro=%q` entries. The
+	// CRIU images carry this mount table, so a pre-existing artifact may only be
+	// adopted for a pod whose plan still matches — otherwise restore fails much
+	// later with a bind-mount error naming a path that no longer exists. Entries
+	// are compared verbatim, so the writer owns the encoding; it names and quotes
+	// every field because a mount path may legally contain any delimiter one
+	// might pick.
+	//
+	// Deliberately not omitempty: nil means "captured by an agent that did not
+	// record a plan" and is unverifiable, while an explicit empty list means "the
+	// container had no mounts" and must still be compared, so that a pod which has
+	// since gained one is refused. The two serialize differently only when the
+	// field is always written.
+	MountPlan []string `yaml:"mountPlan"`
 }
 
-func NewSourcePodManifest(containerID string, pid int, sourceNode, podName, podNamespace, podIP string, stdioFDs []string) SourcePodManifest {
+func NewSourcePodManifest(containerID string, pid int, sourceNode, podName, podNamespace, podIP string, stdioFDs, mountPlan []string) SourcePodManifest {
 	return SourcePodManifest{
 		ContainerID:  containerID,
 		PID:          pid,
@@ -105,7 +122,29 @@ func NewSourcePodManifest(containerID string, pid int, sourceNode, podName, podN
 		PodNamespace: podNamespace,
 		PodIP:        podIP,
 		StdioFDs:     append([]string(nil), stdioFDs...),
+		// slices.Clone keeps an empty plan non-nil, so the in-memory value carries
+		// the same absent-versus-empty meaning the field documents. Appending to a
+		// nil slice would flatten it to nil instead.
+		MountPlan: slices.Clone(mountPlan),
 	}
+}
+
+// DiffMountPlan returns the entries present in only one of the two plans, as
+// "-<entry>" for stored-only and "+<entry>" for current-only. An empty result
+// means the plans match.
+func DiffMountPlan(stored, current []string) []string {
+	var diff []string
+	for _, e := range stored {
+		if !slices.Contains(current, e) {
+			diff = append(diff, "-"+e)
+		}
+	}
+	for _, e := range current {
+		if !slices.Contains(stored, e) {
+			diff = append(diff, "+"+e)
+		}
+	}
+	return diff
 }
 
 // OverlayManifest holds runtime overlay state captured at checkpoint time.

--- a/agent/internal/types/manifest_test.go
+++ b/agent/internal/types/manifest_test.go
@@ -6,6 +6,7 @@ package types
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
@@ -28,7 +29,7 @@ func TestManifestRoundTrip(t *testing.T) {
 			External: []string{"net[12345]:extNetNs"},
 			SkipMnt:  []string{"/proc/kcore"},
 		},
-		NewSourcePodManifest("ctr-abc", 42, "node-1", "my-pod", "default", "10.0.0.11", []string{"pipe:[111]", "pipe:[222]", "pipe:[333]"}),
+		NewSourcePodManifest("ctr-abc", 42, "node-1", "my-pod", "default", "10.0.0.11", []string{"pipe:[111]", "pipe:[222]", "pipe:[333]"}, nil),
 		OverlayManifest{
 			Exclusions:     OverlaySettings{Exclusions: []string{"/proc", "/sys"}},
 			UpperDir:       "/var/lib/containerd/upper",
@@ -175,5 +176,74 @@ func TestManifestRequiresContainerName(t *testing.T) {
 	err := WriteManifest(t.TempDir(), &CheckpointManifest{Artifact: ArtifactManifest{ContentUID: "content-uid-123"}})
 	if err == nil || err.Error() != "checkpoint manifest is missing artifact.containerName" {
 		t.Fatalf("expected missing container name error, got %v", err)
+	}
+}
+
+// A moved or added mount must show up as a diff: that is what stops a stale artifact from
+// being adopted for a pod whose mount table no longer matches it.
+func TestDiffMountPlan(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		stored, current []string
+		want            []string
+	}{
+		{name: "identical", stored: []string{"a:/x"}, current: []string{"a:/x"}},
+		{name: "both empty"},
+		{name: "moved", stored: []string{"a:/x"}, current: []string{"a:/y"}, want: []string{"-a:/x", "+a:/y"}},
+		{name: "added", stored: []string{"a:/x"}, current: []string{"a:/x", "b:/y"}, want: []string{"+b:/y"}},
+		{name: "removed", stored: []string{"a:/x", "b:/y"}, current: []string{"a:/x"}, want: []string{"-b:/y"}},
+		{name: "subpath differs", stored: []string{"a:/x:s1"}, current: []string{"a:/x:s2"}, want: []string{"-a:/x:s1", "+a:/x:s2"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DiffMountPlan(tc.stored, tc.current)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("DiffMountPlan(%v, %v) = %v, want %v", tc.stored, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+// The adoption guard distinguishes a nil plan ("written before plans were recorded", so
+// unverifiable) from an explicitly empty one ("this container had no mounts", so still
+// comparable). The field is written unconditionally to keep that true: under omitempty an
+// empty plan would serialize identically to an old artifact's missing key, and a pod that
+// has since gained a mount would be adopted instead of refused.
+func TestMountPlanRoundTripKeepsAbsentDistinctFromEmpty(t *testing.T) {
+	write := func(t *testing.T, plan []string) []string {
+		t.Helper()
+		dir := t.TempDir()
+		manifest := &CheckpointManifest{
+			Artifact: ArtifactManifest{ContentUID: "content-uid-123", ContainerName: "main"},
+			K8s:      NewSourcePodManifest("ctr", 1, "node-1", "pod", "default", "", nil, plan),
+		}
+		if err := WriteManifest(dir, manifest); err != nil {
+			t.Fatalf("WriteManifest: %v", err)
+		}
+		loaded, err := ReadManifest(dir)
+		if err != nil {
+			t.Fatalf("ReadManifest: %v", err)
+		}
+		return loaded.K8s.MountPlan
+	}
+
+	if got := write(t, []string{}); got == nil {
+		t.Fatal("an explicitly empty plan round-tripped to nil, so it would be skipped as unverifiable")
+	}
+	if got := write(t, []string{"a:/x"}); !slices.Equal(got, []string{"a:/x"}) {
+		t.Fatalf("MountPlan = %v, want [a:/x]", got)
+	}
+
+	// An artifact from an agent that predates the field carries no key at all.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, manifestFilename),
+		[]byte("artifact:\n  contentUID: content-uid-123\n  containerName: main\nk8s:\n  podName: pod\n"), 0o600); err != nil {
+		t.Fatalf("write legacy manifest: %v", err)
+	}
+	loaded, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if loaded.K8s.MountPlan != nil {
+		t.Fatalf("a manifest without mountPlan read back as %#v, want nil", loaded.K8s.MountPlan)
 	}
 }


### PR DESCRIPTION
When a capture finds a complete artifact already on disk it adopts it and writes `Ready=True reason=Captured` without dumping — observed with `creationTimestamp` and the Ready `lastTransitionTime` in the same second. Nothing checked that the artifact still matches the pod it would restore into.

If the pod's mounts moved since the original capture, the adopted CRIU images carry the old mount table and the failure lands far from its cause: the CR says `Captured`, and restore fails on a path that no longer exists anywhere.

```text
Error (criu/mount.c:2394): mnt: Can't bind-mount at /tmp/.criu.mntns.*/13-0000000000/run/dynamo-snapshot: No such file or directory
```

**Change:** record the mount plan at capture, check it at adoption.

- `SourcePodManifest.MountPlan` — the container's pod-spec mounts as sorted `volumeName:mountPath[:subPath]`, the shape CRIU bakes a mount table for.
- On adoption, a mismatch lands `Failed reason=ArtifactIncompatible` with a message naming the differing paths as `-stored`/`+current`.

An artifact written before this field carries no plan and stays adoptable — refusing those would break crash-window recovery for older agents. Deliberate, commented at `adoptedArtifactMountDiff`.

I recorded the plan rather than the hash the issue offered: same cost, and it can name what differs.

**Note on drift:** the issue was filed against v0.1.0-alpha.1, where adoption keyed on checkpoint id. On `main` the path is keyed by content UID and adoption lives in the agent, so a fresh CR gets a fresh path. The branch is still there and still unvalidated — it is the crash-window recovery path — so the fix goes where the adoption actually happens.

**Tests:** linux, go 1.26 → controller `ok 0.631s`, executor `ok 0.136s`, types `ok 0.049s`. Adds two `reconcileSourcePod` cases and a `TestDiffMountPlan` table. `TestDiffMountPlan` red-proofed: deleting the current-only branch fails 3 subtests on their own assertions.

Fixes #145
