### PR TITLE
fix(chart): support OpenShift SCC admission

### DIFF
--- a/charts/snapshot/README.md
+++ b/charts/snapshot/README.md
@@ -19,7 +19,7 @@ namespaces. Workload pods never mount checkpoint storage.
 ## Prerequisites
 
 - Kubernetes cluster with x86_64 GPU nodes
-- NVIDIA driver 580.xx or newer
+- NVIDIA GPU Operator 26.3 or newer, with NVIDIA driver 580.xx or newer
 - **containerd** or **CRI-O** (chart defaults to containerd; see below for CRI-O / OpenShift)
 - a cluster where a privileged DaemonSet with `hostPID`, `hostIPC`, and `hostNetwork` is acceptable
 
@@ -34,17 +34,41 @@ or upgrading. To migrate, create a new RWX claim, copy the retained checkpoint
 data once if it must be preserved, then set `storage.pvc.create=false` and
 `storage.pvc.name` to the new claim. The old retained claim remains untouched.
 
+When using AWS EFS, make sure a reused static PV references a real EFS file
+system ID and has mount targets reachable from every GPU node. A placeholder
+such as `fs-xxxx` can bind a PVC but the snapshot agent will not start because
+the node cannot mount it.
+
 ## CRI-O and OpenShift
 
 For CRI-O nodes set `runtime.type=crio`. Only set `runtime.socketPath` if the CRI
 socket is not the default for that type (see `values.yaml`). On OpenShift, set
 `openshift.enabled=true` so the chart emits the extra RBAC and pod annotations
-the agent needs. Example:
+the agent needs. The agent uses public GHCR images by default and does not need
+an image pull secret; configure `daemonset.imagePullSecrets` only for a private
+image override. When upgrading a release that uses a private agent image, set
+the private registry pull secret in the same Helm upgrade so the new chart
+defaults do not remove the required image access.
+
+Create a checkpoint PVC through an RWX-capable StorageClass, such as an EFS
+StorageClass:
 
 ```bash
 helm upgrade --install snapshot ./charts/snapshot \
   --namespace "${NAMESPACE}" --create-namespace \
   --set storage.pvc.create=true \
+  --set storage.pvc.storageClass=<rwx-storage-class> \
+  --set runtime.type=crio \
+  --set openshift.enabled=true
+```
+
+Or reuse an existing RWX PVC in the installation namespace:
+
+```bash
+helm upgrade --install snapshot ./charts/snapshot \
+  --namespace "${NAMESPACE}" --create-namespace \
+  --set storage.pvc.create=false \
+  --set storage.pvc.name=<existing-rwx-pvc> \
   --set runtime.type=crio \
   --set openshift.enabled=true
 ```
@@ -131,6 +155,8 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=snapshot -o wide
 | `image.operator.repository` | Operator image repository | `ghcr.io/ai-dynamo/snapshot/operator` |
 | `image.agent.repository` | Agent image repository | `ghcr.io/ai-dynamo/snapshot/agent` |
 | `image.agent.tag` | Agent image tag (empty = chart appVersion) | `""` |
+| `daemonset.imagePullSecrets` | Pull secrets for a private agent image override | `[]` |
+| `operator.resources` | CPU and memory requests/limits for the operator manager | 50m CPU / 64Mi request, 500m CPU / 128Mi limit |
 | `storage.type` | Snapshot-owned storage backend | `pvc` |
 | `storage.pvc.create` | Create `snapshot-pvc` instead of using an existing shared PVC | `true` |
 | `storage.pvc.name` | Shared RWX checkpoint PVC mounted by every agent | `snapshot-pvc` |

--- a/charts/snapshot/README.md
+++ b/charts/snapshot/README.md
@@ -54,10 +54,12 @@ Create a checkpoint PVC through an RWX-capable StorageClass, such as an EFS
 StorageClass:
 
 ```bash
+export RWX_STORAGE_CLASS=efs-rwx
+
 helm upgrade --install snapshot ./charts/snapshot \
   --namespace "${NAMESPACE}" --create-namespace \
   --set storage.pvc.create=true \
-  --set storage.pvc.storageClass=<rwx-storage-class> \
+  --set storage.pvc.storageClass="${RWX_STORAGE_CLASS}" \
   --set runtime.type=crio \
   --set openshift.enabled=true
 ```
@@ -65,10 +67,12 @@ helm upgrade --install snapshot ./charts/snapshot \
 Or reuse an existing RWX PVC in the installation namespace:
 
 ```bash
+export EXISTING_RWX_PVC=snapshot-efs-pvc
+
 helm upgrade --install snapshot ./charts/snapshot \
   --namespace "${NAMESPACE}" --create-namespace \
   --set storage.pvc.create=false \
-  --set storage.pvc.name=<existing-rwx-pvc> \
+  --set storage.pvc.name="${EXISTING_RWX_PVC}" \
   --set runtime.type=crio \
   --set openshift.enabled=true
 ```

--- a/charts/snapshot/templates/operator-deployment.yaml
+++ b/charts/snapshot/templates/operator-deployment.yaml
@@ -57,8 +57,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+            {{- /* OpenShift's anyuid SCC does not allow seccomp profiles. */}}
+            {{- if not .Values.openshift.enabled }}
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
+          {{- with .Values.operator.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - {{ printf "--snapshot-storage-base-path=%v" .Values.storage.pvc.basePath | quote }}
             - {{ printf "--artifact-cleanup-scan-interval=%v" .Values.operator.artifactCleanup.scanInterval | quote }}

--- a/charts/snapshot/tests/artifact_cleanup_test.yaml
+++ b/charts/snapshot/tests/artifact_cleanup_test.yaml
@@ -57,3 +57,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.seccompProfile.type
           value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 50m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+
+  - it: omits the manager seccomp profile for the OpenShift anyuid SCC
+    set:
+      openshift.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile
+      - equal:
+          path: spec.template.metadata.annotations["openshift.io/required-scc"]
+          value: anyuid

--- a/charts/snapshot/tests/image_pull_secrets_test.yaml
+++ b/charts/snapshot/tests/image_pull_secrets_test.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: snapshot agent image pull secrets
+templates:
+  - templates/daemonset.yaml
+tests:
+  - it: does not require an image pull secret for the public agent image
+    asserts:
+      - notExists:
+          path: spec.template.spec.imagePullSecrets
+
+  - it: renders explicitly configured image pull secrets
+    set:
+      daemonset.imagePullSecrets:
+        - name: private-registry
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: private-registry

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -17,6 +17,14 @@ image:
 replicaCount: 1
 
 operator:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
   artifactCleanup:
     # Frequency of authoritative orphan artifact scans.
     scanInterval: 10m
@@ -89,9 +97,9 @@ daemonset:
   # Agent and nsrestore log level (trace, debug, info, warn, error)
   snapshotLogLevel: info
 
-  # Image pull secrets
-  imagePullSecrets:
-    - name: ngc-secret
+  # The shipped agent image is public on GHCR. Set this only when an image
+  # override is hosted in a private registry.
+  imagePullSecrets: []
 
   # Resource limits and requests
   resources:


### PR DESCRIPTION
## Summary
- omit the operator manager seccomp profile when OpenShift selects the built-in `anyuid` SCC
- default agent image pull secrets to an empty list for public GHCR images
- document OpenShift CRI-O installation and chart-created or existing RWX PVC storage

## Validation
- `helm unittest charts/snapshot`
- `helm lint charts/snapshot`
- rendered standard and OpenShift Helm configurations

## Notes
A reused static EFS PV must reference a real filesystem ID with mount targets reachable from GPU nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU and memory resources for the operator.
  * Added image pull-secret configuration for private agent images.
  * Updated OpenShift deployments to support environments requiring the `anyuid` security constraint.
  * Expanded guidance for GPU requirements, AWS EFS validation, private registries, and checkpoint storage.

* **Bug Fixes**
  * Public agent images no longer require a registry pull secret by default.

* **Tests**
  * Added coverage for resource settings, OpenShift security, and image pull-secret configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->