### PR TITLE
feat(agent): coordinate CUDA interposer lifecycle

### DIFF
--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -4,8 +4,670 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int
-main(void)
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "protocol.h"
+#include "util.h"
+
+#define TIMEOUT_SECONDS 30
+#define STATE_FILENAME "cuinterposer.state"
+
+struct participant {
+  char* endpoint;
+  char id[CUINTERPOSER_ID_SIZE];
+  struct cuinterposer_record* records;
+  uint32_t count;
+};
+
+struct allocation {
+  uint8_t id[CUINTERPOSER_ALLOCATION_ID_SIZE];
+  char creator[CUINTERPOSER_ID_SIZE];
+  uint64_t size;
+  bool creator_handle;
+  bool creator_mapping;
+  struct allocation* next;
+};
+
+static int
+connect_endpoint(const char* endpoint)
 {
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  int fd;
+
+  if (strlen(endpoint) >= sizeof(address.sun_path))
+    return -1;
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", endpoint);
+  fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0 || set_socket_timeouts(fd, TIMEOUT_SECONDS) != 0 ||
+      connect(fd, (const struct sockaddr*)&address, sizeof(address)) != 0) {
+    if (fd >= 0)
+      close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+static int
+exchange(struct participant* participant, uint16_t operation, struct cuinterposer_record** records, uint32_t* count)
+{
+  struct cuinterposer_header request;
+  struct cuinterposer_header response;
+  uint64_t payload_size;
+  int fd = -1;
+  int result = -1;
+  bool strings_terminated;
+
+  memset(&request, 0, sizeof(request));
+  request.magic = CUINTERPOSER_MAGIC;
+  request.version = CUINTERPOSER_VERSION;
+  request.operation = operation;
+  if (operation != CUINTERPOSER_IDENTIFY)
+    snprintf(request.participant_id, sizeof(request.participant_id), "%s", participant->id);
+  fd = connect_endpoint(participant->endpoint);
+  if (fd < 0 || write_all(fd, &request, sizeof(request)) != 0 ||
+      read_all(fd, &response, sizeof(response)) != 0)
+    goto done;
+  strings_terminated = header_strings_terminated(&response);
+  if (!strings_terminated || response.magic != CUINTERPOSER_MAGIC || response.version != CUINTERPOSER_VERSION ||
+      response.operation != operation || response.status != 0 || response.count > CUINTERPOSER_MAX_RECORDS ||
+      response.payload_size != (uint64_t)response.count * sizeof(struct cuinterposer_record)) {
+    if (strings_terminated && response.message[0] != '\0')
+      fprintf(stderr, "%s: %s\n", participant->endpoint, response.message);
+    goto done;
+  }
+  if (operation == CUINTERPOSER_IDENTIFY) {
+    snprintf(participant->id, sizeof(participant->id), "%s", response.participant_id);
+  } else if (strcmp(response.participant_id, participant->id) != 0) {
+    goto done;
+  }
+  payload_size = response.payload_size;
+  if (payload_size != 0) {
+    *records = calloc(response.count, sizeof(**records));
+    if (*records == NULL || read_all(fd, *records, (size_t)payload_size) != 0)
+      goto done;
+  }
+  *count = response.count;
+  result = 0;
+done:
+  if (fd >= 0)
+    close(fd);
+  if (result != 0) {
+    free(*records);
+    *records = NULL;
+    *count = 0;
+  }
+  return result;
+}
+
+static struct allocation*
+find_allocation(struct allocation* allocations, const uint8_t id[CUINTERPOSER_ALLOCATION_ID_SIZE])
+{
+  struct allocation* allocation;
+
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (memcmp(allocation->id, id, CUINTERPOSER_ALLOCATION_ID_SIZE) == 0)
+      return allocation;
+  }
+  return NULL;
+}
+
+static int
+validate_topology(struct participant* participants, size_t participant_count, struct allocation** output)
+{
+  struct allocation* allocations = NULL;
+  const char* reason = NULL;
+  uint64_t value = UINT64_MAX;
+  size_t participant_index;
+  uint32_t record_index = UINT32_MAX;
+
+  if (participant_count == 0) {
+    fprintf(stderr, "topology validate failed: no participants\n");
+    return -1;
+  }
+  for (participant_index = 0; participant_index < participant_count; participant_index++) {
+    struct participant* participant = &participants[participant_index];
+    size_t previous;
+
+    record_index = UINT32_MAX;
+    if (!is_lower_hex_id(participant->id)) {
+      reason = "invalid participant identity";
+      goto failed;
+    }
+    for (previous = 0; previous < participant_index; previous++) {
+      if (strcmp(participants[previous].id, participant->id) == 0) {
+        reason = "duplicate participant identity";
+        goto failed;
+      }
+    }
+    for (record_index = 0; record_index < participant->count; record_index++) {
+      const struct cuinterposer_record* record = &participant->records[record_index];
+      struct allocation* allocation = find_allocation(allocations, record->allocation_id);
+
+      if (record->kind == CUINTERPOSER_ALLOCATION) {
+        if (allocation == NULL) {
+          allocation = calloc(1, sizeof(*allocation));
+          if (allocation == NULL) {
+            reason = "allocation metadata allocation failed";
+            goto failed;
+          }
+          memcpy(allocation->id, record->allocation_id, sizeof(allocation->id));
+          allocation->next = allocations;
+          allocations = allocation;
+        }
+        if ((record->flags & CUINTERPOSER_CREATOR) != 0) {
+          if (record->requested_handle_types != CUINTERPOSER_POSIX_HANDLE_TYPE) {
+            reason = "non-POSIX requested handle type";
+            value = record->requested_handle_types;
+            goto failed;
+          }
+          if (record->allocation_size == 0) {
+            reason = "zero creator allocation size";
+            goto failed;
+          }
+          if (allocation->creator[0] != '\0' && strcmp(allocation->creator, participant->id) != 0) {
+            reason = "conflicting creators";
+            goto failed;
+          }
+          snprintf(allocation->creator, sizeof(allocation->creator), "%s", participant->id);
+          allocation->size = record->allocation_size;
+          allocation->creator_handle = (record->flags & CUINTERPOSER_APPLICATION_HANDLE_LIVE) != 0;
+        }
+      } else if (record->kind == CUINTERPOSER_MAPPING) {
+        if (record->address == 0) {
+          reason = "zero mapping address";
+          goto failed;
+        }
+        if (record->size == 0) {
+          reason = "zero mapping size";
+          goto failed;
+        }
+        if (record->access_count > CUINTERPOSER_MAX_ACCESS) {
+          reason = "mapping access count exceeds limit";
+          value = record->access_count;
+          goto failed;
+        }
+        if (allocation == NULL) {
+          allocation = calloc(1, sizeof(*allocation));
+          if (allocation == NULL) {
+            reason = "allocation metadata allocation failed";
+            goto failed;
+          }
+          memcpy(allocation->id, record->allocation_id, sizeof(allocation->id));
+          allocation->next = allocations;
+          allocations = allocation;
+        }
+        if ((record->flags & CUINTERPOSER_CREATOR) != 0)
+          allocation->creator_mapping = true;
+      } else {
+        reason = "unknown record kind";
+        value = record->kind;
+        goto failed;
+      }
+    }
+  }
+  {
+    struct allocation* allocation;
+    for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+      struct participant* participant;
+
+      if (allocation->creator[0] == '\0') {
+        reason = "missing creator";
+        goto failed;
+      }
+      if (allocation->size == 0) {
+        reason = "missing allocation size";
+        goto failed;
+      }
+      if (!allocation->creator_handle && !allocation->creator_mapping) {
+        reason = "missing creator anchor";
+        goto failed;
+      }
+      for (participant_index = 0; participant_index < participant_count; participant_index++) {
+        participant = &participants[participant_index];
+        for (record_index = 0; record_index < participant->count; record_index++) {
+          const struct cuinterposer_record* record = &participant->records[record_index];
+          if (record->kind == CUINTERPOSER_MAPPING &&
+              memcmp(record->allocation_id, allocation->id, sizeof(allocation->id)) == 0 &&
+              (record->offset > allocation->size || record->size > allocation->size - record->offset)) {
+            reason = "mapping out of bounds";
+            goto failed;
+          }
+        }
+      }
+    }
+  }
+  *output = allocations;
   return 0;
+failed:
+  if (value != UINT64_MAX)
+    fprintf(
+        stderr, "topology validate failed: %s (value %llu, participant index %zu, record index %u)\n", reason,
+        (unsigned long long)value, participant_index, (unsigned)record_index);
+  else if (participant_index < participant_count && record_index != UINT32_MAX)
+    fprintf(
+        stderr, "topology validate failed: %s (participant index %zu, record index %u)\n", reason, participant_index,
+        (unsigned)record_index);
+  else if (participant_index < participant_count)
+    fprintf(stderr, "topology validate failed: %s (participant index %zu)\n", reason, participant_index);
+  else
+    fprintf(stderr, "topology validate failed: %s\n", reason);
+  while (allocations != NULL) {
+    struct allocation* next = allocations->next;
+    free(allocations);
+    allocations = next;
+  }
+  return -1;
+}
+
+static int write_state(struct participant* participants, size_t count, FILE* output);
+
+static int
+write_state_atomic(const char* path, struct participant* participants, size_t count)
+{
+  char temporary[PATH_MAX];
+  FILE* output = NULL;
+  int fd;
+  int length;
+  int result = -1;
+
+  length = snprintf(temporary, sizeof(temporary), "%s.tmp.XXXXXX", path);
+  if (length < 0 || (size_t)length >= sizeof(temporary))
+    return -1;
+  fd = mkstemp(temporary);
+  if (fd < 0)
+    return -1;
+  output = fdopen(fd, "w");
+  if (output == NULL) {
+    close(fd);
+    unlink(temporary);
+    return -1;
+  }
+  if (write_state(participants, count, output) != 0 || fsync(fileno(output)) != 0)
+    goto done;
+  if (fclose(output) != 0) {
+    output = NULL;
+    goto done;
+  }
+  output = NULL;
+  if (rename(temporary, path) != 0)
+    goto done;
+  result = 0;
+done:
+  if (output != NULL)
+    fclose(output);
+  if (result != 0)
+    unlink(temporary);
+  return result;
+}
+
+static int
+record_compare(const void* left, const void* right)
+{
+  return memcmp(left, right, sizeof(struct cuinterposer_record));
+}
+
+static int
+participant_compare(const void* left, const void* right)
+{
+  const struct participant* a = left;
+  const struct participant* b = right;
+  return strcmp(a->id, b->id);
+}
+
+static int
+write_state(struct participant* participants, size_t count, FILE* output)
+{
+  size_t index;
+
+  qsort(participants, count, sizeof(*participants), participant_compare);
+  if (fprintf(output, "snapshot-cuda-posix-v1\n") < 0)
+    return -1;
+  for (index = 0; index < count; index++) {
+    struct participant* participant = &participants[index];
+    uint32_t record_index;
+
+    qsort(participant->records, participant->count, sizeof(*participant->records), record_compare);
+    if (fprintf(output, "participant %s %u\n", participant->id, participant->count) < 0)
+      return -1;
+    for (record_index = 0; record_index < participant->count; record_index++) {
+      const uint8_t* bytes = (const uint8_t*)&participant->records[record_index];
+      size_t byte_index;
+      for (byte_index = 0; byte_index < sizeof(struct cuinterposer_record); byte_index++) {
+        if (fprintf(output, "%02x", bytes[byte_index]) < 0)
+          return -1;
+      }
+      if (fputc('\n', output) == EOF)
+        return -1;
+    }
+  }
+  return fflush(output);
+}
+
+static int
+hex_digit(int value)
+{
+  if (value >= '0' && value <= '9')
+    return value - '0';
+  if (value >= 'a' && value <= 'f')
+    return value - 'a' + 10;
+  return -1;
+}
+
+static int
+read_record(FILE* input, struct cuinterposer_record* record)
+{
+  uint8_t* bytes = (uint8_t*)record;
+  size_t index;
+
+  for (index = 0; index < sizeof(*record); index++) {
+    int high = hex_digit(fgetc(input));
+    int low = hex_digit(fgetc(input));
+    if (high < 0 || low < 0)
+      return -1;
+    bytes[index] = (uint8_t)((high << 4) | low);
+  }
+  return fgetc(input) == '\n' ? 0 : -1;
+}
+
+static int
+read_state(FILE* input, struct participant** output, size_t* output_count)
+{
+  char line[128];
+  struct participant* participants = NULL;
+  size_t count = 0;
+
+  if (fgets(line, sizeof(line), input) == NULL || strcmp(line, "snapshot-cuda-posix-v1\n") != 0)
+    return -1;
+  while (fgets(line, sizeof(line), input) != NULL) {
+    struct participant* participant;
+    struct participant* expanded;
+    char id[CUINTERPOSER_ID_SIZE];
+    unsigned int record_count;
+    unsigned int index;
+
+    if (sscanf(line, "participant %32s %u", id, &record_count) != 2 || !is_lower_hex_id(id) ||
+        record_count > CUINTERPOSER_MAX_RECORDS)
+      goto failed;
+    expanded = realloc(participants, (count + 1) * sizeof(*participants));
+    if (expanded == NULL)
+      goto failed;
+    participants = expanded;
+    participant = &participants[count++];
+    memset(participant, 0, sizeof(*participant));
+    snprintf(participant->id, sizeof(participant->id), "%s", id);
+    participant->records = calloc(record_count == 0 ? 1 : record_count, sizeof(*participant->records));
+    if (participant->records == NULL)
+      goto failed;
+    participant->count = record_count;
+    for (index = 0; index < record_count; index++) {
+      if (read_record(input, &participant->records[index]) != 0)
+        goto failed;
+    }
+  }
+  *output = participants;
+  *output_count = count;
+  return count == 0 ? -1 : 0;
+failed:
+  if (participants != NULL) {
+    size_t index;
+    for (index = 0; index < count; index++) free(participants[index].records);
+  }
+  free(participants);
+  return -1;
+}
+
+static int
+identify(struct participant* participants, size_t count)
+{
+  size_t index;
+
+  for (index = 0; index < count; index++) {
+    struct cuinterposer_record* records = NULL;
+    uint32_t record_count = 0;
+    if (exchange(&participants[index], CUINTERPOSER_IDENTIFY, &records, &record_count) != 0)
+      return -1;
+    free(records);
+  }
+  return 0;
+}
+
+static int
+inspect(struct participant* participants, size_t count)
+{
+  size_t index;
+
+  if (identify(participants, count) != 0)
+    return -1;
+  for (index = 0; index < count; index++) {
+    if (exchange(
+            &participants[index], CUINTERPOSER_INSPECT, &participants[index].records, &participants[index].count) != 0)
+      return -1;
+  }
+  return 0;
+}
+
+static void
+free_participants(struct participant* participants, size_t count)
+{
+  size_t index;
+
+  if (participants == NULL)
+    return;
+  for (index = 0; index < count; index++) {
+    free(participants[index].endpoint);
+    free(participants[index].records);
+  }
+  free(participants);
+}
+
+static void
+free_allocations(struct allocation* allocations)
+{
+  while (allocations != NULL) {
+    struct allocation* next = allocations->next;
+    free(allocations);
+    allocations = next;
+  }
+}
+
+static int
+command_all(struct participant* participants, size_t count, uint16_t operation)
+{
+  size_t index;
+
+  for (index = 0; index < count; index++) {
+    struct cuinterposer_record* records = NULL;
+    uint32_t record_count = 0;
+    if (exchange(&participants[index], operation, &records, &record_count) != 0)
+      return -1;
+    free(records);
+  }
+  return 0;
+}
+
+static int
+restore_unicast(struct participant* participants, size_t count)
+{
+  /* Creators must finish and listen again before importers request a fresh export. */
+  if (command_all(participants, count, CUINTERPOSER_RESTORE_CREATORS) != 0)
+    return -1;
+  return command_all(participants, count, CUINTERPOSER_RESTORE_IMPORTERS);
+}
+
+static int
+same_participants(struct participant* expected, size_t expected_count, struct participant* actual, size_t actual_count)
+{
+  size_t index;
+
+  if (expected_count != actual_count)
+    return -1;
+  qsort(expected, expected_count, sizeof(*expected), participant_compare);
+  qsort(actual, actual_count, sizeof(*actual), participant_compare);
+  for (index = 0; index < expected_count; index++) {
+    if (strcmp(expected[index].id, actual[index].id) != 0)
+      return -1;
+  }
+  return 0;
+}
+
+static int
+same_topology(struct participant* expected, size_t expected_count, struct participant* actual, size_t actual_count)
+{
+  size_t index;
+
+  if (same_participants(expected, expected_count, actual, actual_count) != 0)
+    return -1;
+  for (index = 0; index < expected_count; index++) {
+    if (expected[index].count != actual[index].count)
+      return -1;
+    qsort(expected[index].records, expected[index].count, sizeof(*expected[index].records), record_compare);
+    qsort(actual[index].records, actual[index].count, sizeof(*actual[index].records), record_compare);
+    if (memcmp(
+            expected[index].records, actual[index].records,
+            (size_t)expected[index].count * sizeof(*expected[index].records)) != 0)
+      return -1;
+  }
+  return 0;
+}
+
+int
+main(int argc, char** argv)
+{
+  struct participant* participants = NULL;
+  struct participant* expected = NULL;
+  struct allocation* allocations = NULL;
+  size_t participant_count = 0;
+  size_t expected_count = 0;
+  size_t index;
+  bool prepare;
+  int result = EXIT_FAILURE;
+  FILE* state = NULL;
+
+  char state_path[PATH_MAX];
+  const char* proc_root;
+  const char* checkpoint_dir;
+  const char* control_dir = "/snapshot-control";
+  int length;
+
+  if (argc < 9 || (argc - 6) % 3 != 0 || (strcmp(argv[1], "--prepare") != 0 && strcmp(argv[1], "--restore") != 0)) {
+    fprintf(
+        stderr,
+        "usage: %s (--prepare|--restore) --proc-root PATH "
+        "--checkpoint-dir PATH --process OBSERVED_PID NAMESPACE_PID...\n",
+        argv[0]);
+    return EXIT_FAILURE;
+  }
+  prepare = strcmp(argv[1], "--prepare") == 0;
+  if (strcmp(argv[2], "--proc-root") != 0 || strcmp(argv[4], "--checkpoint-dir") != 0)
+    return EXIT_FAILURE;
+  proc_root = argv[3];
+  checkpoint_dir = argv[5];
+  length = snprintf(state_path, sizeof(state_path), "%s/%s", checkpoint_dir, STATE_FILENAME);
+  if (length < 0 || (size_t)length >= sizeof(state_path))
+    return EXIT_FAILURE;
+  if (!prepare) {
+    state = fopen(state_path, "r");
+    if (state == NULL)
+      return errno == ENOENT ? EXIT_SUCCESS : EXIT_FAILURE;
+  }
+  if (proc_root[0] == '\0') {
+    const char* control = getenv("DYN_SNAPSHOT_CONTROL_DIR");
+    if (control != NULL && control[0] != '\0')
+      control_dir = control;
+  }
+  participant_count = (size_t)(argc - 6) / 3;
+  participants = calloc(participant_count, sizeof(*participants));
+  if (participants == NULL)
+    goto done;
+  for (index = 0; index < participant_count; index++) {
+    char endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+    char* end;
+    long observed;
+    long namespace;
+    int length;
+
+    if (strcmp(argv[6 + index * 3], "--process") != 0)
+      goto done;
+    errno = 0;
+    observed = strtol(argv[7 + index * 3], &end, 10);
+    if (errno != 0 || *end != '\0' || observed <= 0 || observed > INT_MAX)
+      goto done;
+    errno = 0;
+    namespace = strtol(argv[8 + index * 3], &end, 10);
+    if (errno != 0 || *end != '\0' || namespace <= 0 || namespace > INT_MAX)
+      goto done;
+    if (proc_root[0] == '\0')
+      length =
+          snprintf(endpoint, sizeof(endpoint), "%s/%s%ld.sock", control_dir, CUINTERPOSER_SOCKET_PREFIX, namespace);
+    else
+      length = snprintf(
+          endpoint, sizeof(endpoint), "%s/%ld/root%s/%s%ld.sock", proc_root, observed, control_dir,
+          CUINTERPOSER_SOCKET_PREFIX, namespace);
+    if (length < 0 || (size_t)length >= sizeof(endpoint))
+      goto done;
+    participants[index].endpoint = strdup(endpoint);
+    if (participants[index].endpoint == NULL)
+      goto done;
+  }
+  if (prepare) {
+    if (inspect(participants, participant_count) != 0) {
+      fprintf(stderr, "prepare failed: participant inspect\n");
+      goto done;
+    }
+    if (validate_topology(participants, participant_count, &allocations) != 0) {
+      fprintf(stderr, "prepare failed: topology validate\n");
+      goto done;
+    }
+    if (command_all(participants, participant_count, CUINTERPOSER_PREPARE) != 0) {
+      fprintf(stderr, "prepare failed: participant prepare\n");
+      goto done;
+    }
+    if (write_state_atomic(state_path, participants, participant_count) != 0) {
+      fprintf(stderr, "prepare failed: atomic state write\n");
+      goto done;
+    }
+  } else {
+    if (read_state(state, &expected, &expected_count) != 0)
+      goto done;
+    if (fclose(state) != 0) {
+      state = NULL;
+      goto done;
+    }
+    state = NULL;
+    if (identify(participants, participant_count) != 0 ||
+        same_participants(expected, expected_count, participants, participant_count) != 0)
+      goto done;
+    if (restore_unicast(participants, participant_count) != 0) {
+      goto done;
+    }
+    for (index = 0; index < participant_count; index++) {
+      free(participants[index].records);
+      participants[index].records = NULL;
+      participants[index].count = 0;
+    }
+    if (inspect(participants, participant_count) != 0 ||
+        validate_topology(participants, participant_count, &allocations) != 0 ||
+        same_topology(expected, expected_count, participants, participant_count) != 0)
+      goto done;
+  }
+  result = EXIT_SUCCESS;
+done:
+  if (state != NULL)
+    fclose(state);
+  free_allocations(allocations);
+  free_participants(expected, expected_count);
+  free_participants(participants, participant_count);
+  return result;
 }

--- a/agent/cmd/cuinterpose/protocol.h
+++ b/agent/cmd/cuinterpose/protocol.h
@@ -7,4 +7,76 @@
 #ifndef CUINTERPOSER_PROTOCOL_H
 #define CUINTERPOSER_PROTOCOL_H
 
+#include <stdint.h>
+
+#define CUINTERPOSER_MAGIC 0x44564d4dU
+#define CUINTERPOSER_VERSION 1U
+#define CUINTERPOSER_SOCKET_PREFIX "cuinterposer-"
+#define CUINTERPOSER_ID_SIZE 33U
+#define CUINTERPOSER_ALLOCATION_ID_SIZE 16U
+#define CUINTERPOSER_TOKEN_SIZE 16U
+#define CUINTERPOSER_MAX_ACCESS 8U
+#define CUINTERPOSER_MAX_RECORDS 4096U
+#define CUINTERPOSER_POSIX_HANDLE_TYPE 1U
+
+enum cuinterposer_operation {
+  CUINTERPOSER_IDENTIFY = 1,
+  CUINTERPOSER_INSPECT = 2,
+  CUINTERPOSER_PREPARE = 3,
+  CUINTERPOSER_RESTORE_CREATORS = 4,
+  CUINTERPOSER_RESTORE_IMPORTERS = 5,
+  CUINTERPOSER_EXPORT = 6,
+};
+
+enum cuinterposer_record_kind {
+  CUINTERPOSER_ALLOCATION = 1,
+  CUINTERPOSER_MAPPING = 2,
+};
+
+enum cuinterposer_record_flags {
+  CUINTERPOSER_CREATOR = 1U << 0,
+  CUINTERPOSER_APPLICATION_HANDLE_LIVE = 1U << 1,
+};
+
+struct cuinterposer_header {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t operation;
+  int32_t status;
+  uint32_t count;
+  uint64_t payload_size;
+  char participant_id[CUINTERPOSER_ID_SIZE];
+  char message[96];
+  uint8_t authorization[CUINTERPOSER_TOKEN_SIZE];
+  uint8_t allocation_id[CUINTERPOSER_ALLOCATION_ID_SIZE];
+  uint8_t reserved[71];
+};
+
+struct cuinterposer_access {
+  int32_t location_type;
+  int32_t location_id;
+  uint64_t flags;
+};
+
+struct cuinterposer_record {
+  uint32_t kind;
+  uint32_t flags;
+  uint8_t allocation_id[CUINTERPOSER_ALLOCATION_ID_SIZE];
+  uint64_t address;
+  uint64_t size;
+  uint64_t offset;
+  uint64_t allocation_size;
+  int32_t allocation_type;
+  uint32_t requested_handle_types;
+  int32_t allocation_location_type;
+  int32_t allocation_location_id;
+  uint32_t access_count;
+  uint32_t application_handle_count;
+  struct cuinterposer_access access[CUINTERPOSER_MAX_ACCESS];
+};
+
+_Static_assert(sizeof(struct cuinterposer_header) == 256, "cuinterposer header layout changed");
+_Static_assert(sizeof(struct cuinterposer_access) == 16, "cuinterposer access layout changed");
+_Static_assert(sizeof(struct cuinterposer_record) == 208, "cuinterposer record layout changed");
+
 #endif

--- a/agent/cmd/cuinterpose/util.c
+++ b/agent/cmd/cuinterpose/util.c
@@ -4,4 +4,188 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define _GNU_SOURCE
+
 #include "util.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/random.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+int
+write_all(int fd, const void* value, size_t size)
+{
+  const uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = write(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+read_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = read(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+pread_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+  off_t offset = 0;
+
+  while (size != 0) {
+    ssize_t count = pread(fd, current, size, offset);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    offset += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+random_bytes(void* output, size_t size)
+{
+  unsigned char* current = output;
+
+  while (size != 0) {
+    ssize_t count = getrandom(current, size, 0);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+random_id(char output[CUINTERPOSER_ID_SIZE])
+{
+  uint8_t value[16];
+  size_t index;
+
+  if (random_bytes(value, sizeof(value)) != 0)
+    return -1;
+  for (index = 0; index < sizeof(value); index++)
+    snprintf(output + index * 2, CUINTERPOSER_ID_SIZE - index * 2, "%02x", value[index]);
+  return 0;
+}
+
+bool
+is_lower_hex_id(const char value[CUINTERPOSER_ID_SIZE])
+{
+  size_t index;
+
+  if (value == NULL)
+    return false;
+  for (index = 0; index < CUINTERPOSER_ID_SIZE - 1; index++) {
+    if (!((value[index] >= '0' && value[index] <= '9') || (value[index] >= 'a' && value[index] <= 'f')))
+      return false;
+  }
+  return value[CUINTERPOSER_ID_SIZE - 1] == '\0';
+}
+
+bool
+header_strings_terminated(const struct cuinterposer_header* header)
+{
+  return memchr(header->participant_id, '\0', sizeof(header->participant_id)) != NULL &&
+         memchr(header->message, '\0', sizeof(header->message)) != NULL;
+}
+
+void
+header_error(struct cuinterposer_header* header, const char* message)
+{
+  header->status = -1;
+  snprintf(header->message, sizeof(header->message), "%s", message);
+}
+
+int
+set_socket_timeouts(int fd, int seconds)
+{
+  struct timeval timeout = {.tv_sec = seconds};
+
+  return setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) == 0 &&
+                 setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == 0
+             ? 0
+             : -1;
+}
+
+int
+send_header(int fd, const struct cuinterposer_header* header, int passed_fd)
+{
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {.iov_base = (void*)header, .iov_len = sizeof(*header)};
+  struct msghdr message = {.msg_iov = &vector, .msg_iovlen = 1};
+  ssize_t count;
+
+  if (passed_fd >= 0) {
+    struct cmsghdr* item;
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(item), &passed_fd, sizeof(passed_fd));
+  }
+  do {
+    count = sendmsg(fd, &message, MSG_NOSIGNAL);
+  } while (count < 0 && errno == EINTR);
+  return count == (ssize_t)sizeof(*header) ? 0 : -1;
+}
+
+int
+receive_header(int fd, struct cuinterposer_header* header, int* passed_fd)
+{
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {.iov_base = header, .iov_len = sizeof(*header)};
+  struct msghdr message = {
+      .msg_iov = &vector,
+      .msg_iovlen = 1,
+      .msg_control = control,
+      .msg_controllen = sizeof(control),
+  };
+  struct cmsghdr* item;
+  ssize_t count;
+
+  *passed_fd = -1;
+  do {
+    count = recvmsg(fd, &message, MSG_WAITALL | MSG_CMSG_CLOEXEC);
+  } while (count < 0 && errno == EINTR);
+  if (count != (ssize_t)sizeof(*header) || (message.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) != 0)
+    return -1;
+  item = CMSG_FIRSTHDR(&message);
+  if (item != NULL && item->cmsg_level == SOL_SOCKET && item->cmsg_type == SCM_RIGHTS &&
+      item->cmsg_len == CMSG_LEN(sizeof(int)))
+    memcpy(passed_fd, CMSG_DATA(item), sizeof(*passed_fd));
+  return item == NULL || CMSG_NXTHDR(&message, item) == NULL ? 0 : -1;
+}

--- a/agent/cmd/cuinterpose/util.h
+++ b/agent/cmd/cuinterpose/util.h
@@ -7,4 +7,21 @@
 #ifndef CUINTERPOSER_UTIL_H
 #define CUINTERPOSER_UTIL_H
 
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "protocol.h"
+
+int write_all(int fd, const void* value, size_t size);
+int read_all(int fd, void* value, size_t size);
+int pread_all(int fd, void* value, size_t size);
+int random_bytes(void* output, size_t size);
+int random_id(char output[CUINTERPOSER_ID_SIZE]);
+bool is_lower_hex_id(const char value[CUINTERPOSER_ID_SIZE]);
+bool header_strings_terminated(const struct cuinterposer_header* header);
+void header_error(struct cuinterposer_header* header, const char* message);
+int set_socket_timeouts(int fd, int seconds);
+int send_header(int fd, const struct cuinterposer_header* header, int passed_fd);
+int receive_header(int fd, struct cuinterposer_header* header, int* passed_fd);
+
 #endif

--- a/agent/internal/cuda/cuinterpose.go
+++ b/agent/internal/cuda/cuinterpose.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+	"github.com/go-logr/logr"
+)
+
+const (
+	// CoordinatorBinaryName is the cuinterposer-coordinator executable name.
+	CoordinatorBinaryName = "cuinterposer-coordinator"
+	// DefaultCoordinatorBinaryPath is the agent-side coordinator absolute path,
+	// used for prepare. Restore runs inside the restore target after CRIU has
+	// restored the original mount namespace, which does not contain the agent
+	// bundle, so that call site passes a /proc/self/fd path opened beforehand.
+	DefaultCoordinatorBinaryPath = "/usr/local/bin/" + CoordinatorBinaryName
+
+	cuinterposerSocketPrefix = "cuinterposer-"
+	cuinterposerStateFile    = "cuinterposer.state"
+)
+
+func snapshotControlDir() string {
+	return strings.TrimPrefix(podcontract.SnapshotControlMountPath, string(os.PathSeparator))
+}
+
+func cuinterposerEndpointPath(procRoot string, observedPID, namespacePID int) string {
+	return filepath.Join(
+		procRoot,
+		strconv.Itoa(observedPID),
+		"root",
+		snapshotControlDir(),
+		fmt.Sprintf("%s%d.sock", cuinterposerSocketPrefix, namespacePID),
+	)
+}
+
+// DetectCUDAInterposition reports whether the live CUDA processes are running
+// the interposer. The signal is the shim's Unix sockets under the container's
+// snapshot-control mount, not /proc/<pid>/environ: Python setproctitle
+// (vLLM/SGLang) can clobber procfs environment while the sockets remain.
+// No sockets skips prepare. A partial or invalid set fails closed.
+func DetectCUDAInterposition(procRoot string, observedPIDs, namespacePIDs []int) (bool, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return false, fmt.Errorf(
+			"cuinterposer PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return false, nil
+	}
+	validEndpoints := 0
+	seenEndpoints := 0
+	for index, observedPID := range observedPIDs {
+		endpoint := cuinterposerEndpointPath(procRoot, observedPID, namespacePIDs[index])
+		info, err := os.Lstat(endpoint)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("stat cuinterposer endpoint %q: %w", endpoint, err)
+		}
+		seenEndpoints++
+		if info.Mode()&os.ModeSocket != 0 {
+			validEndpoints++
+		}
+	}
+	if seenEndpoints == 0 {
+		return false, nil
+	}
+	if validEndpoints != len(observedPIDs) {
+		return false, fmt.Errorf(
+			"cuinterposer endpoint missing or invalid for %d of %d CUDA processes",
+			len(observedPIDs)-validEndpoints,
+			len(observedPIDs),
+		)
+	}
+	return true, nil
+}
+
+func HasCUDAInterpositionState(checkpointDir string) (bool, error) {
+	_, err := os.Stat(filepath.Join(checkpointDir, cuinterposerStateFile))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func PrepareCUDAInterposition(
+	ctx context.Context,
+	checkpointDir string,
+	procRoot string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) error {
+	args, err := cuinterposerArgs("prepare", checkpointDir, procRoot, observedPIDs, namespacePIDs)
+	if err != nil {
+		return err
+	}
+	output, err := exec.CommandContext(ctx, coordinatorBinaryPath, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s failed: %w (output: %s)", coordinatorBinaryPath, err, strings.TrimSpace(string(output)))
+	}
+	log.Info("Prepared cuinterposer state")
+	return nil
+}
+
+func RestoreCUDAInterposition(
+	ctx context.Context,
+	checkpointDir string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+) error {
+	args, err := cuinterposerArgs("restore", checkpointDir, "", observedPIDs, namespacePIDs)
+	if err != nil {
+		return err
+	}
+	output, err := exec.CommandContext(ctx, coordinatorBinaryPath, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s failed: %w (output: %s)", coordinatorBinaryPath, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func cuinterposerArgs(operation, checkpointDir, procRoot string, observedPIDs, namespacePIDs []int) ([]string, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return nil, fmt.Errorf(
+			"cuinterposer PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	args := []string{
+		"--" + operation,
+		"--proc-root",
+		procRoot,
+		"--checkpoint-dir",
+		checkpointDir,
+	}
+	for index, observedPID := range observedPIDs {
+		args = append(
+			args,
+			"--process",
+			strconv.Itoa(observedPID),
+			strconv.Itoa(namespacePIDs[index]),
+		)
+	}
+	return args, nil
+}

--- a/agent/internal/cuda/cuinterpose_test.go
+++ b/agent/internal/cuda/cuinterpose_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestDetectCUDAInterpositionSkipsEmptyPIDList(t *testing.T) {
+	interposed, err := DetectCUDAInterposition(t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("DetectCUDAInterposition() error = %v", err)
+	}
+	if interposed {
+		t.Fatal("DetectCUDAInterposition() = true, want skip")
+	}
+}
+
+func TestDetectCUDAInterpositionPIDCountMismatch(t *testing.T) {
+	_, err := DetectCUDAInterposition(t.TempDir(), []int{101}, nil)
+	if err == nil {
+		t.Fatal("expected PID mapping count mismatch")
+	}
+}
+
+func TestDetectCUDAInterpositionSkipsWithoutSockets(t *testing.T) {
+	procRoot := shortTempDir(t)
+	mustControlDir(t, procRoot, 101, 1)
+	interposed, err := DetectCUDAInterposition(procRoot, []int{101, 102}, []int{1, 2})
+	if err != nil {
+		t.Fatalf("DetectCUDAInterposition() error = %v", err)
+	}
+	if interposed {
+		t.Fatal("DetectCUDAInterposition() = true, want skip")
+	}
+}
+
+func TestDetectCUDAInterpositionIgnoresProcfsEnviron(t *testing.T) {
+	procRoot := shortTempDir(t)
+	mustControlDir(t, procRoot, 101, 1)
+	mustControlDir(t, procRoot, 102, 2)
+	mustEnviron(t, procRoot, 101, "IRRELEVANT=1\x00")
+	mustEnviron(t, procRoot, 102, "IRRELEVANT=1\x00")
+
+	interposed, err := DetectCUDAInterposition(procRoot, []int{101, 102}, []int{1, 2})
+	if err != nil {
+		t.Fatalf("DetectCUDAInterposition() error = %v", err)
+	}
+	if interposed {
+		t.Fatal("DetectCUDAInterposition() keyed off procfs environ")
+	}
+}
+
+func TestDetectCUDAInterpositionRequiresEveryCUDAProcessSocket(t *testing.T) {
+	procRoot := shortTempDir(t)
+	listenUnix(t, cuinterposerEndpointPath(procRoot, 101, 1))
+
+	_, err := DetectCUDAInterposition(procRoot, []int{101, 102}, []int{1, 2})
+	if err == nil {
+		t.Fatal("expected missing endpoint to fail closed")
+	}
+
+	listenUnix(t, cuinterposerEndpointPath(procRoot, 102, 2))
+	interposed, err := DetectCUDAInterposition(procRoot, []int{101, 102}, []int{1, 2})
+	if err != nil {
+		t.Fatalf("DetectCUDAInterposition() error = %v", err)
+	}
+	if !interposed {
+		t.Fatal("DetectCUDAInterposition() = false, want true")
+	}
+}
+
+func TestDetectCUDAInterpositionRejectsNonSocketEndpoint(t *testing.T) {
+	procRoot := shortTempDir(t)
+	listenUnix(t, cuinterposerEndpointPath(procRoot, 101, 1))
+	path := cuinterposerEndpointPath(procRoot, 102, 2)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not a socket"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := DetectCUDAInterposition(procRoot, []int{101, 102}, []int{1, 2})
+	if err == nil {
+		t.Fatal("expected non-socket endpoint to fail closed")
+	}
+}
+
+func TestHasCUDAInterpositionState(t *testing.T) {
+	checkpointDir := t.TempDir()
+	present, err := HasCUDAInterpositionState(checkpointDir)
+	if err != nil {
+		t.Fatalf("HasCUDAInterpositionState() error = %v", err)
+	}
+	if present {
+		t.Fatal("HasCUDAInterpositionState() = true for missing sidecar")
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, cuinterposerStateFile), []byte("state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	present, err = HasCUDAInterpositionState(checkpointDir)
+	if err != nil {
+		t.Fatalf("HasCUDAInterpositionState() error = %v", err)
+	}
+	if !present {
+		t.Fatal("HasCUDAInterpositionState() = false, want true")
+	}
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "cui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func mustControlDir(t *testing.T, procRoot string, observedPID, namespacePID int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(cuinterposerEndpointPath(procRoot, observedPID, namespacePID)), 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustEnviron(t *testing.T, procRoot string, observedPID int, content string) {
+	t.Helper()
+	path := filepath.Join(procRoot, strconv.Itoa(observedPID), "environ")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listenUnix(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+}

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -193,6 +193,14 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	if len(cudaHostPIDs) > 0 {
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
+	cudaInterposition, err := cuda.DetectCUDAInterposition(
+		snapshotruntime.HostProcPath,
+		cudaHostPIDs,
+		cudaNamespacePIDs,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("detect CUDA interposition: %w", err)
+	}
 	var gpuUUIDs []string
 	var gpuDeviceMapDuration time.Duration
 	if len(cudaHostPIDs) > 0 {
@@ -214,17 +222,18 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	}
 
 	return &types.CheckpointContainerSnapshot{
-		PID:            pid,
-		RootFS:         rootFS,
-		UpperDir:       upperDir,
-		OCISpec:        ociSpec,
-		Mounts:         mounts,
-		NetNSInode:     netNSInode,
-		StdioFDs:       stdioFDs,
-		HostCgroupPath: hostCgroupPath,
-		CUDAHostPIDs:   cudaHostPIDs,
-		CUDANSPIDs:     cudaNamespacePIDs,
-		GPUUUIDs:       gpuUUIDs,
+		PID:               pid,
+		RootFS:            rootFS,
+		UpperDir:          upperDir,
+		OCISpec:           ociSpec,
+		Mounts:            mounts,
+		NetNSInode:        netNSInode,
+		StdioFDs:          stdioFDs,
+		HostCgroupPath:    hostCgroupPath,
+		CUDAHostPIDs:      cudaHostPIDs,
+		CUDANSPIDs:        cudaNamespacePIDs,
+		GPUUUIDs:          gpuUUIDs,
+		CUDAInterposition: cudaInterposition,
 	}, gpuDeviceMapDuration, nil
 }
 
@@ -263,6 +272,19 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 
 	// CUDA lock+checkpoint must happen before CRIU dump
 	if len(state.CUDAHostPIDs) > 0 {
+		if state.CUDAInterposition {
+			if err := cuda.PrepareCUDAInterposition(
+				ctx,
+				checkpointDir,
+				snapshotruntime.HostProcPath,
+				state.CUDAHostPIDs,
+				state.CUDANSPIDs,
+				cuda.DefaultCoordinatorBinaryPath,
+				log,
+			); err != nil {
+				return nil, fmt.Errorf("prepare CUDA interposition: %w", err)
+			}
+		}
 		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -168,7 +168,14 @@ func executeRestore(
 	// opening the binary now and exec'ing via /proc/self/fd/N after CRIU returns,
 	// the fd remains valid even if the mount is gone.
 	var cudaHelperFdPath string
+	var coordinatorFdPath string
+	hasCUDAInterposition := false
 	if !m.CUDA.IsEmpty() {
+		var stateErr error
+		hasCUDAInterposition, stateErr = cuda.HasCUDAInterpositionState(opts.CheckpointPath)
+		if stateErr != nil {
+			return nil, 0, nil, fmt.Errorf("stat CUDA interposition state: %w", stateErr)
+		}
 		helperPath := filepath.Join(opts.BundleDir, cuda.HelperBinaryName)
 		f, err := os.Open(helperPath)
 		if err != nil {
@@ -176,6 +183,16 @@ func executeRestore(
 		}
 		defer f.Close()
 		cudaHelperFdPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
+
+		if hasCUDAInterposition {
+			coordinatorPath := filepath.Join(opts.BundleDir, cuda.CoordinatorBinaryName)
+			coordinator, err := os.Open(coordinatorPath)
+			if err != nil {
+				return nil, 0, nil, fmt.Errorf("failed to open cuinterposer-coordinator before CRIU restore: %w", err)
+			}
+			defer coordinator.Close()
+			coordinatorFdPath = fmt.Sprintf("/proc/self/fd/%d", coordinator.Fd())
+		}
 	}
 
 	// The restore-complete sentinel lives on the pod emptyDir mounted at
@@ -249,10 +266,21 @@ func executeRestore(
 		)
 		cudaStart := time.Now()
 		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, cudaHelperFdPath, log)
-		timings.cudaRestoreDuration = time.Since(cudaStart)
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("CUDA restore failed: %w", err)
 		}
+		if hasCUDAInterposition {
+			if err := cuda.RestoreCUDAInterposition(
+				ctx,
+				opts.CheckpointPath,
+				restorePIDs,
+				m.CUDA.PIDs,
+				coordinatorFdPath,
+			); err != nil {
+				return nil, 0, nil, fmt.Errorf("restore CUDA interposition: %w", err)
+			}
+		}
+		timings.cudaRestoreDuration = time.Since(cudaStart)
 	}
 
 	return timings, restoredPID, nil, nil

--- a/agent/internal/types/inspect.go
+++ b/agent/internal/types/inspect.go
@@ -20,17 +20,18 @@ type MountInfo struct {
 
 // CheckpointContainerSnapshot holds runtime container state collected during checkpoint inspection.
 type CheckpointContainerSnapshot struct {
-	PID            int
-	RootFS         string
-	UpperDir       string
-	OCISpec        *specs.Spec
-	Mounts         []MountInfo
-	NetNSInode     uint64
-	StdioFDs       []string // readlink targets for FDs 0, 1, 2 (e.g. "pipe:[12345]")
-	HostCgroupPath string   // host filesystem path for CRIU's --freeze-cgroup
-	CUDAHostPIDs   []int    // host-visible PIDs used for checkpoint-side CUDA actions
-	CUDANSPIDs     []int    // namespace-relative PIDs stored in the checkpoint manifest
-	GPUUUIDs       []string // source GPU UUIDs from kubelet PodResources API
+	PID               int
+	RootFS            string
+	UpperDir          string
+	OCISpec           *specs.Spec
+	Mounts            []MountInfo
+	NetNSInode        uint64
+	StdioFDs          []string // readlink targets for FDs 0, 1, 2 (e.g. "pipe:[12345]")
+	HostCgroupPath    string   // host filesystem path for CRIU's --freeze-cgroup
+	CUDAHostPIDs      []int    // host-visible PIDs used for checkpoint-side CUDA actions
+	CUDANSPIDs        []int    // namespace-relative PIDs stored in the checkpoint manifest
+	GPUUUIDs          []string // source GPU UUIDs from kubelet PodResources API
+	CUDAInterposition bool
 }
 
 // RestoreContainerSnapshot holds inspected state for the restore target.


### PR DESCRIPTION
## Summary
- implement the native `cuinterposer-coordinator` protocol and topology validation
- detect live shim participants through Unix sockets and persisted restore state through `cuinterposer.state`
- invoke prepare before native CUDA checkpointing
- pre-open and invoke the coordinator across CRIU mount-namespace replacement during restore
- keep orchestration dormant when the forwarding-only shim from #78 has no control sockets or state file

This is layer 3 of [stack #156](https://github.com/ai-dynamo/snapshot/stack/156). It adds coordinator and agent orchestration, but not POSIX allocation tracking or checkpoint behavior.

## Validation
- all Go tests
- production CUDA-builder compile
- static coordinator has no dynamic dependencies
- intermediate branch builds independently
