### PR TITLE
feat(agent): checkpoint POSIX CUDA VMM state

### DIFF
--- a/agent/cmd/cuinterpose/README.md
+++ b/agent/cmd/cuinterpose/README.md
@@ -1,0 +1,199 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Same-node POSIX CUDA VMM checkpoint and restore
+
+This interposer implements checkpoint and restore for CUDA VMM allocations
+shared between processes on one node with
+`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`.
+
+## Contract
+
+Enable delivery on the SnapshotJob source Pod template:
+
+```yaml
+metadata:
+  annotations:
+    nvidia.com/cuda-interposer: enabled
+```
+
+Snapshot's PodContract shaper copies the shim and `cuda-checkpoint` from the
+configured agent image into an `emptyDir`, mounts it at
+`/tmp/snapshot-interposer`, prepends the shim to `LD_PRELOAD`, and launches
+every checkpoint target through the injected
+`cuda-checkpoint --launch-job`. During restore, the node agent mounts the same
+tool directory from `/snapshot-binaries/cuinterposer` at that path. The
+restore placeholder has no interposer init container and does not preload the
+shim; CRIU restores the already-interposed process tree.
+
+The shim requires glibc 2.34 or newer, covering Ubuntu 22.04 (glibc 2.35) and
+later. It resolves the real `dlsym` through one
+`dlvsym(..., "GLIBC_2.34")` bootstrap. The Makefile rejects any higher glibc
+requirement. The coordinator is statically linked and does not inherit this
+workload glibc constraint.
+
+The annotation enables the complete capture contract, including the launch-job
+wrapper. Workload users do not supply `cuda-checkpoint` or add another wrapper.
+
+The snapshot agent keys off the live shim Unix sockets at
+`/snapshot-control/cuinterposer-<namespace-pid>.sock`, not `/proc/<pid>/environ`.
+Python `setproctitle` (vLLM/SGLang) can clobber procfs environment while the
+sockets remain. No sockets skips prepare. A partial or invalid set of sockets
+fails closed. Restore runs the coordinator only when the checkpoint artifact
+contains `cuinterposer.state`.
+
+Legacy CUDA IPC remains driver-owned and is unsupported by this shim.
+
+`DYN_SNAPSHOT_PARTICIPANT_ID` may provide a stable 32-character lowercase
+hex participant ID. Otherwise, the shim creates one when the process starts.
+
+The orchestrator must externally quiesce the application at the checkpoint
+boundary. Allocation sharing, import, mapping, access updates, kernel work,
+communication-library setup, and teardown must not be in flight.
+
+During ordinary execution:
+
+- CUDA generic allocation handles for POSIX-capable allocations tracked by the
+  shim are tagged logical tokens; the corresponding real driver handles remain
+  internal.
+- Untracked CUDA generic allocation handles remain real driver handles.
+- A POSIX-capable allocation becomes checkpoint-managed when its ticket fd
+  is exported.
+- POSIX exports return sealed ticket FDs containing the creator,
+  allocation, endpoint, and authorization identities.
+- A ticket import resolves through the creator's local Unix endpoint. A
+  transient raw CUDA FD is passed with `SCM_RIGHTS`, imported,
+  closed immediately, and never returned to the application.
+- A raw external POSIX import is passed directly to CUDA and is not tracked by
+  the shim.
+
+Handle ownership is explicit:
+
+| Source | Application receives | Managed table | Driver-handle owner |
+| --- | --- | --- | --- |
+| POSIX-capable create, tracked retain, or ticket import | Tagged logical token | Logical token to driver handle | Shim |
+| Raw external import or other pass-through | Real driver handle | None | Application |
+| Checkpoint carrier | Nothing | No separate entry | Shim |
+
+`posix.c` owns the sealed ticket format and remote creator exchange.
+`symbols.c` owns `dlsym`, `cuGetProcAddress`, and the replacement table.
+`interpose.c` owns CUDA interception, allocation state, and local raw exports.
+
+Before native CUDA checkpoint, the snapshot agent asks the native coordinator
+to validate the complete participant topology. The original `cuMemCreate`
+participant is always the saver and must still have a live creator handle or
+mapping (the creator-anchor invariant). Prepare then keeps one unmapped
+creator-local carrier, removes managed mappings without freeing VA
+reservations, and releases importer handles. Native CUDA alone saves and
+restores allocation bytes.
+
+On restore, native CUDA first restores creator allocations. CUDA processes are
+then unlocked so the shim can replay VMM topology while the application stays
+behind the restore-complete sentinel. The coordinator restores every creator
+and returns to listening before any importer requests a fresh export. The shim
+remaps every allocation at its saved VA, restores effective access and required
+handle translations, and performs final topology validation. Any failed
+validation fails closed. There is no rollback after checkpoint preparation
+mutates CUDA state.
+
+The native coordinator atomically writes `cuinterposer.state`, its opaque durable
+topology sidecar, in the checkpoint directory. Go only orders native VMM
+prepare and restore; it does not serialize or inspect the topology. The
+sidecar contains no raw FDs or allocation contents.
+
+## Interception and symbol resolution
+
+The shim covers direct Driver API symbols and these resolver paths:
+
+- explicit `dlsym()` lookups from `libcuda.so` and `libcudart.so`;
+- `cuGetProcAddress`, `cuGetProcAddress_v2`, and `_ptsz`;
+- `cudaGetDriverEntryPoint` and `cudaGetDriverEntryPointByVersion`, including
+  the `_ptsz` exports present in CUDA 13.
+
+CUDA resolvers must first return success, a valid entry, and a successful query
+status when present. The shim then substitutes only symbols in its existing
+replacement table, using the requested CUDA version to select the ABI.
+Chaining with another `dlsym()` interposer and preserving original-caller
+`RTLD_NEXT` lookup scope are unsupported.
+
+## Testing
+
+Run the native interposer integration test from the repository root:
+
+```bash
+uv run --project agent/cmd/cuinterpose/tests \
+  pytest agent/cmd/cuinterpose/tests/test_cucheckpoint.py -v
+```
+
+## Qualification
+
+Disjoint GPU qualification is limited to source GPUs 0/1 restored onto
+destination GPUs 4/5 with user-mode `libcuda` 615.65 and kernel RM 595.58.03.
+
+## Limitations and future extensions
+
+> [!WARNING]
+> Raw external POSIX imports are passed through and are not tracked or
+> reconstructed. Every mapping and handle from such an import must be unmapped
+> and released before checkpoint prepare, as the GMS saver/sleep flow does. If
+> retained, native checkpoint may fail, or restore may later see stale or
+> incomplete sharing; the shim cannot validate this.
+
+The shim reserves generic handles whose top 16 bits are `0xd94d` for logical
+tokens. If CUDA returns a raw pass-through handle in that range, the shim
+releases it and returns `CUDA_ERROR_INVALID_HANDLE`.
+
+### Potentially silent gaps
+
+The following gaps can bypass bookkeeping or silently preserve stale state:
+
+- An un-interposed raw export or import call bypasses bookkeeping.
+- A missing or unreadable `LD_PRELOAD` path is skipped by the loader with a
+  warning on stderr but no failure, so the workload runs uninterposed and exits
+  0. A shim that is present but below the glibc floor above instead fails
+  loudly, exiting 1 before `main`.
+- Raw FD aliases created with `dup` or `fcntl` are invisible.
+- Raw FDs cached, queued, or transferred with `SCM_RIGHTS` outside the adapter
+  can later import stale pre-restore state.
+- An unshimmed broker or helper makes the sharing topology incomplete.
+- An uncovered CUDA runtime symbol-resolution path can bypass wrappers.
+- An old generic handle retained by an uncovered consumer can be stale.
+- NVIDIA-specific `ioctl`, `fstat`, or `poll` semantics on a ticket FD are
+  unsupported.
+- Checkpoint during sharing or communicator construction is unsupported.
+
+Applications must finish setup and externally quiesce the complete process
+group first.
+
+Children created with `fork()` and no subsequent `exec()` lazily receive a fresh
+random process-local participant identity, a child-PID control socket and thread,
+and empty allocation, handle, and mapping bookkeeping on their first intercepted
+VMM operation. This supports the fork-before-CUDA-initialization lifecycle used
+by vLLM. An explicitly configured parent participant ID is never reused by a
+forked child.
+
+Forking after the shim has tracked VMM allocations, handles, or mappings is
+unsupported. The child deliberately discards its inherited copies without
+freeing them or calling CUDA; inherited tracked CUDA state is not reconciled or
+preserved.
+
+### Fail-closed limitations
+
+The coordinator fails closed for a missing creator anchor, incomplete
+participants or topology, more than eight access descriptors, access ranges
+that partially overlap a tracked mapping, and reconstruction or final
+validation failures. One access call may cover multiple complete mappings.
+There is no rollback after checkpoint preparation mutates CUDA state.
+
+### Future compatibility
+
+FABRIC/IMEX handles, non-POSIX allocation sharing, raw-FD compatibility, and
+multi-node rendezvous are not implemented. The durable sidecar preserves
+allocation type, location, requested-handle type, mapping, access, and creator
+topology needed for those future compatibility seams. Creator endpoints and
+authorization tokens remain transient live/ticket data and are not sidecar
+fields. The sidecar intentionally contains neither raw FDs nor allocation
+bytes.

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -4,87 +4,1365 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define _GNU_SOURCE
+
+#include <cuda.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "posix.h"
+#include "protocol.h"
 #include "symbols.h"
+#include "util.h"
 
-#define LOOKUP(name, type) ((type)cuinterposer_lookup_real_symbol(#name))
+#define CONTROL_DIR "/snapshot-control"
+#define CONTROL_TIMEOUT_SECONDS 30
+#define LOGICAL_HANDLE_TAG UINT64_C(0xd94d000000000000)
+#define LOGICAL_HANDLE_TAG_MASK UINT64_C(0xffff000000000000)
+#define LOGICAL_HANDLE_VALUE_MASK UINT64_C(0x0000ffffffffffff)
 
-CUresult CUDAAPI
-cuMemCreate(
-    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties,
-    unsigned long long flags)
+CUresult CUDAAPI cuMemRetainAllocationHandle(CUmemGenericAllocationHandle*, void*);
+CUresult CUDAAPI cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+
+typedef CUresult(CUDAAPI* create_fn)(
+    CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+typedef CUresult(CUDAAPI* release_fn)(CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* retain_fn)(CUmemGenericAllocationHandle*, void*);
+typedef CUresult(CUDAAPI* map_fn)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+typedef CUresult(CUDAAPI* unmap_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* access_fn)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+typedef CUresult(CUDAAPI* export_fn)(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+typedef CUresult(CUDAAPI* context_set_fn)(CUcontext);
+
+struct allocation;
+
+struct handle {
+  CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle driver;
+  bool live;
+  struct allocation* allocation;
+  struct handle* next;
+};
+
+struct mapping {
+  CUdeviceptr address;
+  size_t size;
+  size_t offset;
+  CUmemAccessDesc access[CUINTERPOSER_MAX_ACCESS];
+  size_t access_count;
+  bool mapped;
+  bool checkpointed;
+  struct allocation* allocation;
+  struct mapping* next;
+};
+
+struct allocation {
+  uint8_t id[CUINTERPOSER_ALLOCATION_ID_SIZE];
+  uint8_t authorization[CUINTERPOSER_TOKEN_SIZE];
+  char creator_participant[CUINTERPOSER_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  size_t size;
+  CUmemAllocationProp properties;
+  CUcontext context;
+  CUmemGenericAllocationHandle carrier;
+  bool creator;
+  bool shared;
+  struct allocation* next;
+};
+
+enum phase {
+  PHASE_ACTIVE,
+  PHASE_CARRIERS,
+  PHASE_PREPARED,
+  PHASE_CREATORS_RESTORED,
+  PHASE_FAILED,
+};
+
+struct context_scope {
+  CUcontext previous;
+  bool changed;
+};
+
+static pthread_mutex_t state_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct allocation* allocations;
+static struct handle* handles;
+static struct mapping* mappings;
+static enum phase current_phase = PHASE_ACTIVE;
+static char failure[96];
+static char participant_id[CUINTERPOSER_ID_SIZE];
+static char control_directory[sizeof(((struct sockaddr_un*)0)->sun_path)];
+static char socket_path[sizeof(((struct sockaddr_un*)0)->sun_path)];
+static int listener = -1;
+static bool endpoint_needs_initialization;
+static uint64_t next_logical_handle = 1;
+
+static void
+set_failure(const char* message)
 {
-  typedef CUresult(CUDAAPI * function_type)(
-      CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
-  function_type function = LOOKUP(cuMemCreate, function_type);
-  return function != NULL ? function(output, size, properties, flags) : cuinterposer_unavailable();
+  current_phase = PHASE_FAILED;
+  snprintf(failure, sizeof(failure), "%s", message);
+}
+
+static void
+set_importer_failure(const char* operation, CUresult result)
+{
+  current_phase = PHASE_FAILED;
+  if (result == CUDA_SUCCESS)
+    snprintf(failure, sizeof(failure), "importer restore: %s", operation);
+  else
+    snprintf(failure, sizeof(failure), "importer restore: %s failed: CUresult=%d", operation, (int)result);
+}
+
+static struct allocation*
+find_allocation(const uint8_t id[CUINTERPOSER_ALLOCATION_ID_SIZE])
+{
+  struct allocation* allocation;
+
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (memcmp(allocation->id, id, CUINTERPOSER_ALLOCATION_ID_SIZE) == 0)
+      return allocation;
+  }
+  return NULL;
+}
+
+static bool
+is_logical_handle(CUmemGenericAllocationHandle handle)
+{
+  return ((uint64_t)handle & LOGICAL_HANDLE_TAG_MASK) == LOGICAL_HANDLE_TAG;
+}
+
+static struct handle*
+resolve_managed_handle(CUmemGenericAllocationHandle logical)
+{
+  struct handle* handle;
+
+  if (!is_logical_handle(logical))
+    return NULL;
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->logical == logical)
+      return handle;
+  }
+  return NULL;
+}
+
+static int
+allocate_logical_handle(CUmemGenericAllocationHandle* output)
+{
+  if (next_logical_handle == 0 || next_logical_handle > LOGICAL_HANDLE_VALUE_MASK)
+    return -1;
+  *output = (CUmemGenericAllocationHandle)(LOGICAL_HANDLE_TAG | next_logical_handle++);
+  return 0;
+}
+
+static CUresult
+transfer_passthrough_handle(CUresult result, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* output)
+{
+  release_fn release;
+
+  if (result != CUDA_SUCCESS)
+    return result;
+  if (output == NULL || is_logical_handle(driver)) {
+    release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  *output = driver;
+  return CUDA_SUCCESS;
+}
+
+static struct mapping*
+find_mapping(CUdeviceptr address, size_t size)
+{
+  struct mapping* mapping;
+
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->mapped && mapping->address == address && mapping->size == size)
+      return mapping;
+  }
+  return NULL;
+}
+
+static struct mapping*
+find_mapping_at(CUdeviceptr address)
+{
+  struct mapping* mapping;
+
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->mapped && address >= mapping->address && address < mapping->address + mapping->size)
+      return mapping;
+  }
+  return NULL;
+}
+
+static size_t
+live_handle_count(const struct allocation* allocation)
+{
+  const struct handle* handle;
+  size_t count = 0;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->allocation == allocation)
+      count++;
+  }
+  return count;
+}
+
+static struct mapping*
+first_mapping(const struct allocation* allocation)
+{
+  struct mapping* mapping;
+
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->allocation == allocation && mapping->mapped)
+      return mapping;
+  }
+  return NULL;
+}
+
+static struct handle*
+first_live_handle(const struct allocation* allocation)
+{
+  struct handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->allocation == allocation && handle->live)
+      return handle;
+  }
+  return NULL;
+}
+
+static int
+add_managed_handle(
+    struct allocation* allocation, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* logical)
+{
+  struct handle* handle = calloc(1, sizeof(*handle));
+
+  if (handle == NULL || allocate_logical_handle(logical) != 0) {
+    free(handle);
+    return -1;
+  }
+  handle->logical = *logical;
+  handle->driver = driver;
+  handle->live = true;
+  handle->allocation = allocation;
+  handle->next = handles;
+  handles = handle;
+  return 0;
+}
+
+static int
+enter_context(CUcontext context, struct context_scope* scope)
+{
+  context_get_fn get_current = (context_get_fn)cuinterposer_lookup_real_symbol("cuCtxGetCurrent");
+  context_set_fn set_current = (context_set_fn)cuinterposer_lookup_real_symbol("cuCtxSetCurrent");
+
+  memset(scope, 0, sizeof(*scope));
+  if (get_current == NULL || set_current == NULL || get_current(&scope->previous) != CUDA_SUCCESS)
+    return -1;
+  if (scope->previous != context) {
+    if (set_current(context) != CUDA_SUCCESS)
+      return -1;
+    scope->changed = true;
+  }
+  return 0;
+}
+
+static int
+leave_context(const struct context_scope* scope)
+{
+  context_set_fn set_current = (context_set_fn)cuinterposer_lookup_real_symbol("cuCtxSetCurrent");
+
+  return !scope->changed || (set_current != NULL && set_current(scope->previous) == CUDA_SUCCESS) ? 0 : -1;
+}
+
+static int
+current_context(CUcontext* context)
+{
+  context_get_fn get_current = (context_get_fn)cuinterposer_lookup_real_symbol("cuCtxGetCurrent");
+
+  return get_current != NULL && get_current(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
+}
+
+static CUresult
+export_raw(struct allocation* allocation, int* output)
+{
+  export_fn export_handle = (export_fn)cuinterposer_lookup_real_symbol("cuMemExportToShareableHandle");
+  retain_fn retain = (retain_fn)cuinterposer_lookup_real_symbol("cuMemRetainAllocationHandle");
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+  struct context_scope scope;
+  struct handle* handle;
+  struct mapping* mapping;
+  CUmemGenericAllocationHandle temporary = 0;
+  CUresult result;
+
+  *output = -1;
+  if (!allocation->creator || export_handle == NULL || enter_context(allocation->context, &scope) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  handle = first_live_handle(allocation);
+  if (allocation->carrier != 0)
+    temporary = allocation->carrier;
+  else if (handle != NULL)
+    temporary = handle->driver;
+  else if ((mapping = first_mapping(allocation)) != NULL && retain != NULL) {
+    result = retain(&temporary, (void*)(uintptr_t)mapping->address);
+    if (result != CUDA_SUCCESS)
+      goto done;
+  } else {
+    result = CUDA_ERROR_INVALID_HANDLE;
+    goto done;
+  }
+  result = export_handle(output, temporary, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+  if (temporary != allocation->carrier && (handle == NULL || temporary != handle->driver) && release != NULL)
+    (void)release(temporary);
+done:
+  if (leave_context(&scope) != 0) {
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    return CUDA_ERROR_UNKNOWN;
+  }
+  return result;
+}
+
+static int
+request_export(const struct cuinterposer_posix_ticket* ticket, int* output, char* error, size_t error_size)
+{
+  int result = -1;
+
+  *output = -1;
+  if (error != NULL && error_size != 0)
+    error[0] = '\0';
+  if (strcmp(ticket->creator_participant, participant_id) == 0) {
+    struct allocation* allocation;
+    CUresult export_result;
+
+    pthread_mutex_lock(&state_lock);
+    allocation = find_allocation(ticket->allocation_id);
+    if (allocation == NULL ||
+        memcmp(allocation->authorization, ticket->authorization, sizeof(allocation->authorization)) != 0) {
+      if (error != NULL && error_size != 0)
+        snprintf(error, error_size, "%s", "creator allocation is unavailable");
+    } else if ((export_result = export_raw(allocation, output)) != CUDA_SUCCESS) {
+      if (error != NULL && error_size != 0)
+        snprintf(error, error_size, "creator export failed: CUresult=%d", (int)export_result);
+    } else {
+      result = 0;
+    }
+    pthread_mutex_unlock(&state_lock);
+    return result;
+  }
+  return cuinterposer_posix_request_export(ticket, output, error, error_size);
+}
+
+static struct cuinterposer_record*
+inspect_records(uint32_t* count)
+{
+  struct cuinterposer_record* records;
+  struct cuinterposer_record* record;
+  struct allocation* allocation;
+  struct mapping* mapping;
+  size_t total = 0;
+  size_t index;
+
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (allocation->shared && (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL))
+      total++;
+  }
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->allocation->shared && mapping->mapped)
+      total++;
+  }
+  if (total > CUINTERPOSER_MAX_RECORDS)
+    return NULL;
+  records = calloc(total == 0 ? 1 : total, sizeof(*records));
+  if (records == NULL)
+    return NULL;
+  record = records;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    size_t handles_count = live_handle_count(allocation);
+    if (!allocation->shared || (handles_count == 0 && first_mapping(allocation) == NULL))
+      continue;
+    record->kind = CUINTERPOSER_ALLOCATION;
+    record->flags = allocation->creator ? CUINTERPOSER_CREATOR : 0;
+    if (handles_count != 0)
+      record->flags |= CUINTERPOSER_APPLICATION_HANDLE_LIVE;
+    memcpy(record->allocation_id, allocation->id, sizeof(record->allocation_id));
+    record->allocation_size = allocation->size;
+    record->allocation_type = allocation->properties.type;
+    record->requested_handle_types = allocation->properties.requestedHandleTypes;
+    record->allocation_location_type = allocation->properties.location.type;
+    record->allocation_location_id = allocation->properties.location.id;
+    record->application_handle_count = (uint32_t)handles_count;
+    record++;
+  }
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (!mapping->allocation->shared || !mapping->mapped)
+      continue;
+    record->kind = CUINTERPOSER_MAPPING;
+    record->flags = mapping->allocation->creator ? CUINTERPOSER_CREATOR : 0;
+    memcpy(record->allocation_id, mapping->allocation->id, sizeof(record->allocation_id));
+    record->address = mapping->address;
+    record->size = mapping->size;
+    record->offset = mapping->offset;
+    record->access_count = (uint32_t)mapping->access_count;
+    for (index = 0; index < mapping->access_count; index++) {
+      record->access[index].location_type = mapping->access[index].location.type;
+      record->access[index].location_id = mapping->access[index].location.id;
+      record->access[index].flags = mapping->access[index].flags;
+    }
+    record++;
+  }
+  *count = (uint32_t)total;
+  return records;
+}
+
+static bool
+driver_handle_used(const struct handle* except, CUmemGenericAllocationHandle driver)
+{
+  const struct handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle != except && handle->live && handle->driver == driver)
+      return true;
+  }
+  return false;
+}
+
+static int
+create_checkpoint_carriers(void)
+{
+  retain_fn retain = (retain_fn)cuinterposer_lookup_real_symbol("cuMemRetainAllocationHandle");
+  struct allocation* allocation;
+  struct context_scope scope;
+
+  if (current_phase != PHASE_ACTIVE || retain == NULL)
+    return -1;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    struct handle* carrier_handle;
+    struct mapping* carrier_mapping;
+    CUresult result;
+
+    if (!allocation->shared || !allocation->creator ||
+        (live_handle_count(allocation) == 0 && first_mapping(allocation) == NULL))
+      continue;
+    carrier_handle = first_live_handle(allocation);
+    carrier_mapping = first_mapping(allocation);
+    if (carrier_handle != NULL) {
+      allocation->carrier = carrier_handle->driver;
+      continue;
+    }
+    if (carrier_mapping == NULL || enter_context(allocation->context, &scope) != 0)
+      goto failed;
+    result = retain(&allocation->carrier, (void*)(uintptr_t)carrier_mapping->address);
+    if (leave_context(&scope) != 0 || result != CUDA_SUCCESS)
+      goto failed;
+  }
+  current_phase = PHASE_CARRIERS;
+  return 0;
+failed:
+  set_failure("cannot create cuinterposer checkpoint carrier");
+  return -1;
+}
+
+static int
+prepare_topology(void)
+{
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+  unmap_fn unmap = (unmap_fn)cuinterposer_lookup_real_symbol("cuMemUnmap");
+  struct allocation* allocation;
+  struct context_scope scope;
+  struct handle* handle;
+  struct mapping* mapping;
+
+  if (current_phase != PHASE_CARRIERS || release == NULL || unmap == NULL)
+    return -1;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (allocation->shared && allocation->creator &&
+        (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL) && allocation->carrier == 0)
+      goto failed;
+  }
+  current_phase = PHASE_PREPARED;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (!allocation->shared ||
+        (live_handle_count(allocation) == 0 && first_mapping(allocation) == NULL && allocation->carrier == 0))
+      continue;
+    if (enter_context(allocation->context, &scope) != 0)
+      goto failed;
+    for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->allocation == allocation && mapping->mapped) {
+        if (unmap(mapping->address, mapping->size) != CUDA_SUCCESS) {
+          (void)leave_context(&scope);
+          goto failed;
+        }
+        mapping->mapped = false;
+        mapping->checkpointed = true;
+      }
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      CUmemGenericAllocationHandle old;
+
+      if (!handle->live || handle->allocation != allocation)
+        continue;
+      old = handle->driver;
+      if (allocation->creator && old == allocation->carrier) {
+        handle->driver = allocation->carrier;
+        continue;
+      }
+      if (!driver_handle_used(handle, old) && release(old) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        goto failed;
+      }
+      handle->driver = allocation->creator ? allocation->carrier : 0;
+    }
+    if (leave_context(&scope) != 0)
+      goto failed;
+  }
+  return 0;
+failed:
+  set_failure("cannot prepare cuinterposer topology");
+  return -1;
+}
+
+static CUresult
+restore_mappings(struct allocation* allocation, CUmemGenericAllocationHandle handle, const char** operation)
+{
+  map_fn map = (map_fn)cuinterposer_lookup_real_symbol("cuMemMap");
+  access_fn set_access = (access_fn)cuinterposer_lookup_real_symbol("cuMemSetAccess");
+  struct mapping* mapping;
+  CUresult result;
+
+  if (map == NULL || set_access == NULL) {
+    *operation = "mapping symbols are unavailable";
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (!mapping->allocation->shared || mapping->allocation != allocation || !mapping->checkpointed)
+      continue;
+    result = map(mapping->address, mapping->size, mapping->offset, handle, 0);
+    if (result != CUDA_SUCCESS) {
+      *operation = "cuMemMap";
+      return result;
+    }
+    mapping->mapped = true;
+    if (mapping->access_count != 0) {
+      result = set_access(mapping->address, mapping->size, mapping->access, mapping->access_count);
+      if (result != CUDA_SUCCESS) {
+        *operation = "cuMemSetAccess";
+        return result;
+      }
+    }
+    mapping->checkpointed = false;
+  }
+  return CUDA_SUCCESS;
+}
+
+static int
+restore_creators(void)
+{
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+  struct allocation* allocation;
+  struct context_scope scope;
+  struct handle* handle;
+  const char* mapping_operation;
+
+  if ((current_phase != PHASE_PREPARED && current_phase != PHASE_FAILED) || release == NULL)
+    return -1;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (!allocation->shared || !allocation->creator || allocation->carrier == 0)
+      continue;
+    if (enter_context(allocation->context, &scope) != 0)
+      goto failed;
+    if (restore_mappings(allocation, allocation->carrier, &mapping_operation) != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      goto failed;
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      if (handle->live && handle->allocation == allocation)
+        handle->driver = allocation->carrier;
+    }
+    if (live_handle_count(allocation) == 0) {
+      if (release(allocation->carrier) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        goto failed;
+      }
+      allocation->carrier = 0;
+    }
+    if (leave_context(&scope) != 0)
+      goto failed;
+  }
+  current_phase = PHASE_CREATORS_RESTORED;
+  failure[0] = '\0';
+  return 0;
+failed:
+  set_failure("cannot restore creator cuinterposer topology");
+  return -1;
+}
+
+static int
+restore_importers(void)
+{
+  import_fn import_handle = (import_fn)cuinterposer_lookup_real_symbol("cuMemImportFromShareableHandle");
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+  struct allocation* allocation;
+  struct context_scope scope;
+  struct handle* handle;
+
+  if (current_phase != PHASE_CREATORS_RESTORED || import_handle == NULL || release == NULL) {
+    snprintf(failure, sizeof(failure), "%s", "importer restore: phase or symbols are not ready");
+    return -1;
+  }
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    struct cuinterposer_posix_ticket ticket;
+    CUmemGenericAllocationHandle imported = 0;
+    CUresult cuda_result;
+    char export_error[sizeof(failure)];
+    int export_result;
+    int raw_fd = -1;
+    bool needed = false;
+    const char* mapping_operation;
+
+    if (!allocation->shared || allocation->creator)
+      continue;
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      if (handle->live && handle->allocation == allocation) {
+        needed = true;
+        break;
+      }
+    }
+    if (!needed) {
+      struct mapping* mapping;
+      for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+        if (mapping->allocation == allocation && mapping->checkpointed) {
+          needed = true;
+          break;
+        }
+      }
+    }
+    if (!needed)
+      continue;
+    memset(&ticket, 0, sizeof(ticket));
+    ticket.magic = CUINTERPOSER_POSIX_TICKET_MAGIC;
+    ticket.version = CUINTERPOSER_POSIX_TICKET_VERSION;
+    snprintf(
+        ticket.creator_participant, sizeof(ticket.creator_participant), "%s", allocation->creator_participant);
+    memcpy(ticket.allocation_id, allocation->id, sizeof(ticket.allocation_id));
+    snprintf(ticket.creator_endpoint, sizeof(ticket.creator_endpoint), "%s", allocation->creator_endpoint);
+    memcpy(ticket.authorization, allocation->authorization, sizeof(ticket.authorization));
+    if (enter_context(allocation->context, &scope) != 0) {
+      set_importer_failure("enter context", CUDA_SUCCESS);
+      return -1;
+    }
+    pthread_mutex_unlock(&state_lock);
+    export_result = request_export(&ticket, &raw_fd, export_error, sizeof(export_error));
+    pthread_mutex_lock(&state_lock);
+    if (export_result != 0) {
+      (void)leave_context(&scope);
+      current_phase = PHASE_FAILED;
+      snprintf(
+          failure, sizeof(failure), "importer restore: creator export: %.61s",
+          export_error[0] != '\0' ? export_error : "request failed");
+      return -1;
+    }
+    cuda_result = import_handle(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    if (cuda_result != CUDA_SUCCESS) {
+      close(raw_fd);
+      (void)leave_context(&scope);
+      set_importer_failure("cuMemImportFromShareableHandle", cuda_result);
+      return -1;
+    }
+    if (close(raw_fd) != 0) {
+      (void)release(imported);
+      (void)leave_context(&scope);
+      set_importer_failure("raw FD close", CUDA_SUCCESS);
+      return -1;
+    }
+    cuda_result = restore_mappings(allocation, imported, &mapping_operation);
+    if (cuda_result != CUDA_SUCCESS) {
+      (void)release(imported);
+      (void)leave_context(&scope);
+      set_importer_failure(mapping_operation, cuda_result);
+      return -1;
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      if (handle->live && handle->allocation == allocation)
+        handle->driver = imported;
+    }
+    if (live_handle_count(allocation) == 0) {
+      cuda_result = release(imported);
+      if (cuda_result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        set_importer_failure("cuMemRelease imported handle", cuda_result);
+        return -1;
+      }
+    }
+    if (leave_context(&scope) != 0) {
+      set_importer_failure("leave context", CUDA_SUCCESS);
+      return -1;
+    }
+  }
+  current_phase = PHASE_ACTIVE;
+  failure[0] = '\0';
+  return 0;
+}
+
+static void
+serve(int client)
+{
+  struct cuinterposer_header request;
+  struct cuinterposer_header response;
+  struct cuinterposer_record* records = NULL;
+  int passed_fd = -1;
+  int exported_fd = -1;
+
+  if (receive_header(client, &request, &passed_fd) != 0)
+    goto done;
+  /* Reply with the same operation and this process's participant id. */
+  memset(&response, 0, sizeof(response));
+  response.magic = CUINTERPOSER_MAGIC;
+  response.version = CUINTERPOSER_VERSION;
+  response.operation = request.operation;
+  snprintf(response.participant_id, sizeof(response.participant_id), "%s", participant_id);
+  /* Reject ancillary FDs and requests that are not a well-formed control header for this process. */
+  if (passed_fd >= 0 || !header_strings_terminated(&request) || request.magic != CUINTERPOSER_MAGIC ||
+      request.version != CUINTERPOSER_VERSION || request.status != 0 || request.count != 0 ||
+      request.payload_size != 0 ||
+      !((request.operation == CUINTERPOSER_IDENTIFY && request.participant_id[0] == '\0') ||
+        strcmp(request.participant_id, participant_id) == 0)) {
+    header_error(&response, "invalid cuinterposer control request");
+    (void)send_header(client, &response, -1);
+    goto done;
+  }
+  pthread_mutex_lock(&state_lock);
+  switch (request.operation) {
+    case CUINTERPOSER_IDENTIFY:
+      if (current_phase == PHASE_FAILED)
+        header_error(&response, failure);
+      (void)send_header(client, &response, -1);
+      break;
+    case CUINTERPOSER_INSPECT:
+      if (current_phase != PHASE_ACTIVE) {
+        header_error(&response, "cuinterposer topology is not active");
+        (void)send_header(client, &response, -1);
+        break;
+      }
+      records = inspect_records(&response.count);
+      if (records == NULL) {
+        header_error(&response, "cannot inspect cuinterposer topology");
+        (void)send_header(client, &response, -1);
+        break;
+      }
+      response.payload_size = (uint64_t)response.count * sizeof(struct cuinterposer_record);
+      if (send_header(client, &response, -1) == 0 && response.payload_size != 0)
+        (void)write_all(client, records, (size_t)response.payload_size);
+      break;
+    case CUINTERPOSER_PREPARE:
+      if (create_checkpoint_carriers() != 0 || prepare_topology() != 0)
+        header_error(&response, failure);
+      (void)send_header(client, &response, -1);
+      break;
+    case CUINTERPOSER_RESTORE_CREATORS:
+      if (restore_creators() != 0)
+        header_error(&response, failure);
+      (void)send_header(client, &response, -1);
+      break;
+    case CUINTERPOSER_RESTORE_IMPORTERS:
+      if (restore_importers() != 0)
+        header_error(&response, failure);
+      (void)send_header(client, &response, -1);
+      break;
+    case CUINTERPOSER_EXPORT: {
+      struct allocation* allocation = find_allocation(request.allocation_id);
+      CUresult export_result;
+      if (strcmp(request.participant_id, participant_id) != 0 || allocation == NULL || !allocation->creator ||
+          memcmp(allocation->authorization, request.authorization, sizeof(request.authorization)) != 0 ||
+          (current_phase != PHASE_ACTIVE && current_phase != PHASE_CREATORS_RESTORED)) {
+        header_error(&response, "creator allocation is unavailable");
+        (void)send_header(client, &response, -1);
+        break;
+      }
+      export_result = export_raw(allocation, &exported_fd);
+      if (export_result != CUDA_SUCCESS) {
+        char message[sizeof(response.message)];
+        snprintf(message, sizeof(message), "creator export failed: CUresult=%d", (int)export_result);
+        header_error(&response, message);
+        (void)send_header(client, &response, -1);
+        break;
+      }
+      memcpy(response.allocation_id, allocation->id, sizeof(response.allocation_id));
+      (void)send_header(client, &response, exported_fd);
+      break;
+    }
+    default:
+      header_error(&response, "unknown cuinterposer control operation");
+      (void)send_header(client, &response, -1);
+      break;
+  }
+  pthread_mutex_unlock(&state_lock);
+done:
+  if (passed_fd >= 0)
+    close(passed_fd);
+  if (exported_fd >= 0)
+    close(exported_fd);
+  free(records);
+}
+
+static void*
+control_agent(void* unused)
+{
+  (void)unused;
+  for (;;) {
+    int client = accept4(listener, NULL, NULL, SOCK_CLOEXEC);
+    if (client < 0) {
+      if (errno == EINTR)
+        continue;
+      return NULL;
+    }
+    if (set_socket_timeouts(client, CONTROL_TIMEOUT_SECONDS) == 0)
+      serve(client);
+    close(client);
+  }
+}
+
+static int
+start_control_endpoint(void)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  pthread_t thread;
+
+  /* Bind the per-process control socket under the snapshot-control directory. */
+  {
+    int count =
+        snprintf(socket_path, sizeof(socket_path), "%s/%s%ld.sock", control_directory, CUINTERPOSER_SOCKET_PREFIX, (long)getpid());
+    if (count < 0 || (size_t)count >= sizeof(socket_path)) {
+      socket_path[0] = '\0';
+      return -1;
+    }
+  }
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", socket_path);
+  listener = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listener >= 0)
+    unlink(socket_path);
+  if (listener < 0 || bind(listener, (const struct sockaddr*)&address, sizeof(address)) != 0 ||
+      listen(listener, 8) != 0 || pthread_create(&thread, NULL, control_agent, NULL) != 0) {
+    if (listener >= 0)
+      close(listener);
+    listener = -1;
+    unlink(socket_path);
+    socket_path[0] = '\0';
+    return -1;
+  }
+  pthread_detach(thread);
+  return 0;
+}
+
+static void
+fork_prepare(void)
+{
+  pthread_mutex_lock(&state_lock);
+}
+
+static void
+fork_parent(void)
+{
+  pthread_mutex_unlock(&state_lock);
+}
+
+static void
+fork_child(void)
+{
+  if (listener >= 0)
+    close(listener);
+  listener = -1;
+  participant_id[0] = '\0';
+  socket_path[0] = '\0';
+  endpoint_needs_initialization = true;
+  allocations = NULL;
+  handles = NULL;
+  mappings = NULL;
+  next_logical_handle = 1;
+  current_phase = PHASE_ACTIVE;
+  failure[0] = '\0';
+  pthread_mutex_unlock(&state_lock);
+}
+
+static CUresult
+ensure_process_endpoint(void)
+{
+  CUresult result = CUDA_SUCCESS;
+
+  pthread_mutex_lock(&state_lock);
+  if (endpoint_needs_initialization) {
+    if (current_phase == PHASE_FAILED) {
+      result = CUDA_ERROR_NOT_INITIALIZED;
+    } else if (random_id(participant_id) != 0 || start_control_endpoint() != 0) {
+      set_failure("cannot start forked cuinterposer control endpoint");
+      result = CUDA_ERROR_NOT_INITIALIZED;
+    } else {
+      endpoint_needs_initialization = false;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+__attribute__((constructor)) static void
+initialize(void)
+{
+  const char* control;
+  const char* configured_participant;
+
+  configured_participant = getenv("DYN_SNAPSHOT_PARTICIPANT_ID");
+  if (configured_participant != NULL && !is_lower_hex_id(configured_participant)) {
+    set_failure("invalid cuinterposer participant identity");
+    return;
+  }
+  if (configured_participant != NULL)
+    snprintf(participant_id, sizeof(participant_id), "%s", configured_participant);
+  else if (random_id(participant_id) != 0) {
+    set_failure("cannot create cuinterposer participant identity");
+    return;
+  }
+  control = getenv("SNAPSHOT_CONTROL_DIR");
+  if (control == NULL || control[0] == '\0')
+    control = getenv("DYN_SNAPSHOT_CONTROL_DIR");
+  if (control == NULL || control[0] == '\0')
+    control = CONTROL_DIR;
+  if (control[0] != '/' || strlen(control) >= sizeof(control_directory) ||
+      snprintf(control_directory, sizeof(control_directory), "%s", control) >= (int)sizeof(control_directory)) {
+    set_failure("invalid cuinterposer control directory");
+    return;
+  }
+  if (pthread_atfork(fork_prepare, fork_parent, fork_child) != 0) {
+    set_failure("cannot register cuinterposer fork handlers");
+    return;
+  }
+  if (start_control_endpoint() != 0) {
+    set_failure("cannot start cuinterposer control endpoint");
+    return;
+  }
+}
+
+__attribute__((destructor)) static void
+finalize(void)
+{
+  if (listener >= 0)
+    close(listener);
+  if (socket_path[0] != '\0')
+    unlink(socket_path);
 }
 
 CUresult CUDAAPI
-cuMemRelease(CUmemGenericAllocationHandle handle)
+cuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
 {
-  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle);
-  function_type function = LOOKUP(cuMemRelease, function_type);
-  return function != NULL ? function(handle) : cuinterposer_unavailable();
+  create_fn function = (create_fn)cuinterposer_lookup_real_symbol("cuMemCreate");
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (properties == NULL || properties->requestedHandleTypes == 0) {
+    result = function != NULL ? function(&driver, size, properties, flags) : cuinterposer_unavailable();
+    return transfer_passthrough_handle(result, driver, output);
+  }
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (properties->requestedHandleTypes != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  if (function == NULL)
+    return cuinterposer_unavailable();
+  result = function(&driver, size, properties, flags);
+  if (result != CUDA_SUCCESS)
+    return result;
+  allocation = calloc(1, sizeof(*allocation));
+  pthread_mutex_lock(&state_lock);
+  if (allocation == NULL || current_phase != PHASE_ACTIVE ||
+      random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
+      random_bytes(allocation->authorization, sizeof(allocation->authorization)) != 0 ||
+      add_managed_handle(allocation, driver, &logical) != 0) {
+    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    free(allocation);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  allocation->size = size;
+  allocation->properties = *properties;
+  allocation->creator = true;
+  snprintf(allocation->creator_participant, sizeof(allocation->creator_participant), "%s", participant_id);
+  snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", socket_path);
+  allocation->next = allocations;
+  allocations = allocation;
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemRelease(CUmemGenericAllocationHandle application)
+{
+  release_fn function = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+  struct handle* handle;
+  CUresult result;
+
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(application) : cuinterposer_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || handle->driver == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = CUDA_SUCCESS;
+  if (!driver_handle_used(handle, handle->driver))
+    result = function != NULL ? function(handle->driver) : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS)
+    handle->live = false;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUresult CUDAAPI
 cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
 {
-  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle*, void*);
-  function_type function = LOOKUP(cuMemRetainAllocationHandle, function_type);
-  return function != NULL ? function(output, address) : cuinterposer_unavailable();
+  retain_fn function = (retain_fn)cuinterposer_lookup_real_symbol("cuMemRetainAllocationHandle");
+  struct mapping* mapping;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterposer_unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  result = function(&driver, address);
+  if (result != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  mapping = find_mapping_at((CUdeviceptr)(uintptr_t)address);
+  if (mapping == NULL) {
+    result = transfer_passthrough_handle(result, driver, output);
+  } else if (add_managed_handle(mapping->allocation, driver, &logical) != 0) {
+    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    result = CUDA_ERROR_OUT_OF_MEMORY;
+  } else {
+    *output = logical;
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUresult CUDAAPI
 cuMemMap(
-    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle application, unsigned long long flags)
 {
-  typedef CUresult(CUDAAPI * function_type)(
-      CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
-  function_type function = LOOKUP(cuMemMap, function_type);
-  return function != NULL ? function(address, size, offset, handle, flags) : cuinterposer_unavailable();
+  map_fn function = (map_fn)cuinterposer_lookup_real_symbol("cuMemMap");
+  struct mapping* mapping;
+  struct handle* handle;
+  CUresult result;
+
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(address, size, offset, application, flags) : cuinterposer_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || handle->driver == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = function != NULL ? function(address, size, offset, handle->driver, flags) : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS) {
+    mapping = calloc(1, sizeof(*mapping));
+    if (mapping == NULL) {
+      unmap_fn unmap = (unmap_fn)cuinterposer_lookup_real_symbol("cuMemUnmap");
+      if (unmap != NULL)
+        (void)unmap(address, size);
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    } else {
+      mapping->address = address;
+      mapping->size = size;
+      mapping->offset = offset;
+      mapping->mapped = true;
+      mapping->allocation = handle->allocation;
+      mapping->next = mappings;
+      mappings = mapping;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUresult CUDAAPI
 cuMemUnmap(CUdeviceptr address, size_t size)
 {
-  typedef CUresult(CUDAAPI * function_type)(CUdeviceptr, size_t);
-  function_type function = LOOKUP(cuMemUnmap, function_type);
-  return function != NULL ? function(address, size) : cuinterposer_unavailable();
+  unmap_fn function = (unmap_fn)cuinterposer_lookup_real_symbol("cuMemUnmap");
+  struct mapping* mapping;
+  CUresult result;
+
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  mapping = find_mapping(address, size);
+  if (mapping == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(address, size) : cuinterposer_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = function != NULL ? function(address, size) : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS)
+    mapping->mapped = false;
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+static bool
+record_access_over_range(
+    CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count,
+    size_t* matched)
+{
+  struct mapping* mapping;
+  CUdeviceptr end;
+
+  *matched = 0;
+  if (size > UINT64_MAX - address)
+    return false;
+  end = address + size;
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    CUdeviceptr mapping_end;
+
+    if (!mapping->mapped)
+      continue;
+    if (mapping->size > UINT64_MAX - mapping->address)
+      return false;
+    mapping_end = mapping->address + mapping->size;
+    if (mapping_end <= address || mapping->address >= end)
+      continue;
+    if (mapping->address < address || mapping_end > end)
+      return false;
+    if (descriptors != NULL) {
+      memcpy(mapping->access, descriptors, count * sizeof(*descriptors));
+      mapping->access_count = count;
+    }
+    (*matched)++;
+  }
+  return true;
 }
 
 CUresult CUDAAPI
 cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
 {
-  typedef CUresult(CUDAAPI * function_type)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
-  function_type function = LOOKUP(cuMemSetAccess, function_type);
-  return function != NULL ? function(address, size, descriptors, count) : cuinterposer_unavailable();
+  access_fn function = (access_fn)cuinterposer_lookup_real_symbol("cuMemSetAccess");
+  size_t matched;
+  CUresult result;
+
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  if (!record_access_over_range(address, size, NULL, 0, &matched)) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_SUPPORTED;
+  }
+  if (matched == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(address, size, descriptors, count)
+                            : cuinterposer_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || count > CUINTERPOSER_MAX_ACCESS) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_SUPPORTED;
+  }
+  result = function != NULL ? function(address, size, descriptors, count)
+                            : cuinterposer_unavailable();
+  if (result == CUDA_SUCCESS)
+    (void)record_access_over_range(address, size, descriptors, count, &matched);
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUresult CUDAAPI
 cuMemExportToShareableHandle(
-    void* output, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
+    void* shareable, CUmemGenericAllocationHandle application, CUmemAllocationHandleType type, unsigned long long flags)
 {
-  typedef CUresult(CUDAAPI * function_type)(
-      void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
-  function_type function = LOOKUP(cuMemExportToShareableHandle, function_type);
-  return function != NULL ? function(output, handle, type, flags) : cuinterposer_unavailable();
+  export_fn function = (export_fn)cuinterposer_lookup_real_symbol("cuMemExportToShareableHandle");
+  struct handle* handle;
+  CUcontext context;
+  CUresult result;
+  int ticket_fd = -1;
+
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(shareable, application, type, flags) : cuinterposer_unavailable();
+  }
+  if (!handle->allocation->creator || current_phase != PHASE_ACTIVE || current_context(&context) != 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  /* Issue a memfd ticket the importer uses to ask this creator for the POSIX fd. */
+  {
+    struct cuinterposer_posix_ticket ticket;
+    memset(&ticket, 0, sizeof(ticket));
+    ticket.magic = CUINTERPOSER_POSIX_TICKET_MAGIC;
+    ticket.version = CUINTERPOSER_POSIX_TICKET_VERSION;
+    snprintf(ticket.creator_participant, sizeof(ticket.creator_participant), "%s", handle->allocation->creator_participant);
+    memcpy(ticket.allocation_id, handle->allocation->id, sizeof(ticket.allocation_id));
+    snprintf(ticket.creator_endpoint, sizeof(ticket.creator_endpoint), "%s", handle->allocation->creator_endpoint);
+    memcpy(ticket.authorization, handle->allocation->authorization, sizeof(ticket.authorization));
+    if (cuinterposer_posix_create_ticket(&ticket, &ticket_fd) != 0) {
+      pthread_mutex_unlock(&state_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+  }
+  handle->allocation->context = context;
+  handle->allocation->shared = true;
+  *(int*)shareable = ticket_fd;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUresult CUDAAPI
 cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
 {
-  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
-  function_type function = LOOKUP(cuMemImportFromShareableHandle, function_type);
-  return function != NULL ? function(output, os_handle, type) : cuinterposer_unavailable();
+  import_fn function = (import_fn)cuinterposer_lookup_real_symbol("cuMemImportFromShareableHandle");
+  properties_fn get_properties;
+  struct cuinterposer_posix_ticket ticket;
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle imported = 0;
+  int raw_fd = -1;
+  int ticket_fd = (int)(uintptr_t)os_handle;
+  CUresult result;
+
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (cuinterposer_posix_read_ticket(ticket_fd, &ticket) != 0) {
+    result = function != NULL ? function(&imported, os_handle, type) : cuinterposer_unavailable();
+    return transfer_passthrough_handle(result, imported, output);
+  }
+  get_properties = (properties_fn)cuinterposer_lookup_real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  if (function == NULL || get_properties == NULL)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  pthread_mutex_unlock(&state_lock);
+  if (request_export(&ticket, &raw_fd, NULL, 0) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  result = function(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  if (close(raw_fd) != 0 && result == CUDA_SUCCESS) {
+    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(imported);
+    return CUDA_ERROR_UNKNOWN;
+  }
+  if (result != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  if (current_phase != PHASE_ACTIVE) {
+    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(imported);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  allocation = find_allocation(ticket.allocation_id);
+  if (allocation == NULL) {
+    allocation = calloc(1, sizeof(*allocation));
+    if (allocation != NULL) {
+      memcpy(allocation->id, ticket.allocation_id, sizeof(allocation->id));
+      memcpy(allocation->authorization, ticket.authorization, sizeof(allocation->authorization));
+      snprintf(
+          allocation->creator_participant, sizeof(allocation->creator_participant), "%s",
+          ticket.creator_participant);
+      snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", ticket.creator_endpoint);
+      allocation->creator = false;
+      allocation->next = allocations;
+      allocations = allocation;
+    }
+  }
+  if (allocation != NULL)
+    allocation->shared = true;
+  if (allocation == NULL || current_context(&allocation->context) != 0 ||
+      get_properties(&allocation->properties, imported) != CUDA_SUCCESS ||
+      add_managed_handle(allocation, imported, &logical) != 0) {
+    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(imported);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUresult CUDAAPI
-cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle application)
 {
-  typedef CUresult(CUDAAPI * function_type)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
-  function_type function = LOOKUP(cuMemGetAllocationPropertiesFromHandle, function_type);
-  return function != NULL ? function(properties, handle) : cuinterposer_unavailable();
-}
+  properties_fn function = (properties_fn)cuinterposer_lookup_real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  struct handle* handle;
+  CUresult result;
 
-#undef LOOKUP
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL)
+    result = is_logical_handle(application) ? CUDA_ERROR_INVALID_HANDLE
+                                            : (function != NULL ? function(properties, application) : cuinterposer_unavailable());
+  else
+    result = current_phase != PHASE_ACTIVE || handle->driver == 0
+                 ? CUDA_ERROR_NOT_READY
+                 : (function != NULL ? function(properties, handle->driver)
+                                     : cuinterposer_unavailable());
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}

--- a/agent/cmd/cuinterpose/posix.c
+++ b/agent/cmd/cuinterpose/posix.c
@@ -4,4 +4,142 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define _GNU_SOURCE
+
 #include "posix.h"
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "util.h"
+
+#define EXPORT_TIMEOUT_SECONDS 30
+
+static bool
+zero_bytes(const void* value, size_t size)
+{
+  const uint8_t* bytes = value;
+  size_t index;
+
+  for (index = 0; index < size; index++) {
+    if (bytes[index] != 0)
+      return false;
+  }
+  return true;
+}
+
+int
+cuinterposer_posix_create_ticket(const struct cuinterposer_posix_ticket* ticket, int* output)
+{
+  const int seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
+  int fd;
+
+  fd = memfd_create("cuinterposer-ticket", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (fd < 0 || write_all(fd, ticket, sizeof(*ticket)) != 0 ||
+      fcntl(fd, F_ADD_SEALS, seals) != 0) {
+    if (fd >= 0)
+      close(fd);
+    return -1;
+  }
+  *output = fd;
+  return 0;
+}
+
+int
+cuinterposer_posix_read_ticket(int fd, struct cuinterposer_posix_ticket* ticket)
+{
+  const int seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
+  struct stat status;
+
+  memset(ticket, 0, sizeof(*ticket));
+  if (fd < 0 || fcntl(fd, F_GET_SEALS) != seals || fstat(fd, &status) != 0 ||
+      status.st_size != (off_t)sizeof(*ticket) ||
+      pread_all(fd, ticket, sizeof(*ticket)) != 0 ||
+      ticket->magic != CUINTERPOSER_POSIX_TICKET_MAGIC ||
+      ticket->version != CUINTERPOSER_POSIX_TICKET_VERSION ||
+      !zero_bytes(ticket->reserved, sizeof(ticket->reserved)) ||
+      !is_lower_hex_id(ticket->creator_participant) ||
+      zero_bytes(ticket->allocation_id, sizeof(ticket->allocation_id)) ||
+      ticket->creator_endpoint[0] != '/' ||
+      memchr(ticket->creator_endpoint, '\0', sizeof(ticket->creator_endpoint)) == NULL ||
+      zero_bytes(ticket->authorization, sizeof(ticket->authorization)) ||
+      !zero_bytes(ticket->reserved_identity, sizeof(ticket->reserved_identity)))
+    return -1;
+  return 0;
+}
+
+int
+cuinterposer_posix_request_export(
+    const struct cuinterposer_posix_ticket* ticket, int* output, char* error, size_t error_size)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  struct cuinterposer_header request;
+  struct cuinterposer_header response;
+  int client = -1;
+  int result = -1;
+
+  *output = -1;
+  if (error != NULL && error_size != 0)
+    error[0] = '\0';
+  memset(&request, 0, sizeof(request));
+  request.magic = CUINTERPOSER_MAGIC;
+  request.version = CUINTERPOSER_VERSION;
+  request.operation = CUINTERPOSER_EXPORT;
+  snprintf(request.participant_id, sizeof(request.participant_id), "%s", ticket->creator_participant);
+  memcpy(request.authorization, ticket->authorization, sizeof(request.authorization));
+  memcpy(request.allocation_id, ticket->allocation_id, sizeof(request.allocation_id));
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", ticket->creator_endpoint);
+  client = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (client < 0 || set_socket_timeouts(client, EXPORT_TIMEOUT_SECONDS) != 0 ||
+      connect(client, (const struct sockaddr*)&address, sizeof(address)) != 0 ||
+      send_header(client, &request, -1) != 0 ||
+      receive_header(client, &response, output) != 0) {
+    if (error != NULL && error_size != 0)
+      snprintf(error, error_size, "%s", "cannot contact creator endpoint");
+    goto done;
+  }
+  if (!header_strings_terminated(&response) || response.magic != CUINTERPOSER_MAGIC ||
+      response.version != CUINTERPOSER_VERSION || response.operation != CUINTERPOSER_EXPORT || response.count != 0 ||
+      response.payload_size != 0 || strcmp(response.participant_id, ticket->creator_participant) != 0) {
+    if (error != NULL && error_size != 0)
+      snprintf(error, error_size, "%s", "invalid creator export response");
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    goto done;
+  }
+  if (response.status != 0) {
+    if (error != NULL && error_size != 0) {
+      if (response.message[0] != '\0')
+        snprintf(error, error_size, "%.*s", (int)sizeof(response.message), response.message);
+      else
+        snprintf(error, error_size, "%s", "creator export request failed");
+    }
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    goto done;
+  }
+  if (memcmp(response.allocation_id, ticket->allocation_id, sizeof(response.allocation_id)) != 0 || *output < 0) {
+    if (error != NULL && error_size != 0)
+      snprintf(error, error_size, "%s", "invalid creator export response");
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    goto done;
+  }
+  result = 0;
+done:
+  if (client >= 0)
+    close(client);
+  return result;
+}

--- a/agent/cmd/cuinterpose/posix.h
+++ b/agent/cmd/cuinterpose/posix.h
@@ -7,4 +7,34 @@
 #ifndef CUINTERPOSER_POSIX_H
 #define CUINTERPOSER_POSIX_H
 
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/un.h>
+
+#include "protocol.h"
+
+#define CUINTERPOSER_POSIX_TICKET_MAGIC 0x44564d43U
+#define CUINTERPOSER_POSIX_TICKET_VERSION 1U
+
+struct cuinterposer_posix_ticket {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t reserved[35];
+  char creator_participant[CUINTERPOSER_ID_SIZE];
+  uint8_t allocation_id[CUINTERPOSER_ALLOCATION_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  uint8_t authorization[CUINTERPOSER_TOKEN_SIZE];
+  uint8_t reserved_identity[42];
+};
+
+_Static_assert(sizeof(struct cuinterposer_posix_ticket) == 256, "cuinterposer POSIX ticket layout changed");
+
+/* On success, output receives a ticket FD owned by the caller. */
+int cuinterposer_posix_create_ticket(const struct cuinterposer_posix_ticket* ticket, int* output);
+/* Reads without taking ownership of fd. */
+int cuinterposer_posix_read_ticket(int fd, struct cuinterposer_posix_ticket* ticket);
+/* On success, output receives a raw export FD owned by the caller. */
+int cuinterposer_posix_request_export(
+    const struct cuinterposer_posix_ticket* ticket, int* output, char* error, size_t error_size);
+
 #endif

--- a/agent/cmd/cuinterpose/tests/pyproject.toml
+++ b/agent/cmd/cuinterpose/tests/pyproject.toml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "cuinterposer-tests"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+  "cuda-bindings>=13.0.3,<14",
+  "pytest",
+  "torch>=2.11,<2.12",
+]
+
+[tool.uv]
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["."]

--- a/agent/cmd/cuinterpose/tests/test_cucheckpoint.py
+++ b/agent/cmd/cuinterpose/tests/test_cucheckpoint.py
@@ -1,0 +1,771 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ctypes
+import os
+import queue
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import traceback
+from multiprocessing.reduction import recv_handle, send_handle
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cuda.bindings import driver
+
+WORLD_SIZE = 2
+NUMEL = 2048
+COMMAND_TIMEOUT_SECONDS = 60
+CHECKPOINT_TIMEOUT_SECONDS = 120
+WORKER_TIMEOUT_SECONDS = 240
+PARENT_PARTICIPANT_ID = "a" * 32
+LOGICAL_HANDLE_TAG = 0xD94D000000000000
+LOGICAL_HANDLE_TAG_MASK = 0xFFFF000000000000
+POSIX_FD_HANDLE_TYPE = (
+    driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+)
+
+
+class _ExternalAllocation(NamedTuple):
+    device: driver.CUdevice
+    context: driver.CUcontext
+    address: int
+    size: int
+    handle: driver.CUmemGenericAllocationHandle
+    fd: int
+
+
+def _cuda_call(function, *arguments):
+    status, *outputs = function(*arguments)
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"{function.__name__} failed: {status.name} ({int(status)})")
+    if not outputs:
+        return None
+    if len(outputs) == 1:
+        return outputs[0]
+    return tuple(outputs)
+
+
+def _assert_no_current_context(process: str) -> None:
+    status, context = driver.cuCtxGetCurrent()
+    if status == driver.CUresult.CUDA_ERROR_NOT_INITIALIZED:
+        return
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuCtxGetCurrent failed: {status.name} ({int(status)})")
+    if int(context) != 0:
+        raise AssertionError(f"{process} has a current CUDA context")
+
+
+def _allocation_properties(device) -> driver.CUmemAllocationProp:
+    properties = driver.CUmemAllocationProp()
+    properties.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    properties.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    properties.location.id = int(device)
+    properties.requestedHandleTypes = POSIX_FD_HANDLE_TYPE
+    return properties
+
+
+def _allocation_size(properties: driver.CUmemAllocationProp) -> int:
+    return int(
+        _cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+        )
+    )
+
+
+def _assert_handle_namespace(handle, logical: bool, stage: str) -> None:
+    tagged = int(handle) & LOGICAL_HANDLE_TAG_MASK == LOGICAL_HANDLE_TAG
+    if tagged != logical:
+        expected = "logical" if logical else "raw"
+        raise AssertionError(f"{stage}: handle {int(handle):#x} is not {expected}")
+
+
+def _map_allocation(handle, size: int, device) -> int:
+    address = int(_cuda_call(driver.cuMemAddressReserve, size, size, 0, 0))
+    mapped = False
+    try:
+        _cuda_call(driver.cuMemMap, address, size, 0, handle, 0)
+        mapped = True
+        access = driver.CUmemAccessDesc()
+        access.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        access.location.id = int(device)
+        access.flags = driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+        _cuda_call(driver.cuMemSetAccess, address, size, [access], 1)
+    except Exception:
+        if mapped:
+            _cuda_call(driver.cuMemUnmap, address, size)
+        _cuda_call(driver.cuMemAddressFree, address, size)
+        raise
+    return address
+
+
+def _write_bytes(address: int, expected: bytes) -> None:
+    source = ctypes.create_string_buffer(expected)
+    _cuda_call(driver.cuMemcpyHtoD, address, ctypes.addressof(source), len(expected))
+
+
+def _assert_bytes(address: int, expected: bytes, stage: str) -> None:
+    actual = ctypes.create_string_buffer(len(expected))
+    _cuda_call(driver.cuMemcpyDtoH, ctypes.addressof(actual), address, len(expected))
+    if actual.raw != expected:
+        raise AssertionError(f"{stage}: got {actual.raw!r}, expected {expected!r}")
+
+
+def _destroy_mapped_allocation(address: int, size: int, handle) -> None:
+    _cuda_call(driver.cuMemUnmap, address, size)
+    _cuda_call(driver.cuMemAddressFree, address, size)
+    _cuda_call(driver.cuMemRelease, handle)
+
+
+def _worker(
+    rank: int,
+    raw_fds: tuple[int, int],
+    restore_fds: tuple[int, int],
+    sync_dir: Path,
+    store_path: Path,
+) -> None:
+    _cuda_call(driver.cuInit, 0)
+    device = _cuda_call(driver.cuDeviceGet, rank)
+    properties = _allocation_properties(device)
+    private_size = _allocation_size(properties)
+    _assert_no_current_context("worker before private cuMemCreate")
+    private_handle = _cuda_call(driver.cuMemCreate, private_size, properties, 0)
+    _assert_handle_namespace(private_handle, True, "managed cuMemCreate")
+
+    torch.cuda.set_device(rank)
+    for other_rank, fd in enumerate(raw_fds):
+        if other_rank != rank:
+            os.close(fd)
+    for other_rank, fd in enumerate(restore_fds):
+        if other_rank != rank:
+            os.close(fd)
+    restore_socket = socket.socket(fileno=restore_fds[rank])
+    raw_fd = raw_fds[rank]
+    external_handle = None
+    external_address = 0
+    try:
+        external_handle = _cuda_call(
+            driver.cuMemImportFromShareableHandle,
+            raw_fd,
+            POSIX_FD_HANDLE_TYPE,
+        )
+        _assert_handle_namespace(external_handle, False, "raw external import")
+    finally:
+        os.close(raw_fd)
+    try:
+        external_address = _map_allocation(external_handle, private_size, device)
+        _assert_bytes(
+            external_address,
+            bytes([rank + 1]) * 32,
+            "raw external allocation",
+        )
+    finally:
+        if external_address:
+            _destroy_mapped_allocation(
+                external_address,
+                private_size,
+                external_handle,
+            )
+        elif external_handle is not None:
+            _cuda_call(driver.cuMemRelease, external_handle)
+
+    private_address = _map_allocation(private_handle, private_size, device)
+    retained_handle = _cuda_call(
+        driver.cuMemRetainAllocationHandle,
+        private_address,
+    )
+    _assert_handle_namespace(retained_handle, True, "managed retain")
+    _cuda_call(driver.cuMemRelease, retained_handle)
+    private_expected = bytes([0xA0 + rank]) * 32
+    _write_bytes(private_address, private_expected)
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{store_path}",
+        rank=rank,
+        world_size=WORLD_SIZE,
+    )
+    group_name = dist.group.WORLD.group_name
+    input_tensor = symm_mem.empty(NUMEL, dtype=torch.float32, device="cuda")
+    input_tensor.fill_(rank + 1)
+    symm_handle = symm_mem.rendezvous(input_tensor, group=group_name)
+    output = torch.empty_like(input_tensor)
+
+    torch.ops.symm_mem.one_shot_all_reduce_out(input_tensor, "sum", group_name, output)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops.symm_mem.one_shot_all_reduce_out(
+            input_tensor, "sum", group_name, output
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "before checkpoint")
+    (sync_dir / f"ready-{rank}").touch()
+
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while not (sync_dir / "continue").exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for restore")
+        time.sleep(0.05)
+
+    fresh_fd = recv_handle(restore_socket)
+    restore_socket.close()
+    fresh_handle = None
+    fresh_address = 0
+    try:
+        fresh_handle = _cuda_call(
+            driver.cuMemImportFromShareableHandle,
+            fresh_fd,
+            POSIX_FD_HANDLE_TYPE,
+        )
+        _assert_handle_namespace(fresh_handle, False, "fresh raw import after restore")
+    finally:
+        os.close(fresh_fd)
+    try:
+        fresh_address = _map_allocation(fresh_handle, private_size, device)
+        _assert_bytes(
+            fresh_address,
+            bytes([0x40 + rank]) * 32,
+            "fresh raw allocation after restore",
+        )
+    finally:
+        if fresh_address:
+            _destroy_mapped_allocation(
+                fresh_address,
+                private_size,
+                fresh_handle,
+            )
+        elif fresh_handle is not None:
+            _cuda_call(driver.cuMemRelease, fresh_handle)
+
+    _assert_bytes(private_address, private_expected, "private allocation after restore")
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "after restore")
+    (sync_dir / f"done-{rank}").touch()
+
+    dist.barrier()
+    del graph, output, symm_handle, input_tensor
+    torch.cuda.empty_cache()
+    dist.destroy_process_group()
+    _destroy_mapped_allocation(private_address, private_size, private_handle)
+
+
+def _assert_exact_result(output: torch.Tensor, stage: str) -> None:
+    expected = torch.full((NUMEL,), 3.0, dtype=torch.float32)
+    actual = output.cpu()
+    if not torch.equal(actual, expected):
+        mismatch = torch.nonzero(actual != expected)[0].item()
+        raise AssertionError(
+            f"{stage}: output[{mismatch}] is {actual[mismatch].item()}, expected 3.0"
+        )
+
+
+def _visible_gpus() -> tuple[str, str]:
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is None:
+        return "0", "1"
+    devices = [entry.strip() for entry in configured.split(",") if entry.strip()]
+    if len(devices) < WORLD_SIZE:
+        raise RuntimeError("CUDA_VISIBLE_DEVICES must contain two GPUs")
+    if devices[0] == devices[1]:
+        raise RuntimeError("the first two CUDA_VISIBLE_DEVICES entries must differ")
+    return devices[0], devices[1]
+
+
+def _create_external_allocations(byte_base: int) -> list[_ExternalAllocation]:
+    _cuda_call(driver.cuInit, 0)
+    allocations = []
+    try:
+        for rank in range(WORLD_SIZE):
+            allocations.append(_create_external_allocation(rank, byte_base))
+    except Exception:
+        _destroy_external_allocations(allocations)
+        raise
+    return allocations
+
+
+def _create_external_allocation(rank: int, byte_base: int) -> _ExternalAllocation:
+    device = _cuda_call(driver.cuDeviceGet, rank)
+    context = _cuda_call(driver.cuDevicePrimaryCtxRetain, device)
+    handle = None
+    address = 0
+    try:
+        _cuda_call(driver.cuCtxPushCurrent, context)
+        try:
+            properties = _allocation_properties(device)
+            size = _allocation_size(properties)
+            handle = _cuda_call(driver.cuMemCreate, size, properties, 0)
+            address = _map_allocation(handle, size, device)
+            _write_bytes(address, bytes([byte_base + rank]) * 32)
+            fd = int(
+                _cuda_call(
+                    driver.cuMemExportToShareableHandle,
+                    handle,
+                    POSIX_FD_HANDLE_TYPE,
+                    0,
+                )
+            )
+        except Exception:
+            if address:
+                _destroy_mapped_allocation(address, size, handle)
+            elif handle is not None:
+                _cuda_call(driver.cuMemRelease, handle)
+            raise
+        finally:
+            _cuda_call(driver.cuCtxPopCurrent)
+    except Exception:
+        _cuda_call(driver.cuDevicePrimaryCtxRelease, device)
+        raise
+    return _ExternalAllocation(device, context, address, size, handle, fd)
+
+
+def _destroy_external_allocations(allocations: list[_ExternalAllocation]) -> None:
+    while allocations:
+        allocation = allocations.pop()
+        os.close(allocation.fd)
+        _cuda_call(driver.cuCtxPushCurrent, allocation.context)
+        try:
+            _destroy_mapped_allocation(
+                allocation.address,
+                allocation.size,
+                allocation.handle,
+            )
+        finally:
+            _cuda_call(driver.cuCtxPopCurrent)
+            _cuda_call(driver.cuDevicePrimaryCtxRelease, allocation.device)
+
+
+def _build_native_tools(tmp_path: Path) -> tuple[Path, Path]:
+    interposer_dir = Path(__file__).resolve().parents[1]
+    cuda_home = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda"))
+    compiler = os.environ.get("CC", "cc")
+    missing = []
+    if shutil.which("make") is None:
+        missing.append("make on PATH")
+    if shutil.which("readelf") is None:
+        missing.append("readelf on PATH")
+    if shutil.which(compiler) is None:
+        missing.append(f"{compiler} on PATH")
+    cuda_header = cuda_home / "include" / "cuda.h"
+    if not cuda_header.is_file():
+        missing.append(str(cuda_header))
+    if missing:
+        pytest.fail(
+            "missing native build prerequisites: "
+            f"{', '.join(missing)}; provide make, readelf, a C compiler, and "
+            "CUDA headers, or set CUDA_HOME to the CUDA toolkit root"
+        )
+    build_dir = tmp_path / "native"
+    result = subprocess.run(
+        [
+            "make",
+            "-C",
+            str(interposer_dir),
+            f"BUILD_DIR={build_dir}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"native build failed ({result.returncode}):\n"
+            f"{result.stdout}{result.stderr}"
+        )
+    interposer = (build_dir / "libcuinterposer.so").resolve()
+    coordinator = (build_dir / "cuinterposer-coordinator").resolve()
+    if not interposer.is_file() or not coordinator.is_file():
+        pytest.fail("native build did not produce the interposer and coordinator")
+    return interposer, coordinator
+
+
+def _fork_workers(
+    raw_fds: tuple[int, int],
+    restore_fds: tuple[int, int],
+    sync_dir: Path,
+    store_path: Path,
+) -> None:
+    if torch.cuda.is_initialized():
+        raise RuntimeError("parent initialized CUDA before forking workers")
+    _assert_no_current_context("parent before forking workers")
+
+    children = []
+    for rank in range(WORLD_SIZE):
+        child = os.fork()
+        if child == 0:
+            try:
+                _worker(rank, raw_fds, restore_fds, sync_dir, store_path)
+            except BaseException:  # noqa: BLE001 -- report child failures to parent
+                traceback.print_exc()
+                os._exit(1)
+            os._exit(0)
+        children.append((rank, child))
+        (sync_dir / f"pid-{rank}").write_text(f"{child}\n")
+
+    for fd in raw_fds:
+        os.close(fd)
+    for fd in restore_fds:
+        os.close(fd)
+
+    remaining = dict(children)
+    while remaining:
+        failures = []
+        for rank, child in tuple(remaining.items()):
+            waited, status = os.waitpid(child, os.WNOHANG)
+            if waited == 0:
+                continue
+            del remaining[rank]
+            exit_code = os.waitstatus_to_exitcode(status)
+            if not os.WIFEXITED(status) or exit_code != 0:
+                failures.append(f"rank {rank} PID {child}: {exit_code}")
+        if failures:
+            for child in remaining.values():
+                try:
+                    os.kill(child, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            for child in remaining.values():
+                os.waitpid(child, 0)
+            raise RuntimeError(f"forked workers failed: {', '.join(failures)}")
+        time.sleep(0.05)
+
+
+def _start_parent(
+    gpus: tuple[str, str],
+    interposer: Path,
+    control_dir: Path,
+    sync_dir: Path,
+    store_path: Path,
+    raw_fds: tuple[int, int],
+    restore_fds: tuple[int, int],
+) -> subprocess.Popen[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CUDA_VISIBLE_DEVICES": ",".join(gpus),
+            "DYN_SNAPSHOT_PARTICIPANT_ID": PARENT_PARTICIPANT_ID,
+            "DYN_SNAPSHOT_CONTROL_DIR": str(control_dir),
+            "LD_PRELOAD": str(interposer),
+            "PYTHONFAULTHANDLER": "1",
+            "PYTHONUNBUFFERED": "1",
+            "TORCH_SYMMEM_IMPLICIT_POOL": "0",
+            "TORCH_SYMM_MEM_DISABLE_MULTICAST": "1",
+        }
+    )
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-X",
+            "faulthandler",
+            "-u",
+            str(Path(__file__).resolve()),
+            "--parent",
+            *(str(fd) for fd in raw_fds),
+            *(str(fd) for fd in restore_fds),
+            str(sync_dir),
+            str(store_path),
+        ],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+        pass_fds=raw_fds + restore_fds,
+    )
+
+
+def _wait_for_child_pids(
+    parent: subprocess.Popen[str], sync_dir: Path
+) -> tuple[int, int]:
+    paths = [sync_dir / f"pid-{rank}" for rank in range(WORLD_SIZE)]
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while True:
+        try:
+            pids = tuple(int(path.read_text()) for path in paths)
+        except (FileNotFoundError, ValueError):
+            pids = ()
+        if len(pids) == WORLD_SIZE:
+            if len(set(pids)) != WORLD_SIZE:
+                raise AssertionError(f"forked worker PIDs are not unique: {pids}")
+            return pids
+        if parent.poll() is not None:
+            raise RuntimeError(
+                f"parent {parent.pid} exited before publishing child PIDs "
+                f"with {parent.returncode}"
+            )
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for forked worker PIDs")
+        time.sleep(0.05)
+
+
+def _wait_for_workers(
+    parent: subprocess.Popen[str],
+    sync_dir: Path,
+    marker: str,
+) -> None:
+    expected = [sync_dir / f"{marker}-{rank}" for rank in range(WORLD_SIZE)]
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while not all(path.exists() for path in expected):
+        if parent.poll() is not None:
+            raise RuntimeError(
+                f"parent {parent.pid} exited before workers reached {marker} "
+                f"with {parent.returncode}"
+            )
+        if time.monotonic() >= deadline:
+            missing = [str(path) for path in expected if not path.exists()]
+            raise TimeoutError(f"timed out waiting for {marker}: {', '.join(missing)}")
+        time.sleep(0.05)
+
+
+def _assert_worker_runtime(
+    process_id: int, interposer: Path, control_dir: Path
+) -> None:
+    maps = Path(f"/proc/{process_id}/maps").read_text().splitlines()
+    mapped_paths = {
+        fields[5] for line in maps if len(fields := line.split(maxsplit=5)) == 6
+    }
+    if str(interposer) not in mapped_paths:
+        raise AssertionError(f"{interposer} is not loaded in process {process_id}")
+    endpoint = control_dir / f"cuinterposer-{process_id}.sock"
+    if not endpoint.is_socket():
+        raise AssertionError(f"interposer endpoint does not exist: {endpoint}")
+
+
+def _run_coordinator(
+    coordinator: Path,
+    operation: str,
+    checkpoint_dir: Path,
+    control_dir: Path,
+    process_ids: tuple[int, int],
+) -> None:
+    command = [
+        str(coordinator),
+        operation,
+        "--proc-root",
+        "",
+        "--checkpoint-dir",
+        str(checkpoint_dir),
+    ]
+    for process_id in process_ids:
+        command.extend(["--process", str(process_id), str(process_id)])
+    environment = os.environ.copy()
+    environment.pop("LD_PRELOAD", None)
+    environment["DYN_SNAPSHOT_CONTROL_DIR"] = str(control_dir)
+    result = subprocess.run(
+        command,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"coordinator {operation} failed ({result.returncode}):\n"
+            f"{result.stdout}{result.stderr}"
+        )
+
+
+def _expect_state(process_id: int, expected) -> None:
+    actual = _cuda_call(driver.cuCheckpointProcessGetState, process_id)
+    if actual != expected:
+        raise AssertionError(
+            f"CUDA process {process_id} is {actual.name}, expected {expected.name}"
+        )
+
+
+def _native_checkpoint(process_ids: tuple[int, int]) -> None:
+    _cuda_call(driver.cuInit, 0)
+    running = driver.CUprocessState.CU_PROCESS_STATE_RUNNING
+    locked = driver.CUprocessState.CU_PROCESS_STATE_LOCKED
+    checkpointed = driver.CUprocessState.CU_PROCESS_STATE_CHECKPOINTED
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+    lock_arguments = driver.CUcheckpointLockArgs()
+    lock_arguments.timeoutMs = COMMAND_TIMEOUT_SECONDS * 1000
+    for process_id in process_ids:
+        _cuda_call(driver.cuCheckpointProcessLock, process_id, lock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    checkpoint_arguments = driver.CUcheckpointCheckpointArgs()
+    for process_id in process_ids:
+        _cuda_call(
+            driver.cuCheckpointProcessCheckpoint,
+            process_id,
+            checkpoint_arguments,
+        )
+    for process_id in process_ids:
+        _expect_state(process_id, checkpointed)
+
+    restore_arguments = driver.CUcheckpointRestoreArgs()
+    for process_id in process_ids:
+        _cuda_call(driver.cuCheckpointProcessRestore, process_id, restore_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    unlock_arguments = driver.CUcheckpointUnlockArgs()
+    for process_id in process_ids:
+        _cuda_call(driver.cuCheckpointProcessUnlock, process_id, unlock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+
+def _native_checkpoint_with_timeout(
+    process_ids: tuple[int, int],
+) -> None:
+    outcomes: queue.Queue[Exception | None] = queue.Queue(maxsize=1)
+
+    def run() -> None:
+        try:
+            _native_checkpoint(process_ids)
+        except Exception as error:  # noqa: BLE001
+            outcomes.put(error)
+        else:
+            outcomes.put(None)
+
+    threading.Thread(target=run, daemon=True).start()
+    try:
+        outcome = outcomes.get(timeout=CHECKPOINT_TIMEOUT_SECONDS)
+    except queue.Empty as error:
+        raise TimeoutError(
+            f"native CUDA checkpoint exceeded {CHECKPOINT_TIMEOUT_SECONDS} seconds"
+        ) from error
+    if outcome is not None:
+        raise outcome
+
+
+def test_cucheckpoint_preserves_symmetric_memory_cuda_graph(tmp_path: Path) -> None:
+    interposer, coordinator = _build_native_tools(tmp_path)
+    gpus = _visible_gpus()
+    control_dir = tmp_path / "control"
+    checkpoint_dir = tmp_path / "checkpoint"
+    sync_dir = tmp_path / "sync"
+    control_dir.mkdir()
+    checkpoint_dir.mkdir()
+    sync_dir.mkdir()
+    store_path = tmp_path / "torch-distributed-store"
+
+    parent: subprocess.Popen[str] | None = None
+    child_pids: tuple[int, int] = ()
+    output = ("", "")
+    output_collected = False
+    failure: Exception | None = None
+    external_allocations: list[_ExternalAllocation] = []
+    restore_channels = [socket.socketpair() for _ in range(WORLD_SIZE)]
+
+    try:
+        external_allocations = _create_external_allocations(1)
+        parent = _start_parent(
+            gpus,
+            interposer,
+            control_dir,
+            sync_dir,
+            store_path,
+            tuple(allocation.fd for allocation in external_allocations),
+            tuple(receiver.fileno() for _, receiver in restore_channels),
+        )
+        for _, receiver in restore_channels:
+            receiver.close()
+        child_pids = _wait_for_child_pids(parent, sync_dir)
+        _wait_for_workers(parent, sync_dir, "ready")
+        _destroy_external_allocations(external_allocations)
+        _assert_worker_runtime(parent.pid, interposer, control_dir)
+        for child_pid in child_pids:
+            _assert_worker_runtime(child_pid, interposer, control_dir)
+
+        _run_coordinator(
+            coordinator,
+            "--prepare",
+            checkpoint_dir,
+            control_dir,
+            child_pids,
+        )
+        state = checkpoint_dir / "cuinterposer.state"
+        if not state.is_file() or state.stat().st_size == 0:
+            raise AssertionError("coordinator did not write nonempty cuinterposer.state")
+
+        _native_checkpoint_with_timeout(child_pids)
+        _run_coordinator(
+            coordinator,
+            "--restore",
+            checkpoint_dir,
+            control_dir,
+            child_pids,
+        )
+        external_allocations = _create_external_allocations(0x40)
+        for rank, (sender, _) in enumerate(restore_channels):
+            send_handle(sender, external_allocations[rank].fd, child_pids[rank])
+        (sync_dir / "continue").touch()
+        _wait_for_workers(parent, sync_dir, "done")
+
+        output = parent.communicate(timeout=COMMAND_TIMEOUT_SECONDS)
+        output_collected = True
+        if parent.returncode != 0:
+            raise RuntimeError(f"parent {parent.pid} exited with {parent.returncode}")
+    except Exception as error:  # noqa: BLE001
+        failure = error
+    finally:
+        if parent is not None and (failure is not None or parent.poll() is None):
+            try:
+                os.killpg(parent.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        if parent is not None and not output_collected:
+            try:
+                output = parent.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(parent.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                output = parent.communicate(timeout=10)
+        _destroy_external_allocations(external_allocations)
+        for sender, receiver in restore_channels:
+            sender.close()
+            receiver.close()
+
+    if failure is not None:
+        parent_pid = parent.pid if parent is not None else "not started"
+        parent_returncode = parent.returncode if parent is not None else "not started"
+        sockets = sorted(path.name for path in control_dir.glob("*.sock"))
+        raise AssertionError(
+            f"{failure}\n"
+            f"parent PID/return code: {parent_pid}/{parent_returncode}\n"
+            f"forked child PIDs: {child_pids}\n"
+            f"control sockets: {sockets}\n"
+            f"parent and worker stdout:\n{output[0]}\n"
+            f"parent and worker stderr:\n{output[1]}"
+        ) from failure
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 8 or sys.argv[1] != "--parent":
+        raise SystemExit(
+            "usage: test_cucheckpoint.py --parent RAW_FD_0 RAW_FD_1 "
+            "RESTORE_FD_0 RESTORE_FD_1 SYNC_DIR STORE_PATH"
+        )
+    _fork_workers(
+        (int(sys.argv[2]), int(sys.argv[3])),
+        (int(sys.argv[4]), int(sys.argv[5])),
+        Path(sys.argv[6]),
+        Path(sys.argv[7]),
+    )


### PR DESCRIPTION
## Summary
- add POSIX-shareable allocation, logical-handle, mapping, access-range, and ticket-import tracking to `interpose.c` and `posix.c`
- expose the control endpoint consumed by the coordinator added in #155
- implement prepare and restore behavior around native CUDA checkpointing
- record access descriptors for every fully covered mapping and fail closed on partial overlaps
- keep multicast entirely outside this layer

This is layer 4 of [stack #156](https://github.com/ai-dynamo/snapshot/stack/156). Coordinator/protocol and Go orchestration are isolated in #155.

## Validation
- all Go tests
- pinned CUDA-devel image builds the shim and static coordinator
- POSIX checkpoint integration tests
- shim GLIBC requirement is at most 2.34
- no multicast exports in this layer
