### PR TITLE
docs: mntnsCompatMode is a dump-time setting, and the RKE2 mount-v2 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,51 @@ Current limitations:
 
 Multi-GPU and Arm support are on the roadmap.
 
+## Known Issues
+
+### `mntnsCompatMode` is applied at dump time, not restore time
+
+`config.criu.mntnsCompatMode` reads as a restore-side option — it maps to a CRIU
+restore RPC field — but it takes effect **at capture**. The value in force when a
+checkpoint is dumped is persisted into that checkpoint's `manifest.yaml`, and
+`BuildRestoreOpts` reads the setting back out of the manifest
+(`m.CRIUDump.CRIU`) rather than from the agent's live configuration.
+
+Consequences:
+
+- Flipping `config.criu.mntnsCompatMode` does **not** change how an already
+  captured checkpoint restores. Only checkpoints captured after the change pick
+  it up.
+- A restore that still fails after enabling the flag is not evidence the flag
+  does not help — re-capture first, then restore.
+
+### CRIU mount-v2 sharing-copy failure with nvidia-runtime bind mounts on RKE2
+
+Restoring a checkpoint captured with `runtimeClassName: nvidia` can fail in
+CRIU's mount-v2 engine while restoring the NVIDIA device bind mounts:
+
+```text
+mnt-v2: Failed to copy sharing from -1:/dev/nvidia0 to <id>: Invalid argument
+...
+Restoring FAILED
+```
+
+The device mounts are correctly declared external on both sides; this is CRIU's
+mount-namespace-restore engine failing to reconcile the mount's
+propagation/sharing group recorded at dump time against the restore mount
+namespace — a separate mechanism from external-mount handling, and dependent on
+the host's mount-propagation setup.
+
+**Workaround:** set `config.criu.mntnsCompatMode=true` **before** capturing the
+checkpoint you intend to restore, then re-capture. Per the note above, enabling
+it after the capture cannot fix an existing artifact.
+
+```bash
+helm upgrade --install snapshot ./charts/snapshot \
+  --namespace "${NAMESPACE}" \
+  --set config.criu.mntnsCompatMode=true
+```
+
 ## Documentation
 
 **Get started**

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -242,9 +242,17 @@ config:
     manageCgroupsMode: soft # CRIU cgroup management mode (ignore/soft/full/strict)
     imageIoMode: direct     # CRIU image I/O mode (writeback/direct); direct uses O_DIRECT to avoid page-cache double-buffering
 
-    # Restore-specific options (only apply during CRIU restore, not dump)
+    # Restore-side options. These shape the restore, not the dump; note that
+    # mntnsCompatMode below is nonetheless read at capture time and persisted.
     rstSibling: true         # Restore as sibling process (required for go-criu swrk mode)
-    mntnsCompatMode: false   # Mount namespace compatibility mode
+    # Mount namespace compatibility mode. This is a restore-side CRIU option,
+    # but it is APPLIED AT DUMP TIME: the value in effect when a checkpoint is
+    # captured is persisted into that checkpoint's manifest.yaml, and
+    # BuildRestoreOpts reads it back from there (m.CRIUDump.CRIU) rather than
+    # from the agent's live config. Flipping this value therefore does NOT
+    # change how an existing checkpoint restores — set it before the capture
+    # and re-capture to take effect. See Known Issues in the top-level README.
+    mntnsCompatMode: false
     evasiveDevices: true     # Use any device path if original is inaccessible
     forceIrmap: true         # Force resolving inotify/fsnotify watch names
 


### PR DESCRIPTION
`config.criu.mntnsCompatMode` maps to a CRIU **restore** RPC field, so it reads as a restore-time knob. It is not one.

`BuildRestoreOpts` builds its options from the checkpoint's persisted manifest (`settings := m.CRIUDump.CRIU`), not from the agent's live config. The value in force **at capture** is what a checkpoint restores with. Flipping the chart value does not change an existing checkpoint; only later captures pick it up.

That makes the workaround easy to apply too late and read as a false negative — a restore that still fails after enabling the flag looks like the flag did not help, when it simply was not set before the capture. Verified 3/3 in #144: a pre-flip checkpoint fails identically with the flag on; re-capturing with it on succeeds.

**Change:** docs only.

- `values.yaml`: the comment now says it is applied at dump time and a re-capture is required.
- `README.md`: a Known Issues section with that entry, plus the CRIU mount-v2 sharing-copy failure for nvidia bind mounts on RKE2 and its `mntnsCompatMode=true` + re-capture workaround.

The mount-v2 entry is explicit that external-mount handling is *not* the bug — the device mounts are correctly declared external on both sides. It is CRIU failing to reconcile the propagation group recorded at dump time.

Scope: ask (2) of #144. Ask (1), the upstream CRIU/kernel investigation, and ask (3), a restore-time override, are out of scope.

**Tests:** `helm lint` and `helm unittest charts/snapshot` pass; `helm template` output unchanged apart from the comment.

Fixes #144


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance explaining that `mntnsCompatMode` must be enabled before capturing a checkpoint and that its setting is retained in checkpoint metadata for restoration.
  - Clarified that changing the configuration does not affect existing checkpoints until they are captured again; the default remains disabled.
  - Documented an RKE2/NVIDIA runtime restore issue involving mount handling and provided a Helm-based recapture workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->