### PR TITLE
fix(agent): recreate large shared allocations on restore

### DIFF
--- a/agent/cmd/cuinterpose/Makefile
+++ b/agent/cmd/cuinterpose/Makefile
@@ -8,6 +8,9 @@ COORDINATOR := $(BUILD_DIR)/cuinterposer-coordinator
 MULTICAST_FORWARD_TEST := $(BUILD_DIR)/multicast-forward-test
 MIN_GLIBC := GLIBC_2.34
 INTERPOSER_CPPFLAGS := -DCUINTERPOSER_DLSYM_VERSION=\"$(MIN_GLIBC)\"
+ifneq ($(HOST_CARRIER_THRESHOLD),)
+INTERPOSER_CPPFLAGS += -DCUINTERPOSER_HOST_CARRIER_THRESHOLD=$(HOST_CARRIER_THRESHOLD)
+endif
 COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror
 INTERPOSER_SOURCES := interpose.c multicast.c posix.c symbols.c util.c
 INTERPOSER_HEADERS := multicast.h posix.h protocol.h symbols.h util.h

--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -23,6 +23,7 @@
 #include "util.h"
 
 #define TIMEOUT_SECONDS 30
+#define CARRIER_TIMEOUT_SECONDS 600
 #define STATE_FILENAME "cuinterposer.state"
 
 struct participant {
@@ -58,7 +59,15 @@ struct allocation {
   uint64_t size;
   bool creator_handle;
   bool creator_mapping;
+  bool host_carrier;
   struct allocation* next;
+};
+
+struct carrier_job {
+  struct participant* participant;
+  struct allocation* allocations;
+  uint16_t operation;
+  int result;
 };
 
 static int
@@ -245,6 +254,10 @@ validate_topology(struct participant* participants, size_t participant_count, st
           snprintf(allocation->creator, sizeof(allocation->creator), "%s", participant->id);
           allocation->size = record->allocation_size;
           allocation->creator_handle = (record->flags & CUINTERPOSER_APPLICATION_HANDLE_LIVE) != 0;
+          allocation->host_carrier = (record->flags & CUINTERPOSER_HOST_CARRIER) != 0;
+        } else if ((record->flags & CUINTERPOSER_HOST_CARRIER) != 0) {
+          reason = "host carrier flag on importer";
+          goto failed;
         }
       } else if (record->kind == CUINTERPOSER_MAPPING) {
         if (record->address == 0) {
@@ -727,6 +740,128 @@ done:
 }
 
 static int
+exchange_carrier(
+    struct participant* participant, uint16_t operation, const uint8_t allocation_id[CUINTERPOSER_ALLOCATION_ID_SIZE],
+    uint64_t size)
+{
+  struct cuinterposer_header request;
+  struct cuinterposer_header response;
+  int response_fd = -1;
+  int fd = -1;
+  int result = -1;
+
+  memset(&request, 0, sizeof(request));
+  request.magic = CUINTERPOSER_MAGIC;
+  request.version = CUINTERPOSER_VERSION;
+  request.operation = operation;
+  request.payload_size = size;
+  snprintf(request.participant_id, sizeof(request.participant_id), "%s", participant->id);
+  memcpy(request.allocation_id, allocation_id, sizeof(request.allocation_id));
+  fd = connect_endpoint(participant->endpoint);
+  if (fd < 0 || set_socket_timeouts(fd, CARRIER_TIMEOUT_SECONDS) != 0 ||
+      send_header(fd, &request, -1) != 0 || receive_header(fd, &response, &response_fd) != 0)
+    goto done;
+  if (response_fd >= 0 || !header_strings_terminated(&response) || response.magic != CUINTERPOSER_MAGIC ||
+      response.version != CUINTERPOSER_VERSION || response.operation != operation || response.status != 0 ||
+      response.count != 0 || response.payload_size != 0 || strcmp(response.participant_id, participant->id) != 0) {
+    if (header_strings_terminated(&response) && response.message[0] != '\0')
+      fprintf(stderr, "%s: %s\n", participant->endpoint, response.message);
+    goto done;
+  }
+  result = 0;
+done:
+  if (response_fd >= 0)
+    close(response_fd);
+  if (fd >= 0)
+    close(fd);
+  return result;
+}
+
+static void*
+run_carrier_job(void* argument)
+{
+  struct carrier_job* job = argument;
+  struct allocation* allocation;
+
+  job->result = 0;
+  for (allocation = job->allocations; allocation != NULL; allocation = allocation->next) {
+    if (!allocation->host_carrier || strcmp(allocation->creator, job->participant->id) != 0)
+      continue;
+    job->result =
+        exchange_carrier(job->participant, job->operation, allocation->id, allocation->size);
+    if (job->result != 0)
+      break;
+  }
+  return NULL;
+}
+
+static int
+transfer_host_carriers(
+    struct participant* participants, size_t participant_count, struct allocation* allocations,
+    uint16_t operation)
+{
+  struct carrier_job* jobs;
+  pthread_t* threads;
+  bool* launched;
+  size_t index;
+  int result = 0;
+
+  jobs = calloc(participant_count, sizeof(*jobs));
+  threads = calloc(participant_count, sizeof(*threads));
+  launched = calloc(participant_count, sizeof(*launched));
+  if (jobs == NULL || threads == NULL || launched == NULL) {
+    result = -1;
+    goto done;
+  }
+  for (index = 0; index < participant_count; index++) {
+    struct allocation* allocation;
+    bool owns_carrier = false;
+
+    for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+      if (allocation->host_carrier && strcmp(allocation->creator, participants[index].id) == 0) {
+        owns_carrier = true;
+        break;
+      }
+    }
+    if (!owns_carrier)
+      continue;
+    jobs[index].participant = &participants[index];
+    jobs[index].allocations = allocations;
+    jobs[index].operation = operation;
+    if (pthread_create(&threads[index], NULL, run_carrier_job, &jobs[index]) != 0) {
+      result = -1;
+      break;
+    }
+    launched[index] = true;
+  }
+  for (index = 0; index < participant_count; index++) {
+    if (launched[index] && (pthread_join(threads[index], NULL) != 0 || jobs[index].result != 0))
+      result = -1;
+  }
+done:
+  free(launched);
+  free(threads);
+  free(jobs);
+  return result;
+}
+
+static int
+save_host_carriers(
+    struct participant* participants, size_t participant_count, struct allocation* allocations)
+{
+  return transfer_host_carriers(
+      participants, participant_count, allocations, CUINTERPOSER_SAVE_HOST_CARRIER);
+}
+
+static int
+restore_host_carriers(
+    struct participant* participants, size_t participant_count, struct allocation* allocations)
+{
+  return transfer_host_carriers(
+      participants, participant_count, allocations, CUINTERPOSER_RESTORE_HOST_CARRIER);
+}
+
+static int
 restore_unicast(struct participant* participants, size_t count)
 {
   /* Creators must finish and listen again before importers request a fresh export. */
@@ -792,6 +927,7 @@ main(int argc, char** argv)
   struct participant* participants = NULL;
   struct participant* expected = NULL;
   struct allocation* allocations = NULL;
+  struct allocation* restored_allocations = NULL;
   size_t participant_count = 0;
   size_t expected_count = 0;
   size_t index;
@@ -882,6 +1018,10 @@ main(int argc, char** argv)
       fprintf(stderr, "prepare failed: multicast teardown\n");
       goto done;
     }
+    if (save_host_carriers(participants, participant_count, allocations) != 0) {
+      fprintf(stderr, "prepare failed: host carrier save\n");
+      goto done;
+    }
     if (command_all(participants, participant_count, CUINTERPOSER_PREPARE) != 0) {
       fprintf(stderr, "prepare failed: participant prepare\n");
       goto done;
@@ -901,6 +1041,9 @@ main(int argc, char** argv)
     if (identify(participants, participant_count) != 0 ||
         same_participants(expected, expected_count, participants, participant_count) != 0)
       goto done;
+    if (validate_topology(expected, expected_count, &allocations) != 0 ||
+        restore_host_carriers(participants, participant_count, allocations) != 0)
+      goto done;
     if (restore_unicast(participants, participant_count) != 0 ||
         restore_multicast(participants, participant_count) != 0) {
       goto done;
@@ -911,7 +1054,7 @@ main(int argc, char** argv)
       participants[index].count = 0;
     }
     if (inspect(participants, participant_count) != 0 ||
-        validate_topology(participants, participant_count, &allocations) != 0 ||
+        validate_topology(participants, participant_count, &restored_allocations) != 0 ||
         same_topology(expected, expected_count, participants, participant_count) != 0)
       goto done;
   }
@@ -919,6 +1062,7 @@ main(int argc, char** argv)
 done:
   if (state != NULL)
     fclose(state);
+  free_allocations(restored_allocations);
   free_allocations(allocations);
   free_participants(expected, expected_count);
   free_participants(participants, participant_count);

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -33,6 +34,10 @@
 #define LOGICAL_HANDLE_TAG UINT64_C(0xd94d000000000000)
 #define LOGICAL_HANDLE_TAG_MASK UINT64_C(0xffff000000000000)
 #define LOGICAL_HANDLE_VALUE_MASK UINT64_C(0x0000ffffffffffff)
+#ifndef CUINTERPOSER_HOST_CARRIER_THRESHOLD
+#define CUINTERPOSER_HOST_CARRIER_THRESHOLD (UINT64_C(512) * 1024 * 1024)
+#endif
+#define CUINTERPOSER_FLA_MIN_GRANULARITY (UINT64_C(2) * 1024 * 1024)
 
 CUresult CUDAAPI cuMemRetainAllocationHandle(CUmemGenericAllocationHandle*, void*);
 CUresult CUDAAPI cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp*, CUmemGenericAllocationHandle);
@@ -50,6 +55,13 @@ typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmem
 typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
 typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
 typedef CUresult(CUDAAPI* context_set_fn)(CUcontext);
+typedef CUresult(CUDAAPI* address_reserve_fn)(
+    CUdeviceptr*, size_t, size_t, CUdeviceptr, unsigned long long);
+typedef CUresult(CUDAAPI* address_free_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* host_register_fn)(void*, size_t, unsigned int);
+typedef CUresult(CUDAAPI* host_unregister_fn)(void*);
+typedef CUresult(CUDAAPI* copy_dtoh_fn)(void*, CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* copy_htod_fn)(CUdeviceptr, const void*, size_t);
 
 struct allocation;
 
@@ -82,8 +94,10 @@ struct allocation {
   CUmemAllocationProp properties;
   CUcontext context;
   CUmemGenericAllocationHandle carrier;
+  void* host_carrier;
   bool creator;
   bool shared;
+  bool host_checkpointed;
   struct allocation* next;
 };
 
@@ -121,6 +135,23 @@ static struct handle* resolve_managed_handle(CUmemGenericAllocationHandle logica
 static struct mapping* find_mapping_at(CUdeviceptr address);
 static struct mapping* first_mapping(const struct allocation* allocation);
 static struct handle* first_live_handle(const struct allocation* allocation);
+
+static bool
+needs_host_carrier(const struct allocation* allocation)
+{
+  /*
+   * r615 may attach FLA state to large, aligned device allocations. Native
+   * restore preserves their contents but a subsequently exported POSIX handle
+   * can retain stale FLA state. Recreate only the shared allocations that can
+   * enter that path; smaller and non-exported allocations remain native.
+   */
+  return allocation->creator && allocation->shared &&
+      allocation->properties.type == CU_MEM_ALLOCATION_TYPE_PINNED &&
+      allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE &&
+      allocation->properties.requestedHandleTypes == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+      allocation->size >= CUINTERPOSER_HOST_CARRIER_THRESHOLD &&
+      allocation->size % CUINTERPOSER_FLA_MIN_GRANULARITY == 0;
+}
 
 static void
 release_state_lock(void)
@@ -499,6 +530,8 @@ inspect_records(uint32_t* count)
     record->flags = allocation->creator ? CUINTERPOSER_CREATOR : 0;
     if (handles_count != 0)
       record->flags |= CUINTERPOSER_APPLICATION_HANDLE_LIVE;
+    if (needs_host_carrier(allocation))
+      record->flags |= CUINTERPOSER_HOST_CARRIER;
     memcpy(record->allocation_id, allocation->id, sizeof(record->allocation_id));
     record->allocation_size = allocation->size;
     record->allocation_type = allocation->properties.type;
@@ -543,6 +576,186 @@ driver_handle_used(const struct handle* except, CUmemGenericAllocationHandle dri
       return true;
   }
   return false;
+}
+
+static CUresult
+map_temporary(
+    const struct allocation* allocation, CUmemGenericAllocationHandle handle, CUdeviceptr* address,
+    const char** operation)
+{
+  address_reserve_fn reserve = (address_reserve_fn)cuinterposer_lookup_real_symbol("cuMemAddressReserve");
+  address_free_fn free_address = (address_free_fn)cuinterposer_lookup_real_symbol("cuMemAddressFree");
+  map_fn map = (map_fn)cuinterposer_lookup_real_symbol("cuMemMap");
+  unmap_fn unmap = (unmap_fn)cuinterposer_lookup_real_symbol("cuMemUnmap");
+  access_fn set_access = (access_fn)cuinterposer_lookup_real_symbol("cuMemSetAccess");
+  CUmemAccessDesc access;
+  CUresult result;
+
+  *address = 0;
+  if (reserve == NULL || free_address == NULL || map == NULL || unmap == NULL || set_access == NULL) {
+    *operation = "temporary mapping symbols are unavailable";
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  result = reserve(address, allocation->size, 0, 0, 0);
+  if (result != CUDA_SUCCESS) {
+    *operation = "cuMemAddressReserve";
+    return result;
+  }
+  result = map(*address, allocation->size, 0, handle, 0);
+  if (result != CUDA_SUCCESS) {
+    *operation = "cuMemMap";
+    (void)free_address(*address, allocation->size);
+    *address = 0;
+    return result;
+  }
+  memset(&access, 0, sizeof(access));
+  access.location = allocation->properties.location;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  result = set_access(*address, allocation->size, &access, 1);
+  if (result != CUDA_SUCCESS) {
+    *operation = "cuMemSetAccess";
+    (void)unmap(*address, allocation->size);
+    (void)free_address(*address, allocation->size);
+    *address = 0;
+  }
+  return result;
+}
+
+static int
+unmap_temporary(CUdeviceptr address, size_t size)
+{
+  unmap_fn unmap = (unmap_fn)cuinterposer_lookup_real_symbol("cuMemUnmap");
+  address_free_fn free_address = (address_free_fn)cuinterposer_lookup_real_symbol("cuMemAddressFree");
+
+  if (address == 0)
+    return 0;
+  if (unmap == NULL || free_address == NULL || unmap(address, size) != CUDA_SUCCESS ||
+      free_address(address, size) != CUDA_SUCCESS)
+    return -1;
+  return 0;
+}
+
+static void*
+create_host_carrier(size_t size)
+{
+  host_register_fn register_host = (host_register_fn)cuinterposer_lookup_real_symbol("cuMemHostRegister_v2");
+  void* carrier;
+
+  if (register_host == NULL)
+    return NULL;
+  carrier = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (carrier == MAP_FAILED)
+    return NULL;
+  if (register_host(carrier, size, 0) != CUDA_SUCCESS) {
+    (void)munmap(carrier, size);
+    return NULL;
+  }
+  return carrier;
+}
+
+static int
+destroy_host_carrier(void* carrier, size_t size)
+{
+  host_unregister_fn unregister_host = (host_unregister_fn)cuinterposer_lookup_real_symbol("cuMemHostUnregister");
+
+  if (carrier == NULL)
+    return 0;
+  if (unregister_host == NULL || unregister_host(carrier) != CUDA_SUCCESS)
+    return -1;
+  return munmap(carrier, size);
+}
+
+static int
+save_host_carrier(struct allocation* allocation)
+{
+  copy_dtoh_fn copy = (copy_dtoh_fn)cuinterposer_lookup_real_symbol("cuMemcpyDtoH_v2");
+  struct context_scope scope;
+  CUdeviceptr address = 0;
+  const char* operation = NULL;
+  void* carrier = NULL;
+  int result = -1;
+  bool entered = false;
+
+  if (current_phase != PHASE_MULTICAST_DETACHED || !needs_host_carrier(allocation) ||
+      allocation->carrier == 0 || allocation->host_carrier != NULL || allocation->host_checkpointed ||
+      copy == NULL)
+    return -1;
+  if (enter_context(allocation->context, &scope) != 0)
+    goto done;
+  entered = true;
+  if (map_temporary(allocation, allocation->carrier, &address, &operation) != CUDA_SUCCESS)
+    goto done;
+  carrier = create_host_carrier(allocation->size);
+  if (carrier == NULL)
+    goto done;
+  if (copy(carrier, address, allocation->size) != CUDA_SUCCESS)
+    goto done;
+  if (unmap_temporary(address, allocation->size) != 0)
+    goto done;
+  address = 0;
+  if (leave_context(&scope) != 0)
+    goto done;
+  entered = false;
+  allocation->host_carrier = carrier;
+  carrier = NULL;
+  allocation->host_checkpointed = true;
+  result = 0;
+done:
+  if (carrier != NULL)
+    (void)destroy_host_carrier(carrier, allocation->size);
+  if (address != 0)
+    (void)unmap_temporary(address, allocation->size);
+  if (entered)
+    (void)leave_context(&scope);
+  return result;
+}
+
+static int
+restore_host_carrier(struct allocation* allocation)
+{
+  create_fn create = (create_fn)cuinterposer_lookup_real_symbol("cuMemCreate");
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+  copy_htod_fn copy = (copy_htod_fn)cuinterposer_lookup_real_symbol("cuMemcpyHtoD_v2");
+  struct context_scope scope;
+  CUmemGenericAllocationHandle carrier = 0;
+  CUdeviceptr address = 0;
+  const char* operation = NULL;
+  int result = -1;
+  bool entered = false;
+
+  if (current_phase != PHASE_PREPARED || !needs_host_carrier(allocation) ||
+      !allocation->host_checkpointed || allocation->carrier != 0 || create == NULL || release == NULL ||
+      allocation->host_carrier == NULL || copy == NULL)
+    return -1;
+  if (enter_context(allocation->context, &scope) != 0)
+    goto done;
+  entered = true;
+  if (create(&carrier, allocation->size, &allocation->properties, 0) != CUDA_SUCCESS)
+    goto done;
+  if (map_temporary(allocation, carrier, &address, &operation) != CUDA_SUCCESS)
+    goto done;
+  if (copy(address, allocation->host_carrier, allocation->size) != CUDA_SUCCESS)
+    goto done;
+  if (unmap_temporary(address, allocation->size) != 0)
+    goto done;
+  address = 0;
+  if (destroy_host_carrier(allocation->host_carrier, allocation->size) != 0)
+    goto done;
+  allocation->host_carrier = NULL;
+  if (leave_context(&scope) != 0)
+    goto done;
+  entered = false;
+  allocation->carrier = carrier;
+  allocation->host_checkpointed = false;
+  result = 0;
+done:
+  if (address != 0)
+    (void)unmap_temporary(address, allocation->size);
+  if (carrier != 0 && result != 0)
+    (void)release(carrier);
+  if (entered)
+    (void)leave_context(&scope);
+  return result;
 }
 
 static int
@@ -595,7 +808,8 @@ prepare_topology(void)
     return -1;
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
     if (allocation->shared && allocation->creator &&
-        (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL) && allocation->carrier == 0)
+        (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL) &&
+        (allocation->carrier == 0 || (needs_host_carrier(allocation) && !allocation->host_checkpointed)))
       goto failed;
   }
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
@@ -620,6 +834,14 @@ prepare_topology(void)
       if (!handle->live || handle->allocation != allocation)
         continue;
       old = handle->driver;
+      if (allocation->creator && allocation->host_checkpointed) {
+        if (old != allocation->carrier && !driver_handle_used(handle, old) && release(old) != CUDA_SUCCESS) {
+          (void)leave_context(&scope);
+          goto failed;
+        }
+        handle->driver = 0;
+        continue;
+      }
       if (allocation->creator && old == allocation->carrier) {
         handle->driver = allocation->carrier;
         continue;
@@ -629,6 +851,13 @@ prepare_topology(void)
         goto failed;
       }
       handle->driver = allocation->creator ? allocation->carrier : 0;
+    }
+    if (allocation->creator && allocation->host_checkpointed) {
+      if (release(allocation->carrier) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        goto failed;
+      }
+      allocation->carrier = 0;
     }
     if (leave_context(&scope) != 0)
       goto failed;
@@ -840,10 +1069,13 @@ serve(int client)
   response.version = CUINTERPOSER_VERSION;
   response.operation = request.operation;
   snprintf(response.participant_id, sizeof(response.participant_id), "%s", participant_id);
-  /* Reject ancillary FDs and requests that are not a well-formed control header for this process. */
-  if (passed_fd >= 0 || !header_strings_terminated(&request) || request.magic != CUINTERPOSER_MAGIC ||
+  /* Carrier commands identify one allocation by ID and size; no carrier bytes cross the socket. */
+  bool carrier_request =
+      request.operation == CUINTERPOSER_SAVE_HOST_CARRIER ||
+      request.operation == CUINTERPOSER_RESTORE_HOST_CARRIER;
+  if (passed_fd >= 0 || (carrier_request ? request.payload_size == 0 : request.payload_size != 0) ||
+      !header_strings_terminated(&request) || request.magic != CUINTERPOSER_MAGIC ||
       request.version != CUINTERPOSER_VERSION || request.status != 0 || request.count != 0 ||
-      request.payload_size != 0 ||
       !((request.operation == CUINTERPOSER_IDENTIFY && request.participant_id[0] == '\0') ||
         strcmp(request.participant_id, participant_id) == 0)) {
     header_error(&response, "invalid cuinterposer control request");
@@ -857,6 +1089,28 @@ serve(int client)
         header_error(&response, failure);
       (void)send_header(client, &response, -1);
       break;
+    case CUINTERPOSER_SAVE_HOST_CARRIER:
+    case CUINTERPOSER_RESTORE_HOST_CARRIER: {
+      struct allocation* allocation = find_allocation(request.allocation_id);
+      int transfer_result;
+
+      if (allocation == NULL || request.payload_size != allocation->size) {
+        header_error(&response, "host carrier allocation is unavailable");
+      } else {
+        transfer_result = request.operation == CUINTERPOSER_SAVE_HOST_CARRIER
+            ? save_host_carrier(allocation)
+            : restore_host_carrier(allocation);
+        if (transfer_result != 0) {
+          set_failure(
+              request.operation == CUINTERPOSER_SAVE_HOST_CARRIER
+                  ? "cannot save host-backed cuinterposer carrier"
+                  : "cannot restore host-backed cuinterposer carrier");
+          header_error(&response, failure);
+        }
+      }
+      (void)send_header(client, &response, -1);
+      break;
+    }
     case CUINTERPOSER_INSPECT:
       if (current_phase != PHASE_ACTIVE) {
         header_error(&response, "cuinterposer topology is not active");

--- a/agent/cmd/cuinterpose/protocol.h
+++ b/agent/cmd/cuinterpose/protocol.h
@@ -31,6 +31,8 @@ enum cuinterposer_operation {
   CUINTERPOSER_RESTORE_MULTICAST_IMPORTERS = 9,
   CUINTERPOSER_RESTORE_MULTICAST_DEVICES = 10,
   CUINTERPOSER_RESTORE_MULTICAST = 11,
+  CUINTERPOSER_SAVE_HOST_CARRIER = 12,
+  CUINTERPOSER_RESTORE_HOST_CARRIER = 13,
 };
 
 enum cuinterposer_record_kind {
@@ -45,6 +47,7 @@ enum cuinterposer_record_kind {
 enum cuinterposer_record_flags {
   CUINTERPOSER_CREATOR = 1U << 0,
   CUINTERPOSER_APPLICATION_HANDLE_LIVE = 1U << 1,
+  CUINTERPOSER_HOST_CARRIER = 1U << 2,
 };
 
 enum cuinterposer_resource_kind {

--- a/agent/cmd/cuinterpose/tests/test_cucheckpoint.py
+++ b/agent/cmd/cuinterpose/tests/test_cucheckpoint.py
@@ -452,6 +452,7 @@ def _build_native_tools(tmp_path: Path) -> tuple[Path, Path]:
             "-C",
             str(interposer_dir),
             f"BUILD_DIR={build_dir}",
+            "HOST_CARRIER_THRESHOLD=1",
         ],
         check=False,
         capture_output=True,
@@ -821,6 +822,11 @@ def _run_cucheckpoint_test(tmp_path: Path, multicast: bool) -> None:
         state = checkpoint_dir / "cuinterposer.state"
         if not state.is_file() or state.stat().st_size == 0:
             raise AssertionError("coordinator did not write nonempty cuinterposer.state")
+        carriers = list(checkpoint_dir.glob("cuinterposer-host-*.bin"))
+        if carriers:
+            raise AssertionError(
+                f"host carriers must remain process memory, found files: {carriers}"
+            )
 
         _native_checkpoint_with_timeout(child_pids)
         _run_coordinator(


### PR DESCRIPTION
## Summary

- preserve large shared POSIX-exportable device allocations in anonymous pinned host memory owned by the workload process before CUDA checkpoint
- release the original exportable device backing before native CUDA checkpoint
- let CRIU capture the pinned host carrier as ordinary process memory; no carrier sidecar files are created
- after restore, create fresh exportable device backing, restore bytes with H2D, then unregister and unmap the host carrier
- transfer creator ranks in parallel and use bounded control timeouts
- force the path in `test_cucheckpoint.py` without changing the production threshold, and assert that no carrier files appear

This is a transparent r615 workaround for large shared allocations whose bytes restore but whose original post-restore POSIX export state is stale. It does not change the driver, disable FLA/FABRIC, require GMS, or retain a second device allocation. Small, non-shared, non-POSIX-exportable, and non-device allocations remain on the native CUDA checkpoint path.

## Validation

- exact 578 MiB two-GPU symmetric-memory A/B:
  - PR #133 without this workaround fails during coordinator restore when creator re-export returns `CUDA_ERROR_INVALID_VALUE`
  - this patch restores successfully and verifies CUDA-graph output and allocation bytes
- native CUDA checkpoint test builds the shim with `HOST_CARRIER_THRESHOLD=1`, exercises the carrier path, and rejects any `cuinterposer-host-*.bin` artifact
- GLM 5.2 / DeepSeek-V4-Flash-NVFP4 SGLang TP8/EP8 on eight B200 GPUs, context length 32768, with warm compile/JIT/FlashInfer caches:
  - source startup: 87.02 s
  - checkpoint: 290.891 s total; CRIU dump 262.580 s; CUDA checkpoint 27.632 s
  - active restore: 37.410 s total; CRIU 12.914 s; CUDA 24.291 s
  - standby restore: 40.165 s total; CRIU 12.921 s; CUDA 27.033 s
  - aggregate CRIU process artifact: about 100 GiB; no separate carrier artifact
  - coherent post-restore and post-promotion inference both returned `17 * 23 = 391`
- clean CUDA-image build with `-Wall -Wextra -Werror`
- `git diff --check`
- `python3 -m py_compile agent/cmd/cuinterpose/tests/test_cucheckpoint.py`
