### PR TITLE
ci(e2e): pin auto-resolved images to the checked-out commit

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,9 +10,8 @@ on:
         description: >-
           Operator/agent image tag to install (e.g. from a manual
           push-artifacts.yaml dispatch on a feature branch). Leave empty to
-          auto-resolve the newest tag published for both images in GHCR,
-          which is not necessarily built from the branch this workflow runs
-          against.
+          test the checked-out commit itself: its dev tag must already be
+          published for both images in GHCR, otherwise the run fails.
         required: false
         type: string
   schedule:

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -53,6 +53,7 @@ jobs:
           # Use the CI run's head SHA for dev builds, not GITHUB_SHA which may
           # have advanced to a later commit by the time this workflow fires.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          REF_NAME: ${{ github.event.workflow_run.head_branch || github.ref_name }}
         run: |
           if [ -n "${INPUT}" ]; then
             echo "${INPUT}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' \
@@ -61,9 +62,24 @@ jobs:
             # Keep the v prefix in Docker tags (e.g. v0.1.0 latest).
             # Push 'latest' only on explicit release builds, not dev snapshots.
             echo "tags=${INPUT} latest" >> "$GITHUB_OUTPUT"
-          else
+          elif [[ "${REF_NAME}" == "main" || "${REF_NAME}" == release/* ]]; then
             # The 'g' prefix prevents all-numeric SHAs from forming invalid semver.
             VERSION="v0.0.0-g${HEAD_SHA:0:8}"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "tags=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            # Feature-branch dev builds get a branch-slugged tag so the e2e
+            # tag auto-resolver (hack/resolve-snapshot-image-tag.py), which
+            # only accepts plain v0.0.0-g<sha8> tags, never picks them up.
+            # Keep the slug valid for Docker tags and semver prerelease:
+            # lowercase alphanumerics and single hyphens, capped at 30 chars.
+            SLUG="$(echo "${REF_NAME}" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed -E 's/[^a-z0-9]+/-/g; s/^-+//' \
+              | cut -c1-30 \
+              | sed -E 's/-+$//')"
+            SLUG="${SLUG:-branch}"
+            VERSION="v0.0.0-${SLUG}-g${HEAD_SHA:0:8}"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "tags=${VERSION}" >> "$GITHUB_OUTPUT"
           fi

--- a/hack/resolve-snapshot-image-tag.py
+++ b/hack/resolve-snapshot-image-tag.py
@@ -1,13 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Resolve the newest shared published Snapshot image tag for e2e runs."""
+"""Resolve the Snapshot image tag for the exact commit under test.
+
+The e2e run must test the commit it checked out, so the tag is derived from
+HEAD (v0.0.0-g<sha8>) and merely verified to be published for both the
+operator and agent packages. If push-artifacts has not published HEAD yet,
+the run fails instead of silently testing something else.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime
 import json
 import os
+import subprocess
 import sys
 import urllib.parse
 import urllib.request
@@ -16,15 +22,26 @@ import urllib.request
 GITHUB_API_VERSION = "2022-11-28"
 MAX_PAGES = 5
 ORG = "ai-dynamo"
-TAG_PREFIX = "v0.0.0-g"
 
 
-def parse_created_at(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+def head_sha() -> str:
+    sha = os.environ.get("GITHUB_SHA")
+    if sha:
+        return sha
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
-def package_tags(package: str, headers: dict[str, str]) -> dict[str, datetime]:
-    tags: dict[str, datetime] = {}
+def dev_tag(sha: str) -> str:
+    return f"v0.0.0-g{sha[:8]}"
+
+
+def package_has_tag(package: str, tag: str, headers: dict[str, str]) -> bool:
     encoded = urllib.parse.quote(package, safe="")
 
     for page in range(1, MAX_PAGES + 1):
@@ -40,29 +57,11 @@ def package_tags(package: str, headers: dict[str, str]) -> dict[str, datetime]:
             break
 
         for version in versions:
-            created_at = parse_created_at(version["created_at"])
             version_tags = version.get("metadata", {}).get("container", {}).get("tags", [])
-            for tag in version_tags:
-                if not tag.startswith(TAG_PREFIX):
-                    continue
-                if tag not in tags or created_at > tags[tag]:
-                    tags[tag] = created_at
+            if tag in version_tags:
+                return True
 
-    return tags
-
-
-def newest_shared_tag(
-    operator_tags: dict[str, datetime],
-    agent_tags: dict[str, datetime],
-) -> str | None:
-    shared_tags = operator_tags.keys() & agent_tags.keys()
-    if not shared_tags:
-        return None
-
-    return max(
-        shared_tags,
-        key=lambda tag: (min(operator_tags[tag], agent_tags[tag]), tag),
-    )
+    return False
 
 
 def write_github_env(tag: str) -> None:
@@ -83,17 +82,27 @@ def main() -> int:
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    operator_tags = package_tags("snapshot/operator", headers)
-    agent_tags = package_tags("snapshot/agent", headers)
+    sha = head_sha()
+    tag = dev_tag(sha)
 
-    tag = newest_shared_tag(operator_tags, agent_tags)
-    if tag:
-        write_github_env(tag)
-        print(f"Resolved Snapshot image tag: {tag}")
-        return 0
+    missing = [
+        package
+        for package in ("snapshot/operator", "snapshot/agent")
+        if not package_has_tag(package, tag, headers)
+    ]
+    if missing:
+        print(
+            f"Tag {tag} for commit {sha} is not published for: "
+            f"{', '.join(missing)}. Wait for push-artifacts to publish this "
+            "commit, or dispatch the e2e workflow with an explicit "
+            "snapshot_tag.",
+            file=sys.stderr,
+        )
+        return 1
 
-    print("No shared published Snapshot operator/agent tag found", file=sys.stderr)
-    return 1
+    write_github_env(tag)
+    print(f"Resolved Snapshot image tag: {tag} (commit {sha})")
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

The scheduled e2e run auto-resolves the newest dev tag shared by the `snapshot/operator` and `snapshot/agent` GHCR packages, with no knowledge of which branch built it. Since `push-artifacts.yaml` `workflow_dispatch` publishes `v0.0.0-g<sha8>` tags from any branch, a manual artifact push from a feature branch hijacks the nightly signal for `main`.

That's what broke nightly run [33367419492](https://github.com/ai-dynamo/snapshot/actions/runs/33367419492): it ran on `main@c1206a4` but tested `v0.0.0-g1a25a63a`, built from an unmerged feature branch whose agent requires the CRI `ContainerStatus.image_id` field — which containerd 1.7 on the CI cluster does not populate — so all four tests failed with `CheckpointFailed: ... has no image ID`.

### Fix

Two complementary changes:

1. **Resolve from the checkout, not the registry.** `hack/resolve-snapshot-image-tag.py` now derives the tag from the checked-out commit (`GITHUB_SHA`, or `git rev-parse HEAD` locally) and only verifies it is published for both packages. An e2e run therefore always tests the latest commit of the branch it runs on; if push-artifacts hasn't published that commit yet, the run fails early with an actionable message instead of silently testing something else.
2. **Keep feature-branch tags out of the plain namespace.** Dev builds dispatched from refs other than `main`/`release/*` now publish `v0.0.0-<branch-slug>-g<sha8>` (slug sanitized for Docker tag and semver-prerelease rules, capped at 30 chars), so they can never collide with branch-history tags even in principle.

### Unchanged flows

- Manual feature-branch e2e still works: dispatch push-artifacts on the branch, then dispatch e2e with the (now slugged) tag via the existing `snapshot_tag` input, which bypasses the resolver entirely.
- `workflow_run` publishes from `main`/`release/*` and explicit release versions keep their current tag forms.

### Behavior change to be aware of

If the newest commit on the branch has failed CI or a still-running push-artifacts when the nightly fires, the run now fails (publishing is broken for HEAD) rather than falling back to an older commit. If that proves noisy, the follow-up is an "ensure" build fallback via `workflow_call` into push-artifacts, not a resolution fallback.

### Testing

- Both workflow files parse; `actionlint` reports only the pre-existing self-hosted runner-label warning.
- Resolver logic smoke-tested: `GITHUB_SHA` precedence, git fallback, and tag-pattern filtering (slugged/release/`latest` tags rejected).
- Slug sanitizer exercised against awkward refs (`a/b/c`, uppercase, dots, `//`, trailing junk) — all yield valid Docker/semver tags.

### Notes

The agent-side fix (falling back to `image_ref` when CRI `image_id` is empty, needed for containerd < 2.x) is out of scope here and belongs in #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot image selection now consistently uses the checked-out commit’s development tag.
  * Snapshot validation now reports an error when the matching operator or agent image is unavailable.

* **Improvements**
  * Artifact tags now clearly distinguish main and release builds from other branches.
  * Non-main branch tags use sanitized, length-limited branch names for easier identification.
  * Workflow guidance now explains how empty snapshot tag values are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->