### PR TITLE
🐛 Spawn vLLM workers in the snapshot example

### DIFF
--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -49,11 +49,12 @@ listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
-Before constructing `AsyncLLM`, the program sets
-`VLLM_WORKER_MULTIPROC_METHOD=spawn`. vLLM otherwise defaults to `fork`, which
-can copy CUDA file descriptors into child processes after the parent has
-initialized CUDA. Starting workers with `spawn` gives each child a fresh
-process state that Snapshot can capture and restore.
+The program uses `AsyncLLM` directly rather than vLLM's CLI wrapper, which sets
+`VLLM_WORKER_MULTIPROC_METHOD=spawn` automatically when it is unset. The
+library path defaults to `fork` and can switch to `spawn` if vLLM detects that
+CUDA is initialized. This example sets `spawn` explicitly before constructing
+`AsyncLLM` so worker startup does not depend on the wrapper or runtime
+detection.
 
 The Dockerfile starts from the official vLLM 0.27.1 image and installs the
 Ubuntu 24.04 glibc required by the current Snapshot restore bundle. It creates

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -49,6 +49,12 @@ listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
+Before constructing `AsyncLLM`, the program sets
+`VLLM_WORKER_MULTIPROC_METHOD=spawn`. vLLM otherwise defaults to `fork`, which
+can copy CUDA file descriptors into child processes after the parent has
+initialized CUDA. Starting workers with `spawn` gives each child a fresh
+process state that Snapshot can capture and restore.
+
 The Dockerfile starts from the official vLLM 0.27.1 image and installs the
 Ubuntu 24.04 glibc required by the current Snapshot restore bundle. It creates
 `/snapshot-control` and adds `app.py`.

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -14,6 +14,8 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
 CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
 MODEL = os.environ["SNAPSHOT_MODEL"]
 


### PR DESCRIPTION
## Summary

- force the vLLM guide application to create workers with `spawn`
- explain why `fork` is unsafe after CUDA initialization

## Validation

- compiled `docs/guides/vllm/app.py`
- imported the updated app in the vLLM 0.27.1 guide image and verified `get_mp_context().get_start_method()` returns `spawn`
- ran `git diff --check`