### PR TITLE
fix(agent): collapse duplicate CUDA handle references

### DIFF
--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -1523,7 +1523,9 @@ CUresult CUDAAPI
 cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
 {
   retain_fn function = (retain_fn)cuinterposer_lookup_real_symbol("cuMemRetainAllocationHandle");
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
   struct mapping* mapping;
+  struct handle* existing;
   CUmemGenericAllocationHandle driver = 0;
   CUmemGenericAllocationHandle logical;
   CUresult result;
@@ -1548,13 +1550,18 @@ cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
   mapping = find_mapping_at((CUdeviceptr)(uintptr_t)address);
   if (mapping == NULL) {
     result = transfer_passthrough_handle(result, driver, output);
-  } else if (add_managed_handle(mapping->allocation, driver, &logical) != 0) {
-    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
-    if (release != NULL)
-      (void)release(driver);
-    result = CUDA_ERROR_OUT_OF_MEMORY;
   } else {
-    *output = logical;
+    existing = first_live_handle(mapping->allocation);
+    if (existing != NULL && (release == NULL || release(driver) != CUDA_SUCCESS)) {
+      result = CUDA_ERROR_UNKNOWN;
+    } else if (add_managed_handle(
+                   mapping->allocation, existing != NULL ? existing->driver : driver, &logical) != 0) {
+      if (existing == NULL && release != NULL)
+        (void)release(driver);
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    } else {
+      *output = logical;
+    }
   }
   pthread_mutex_unlock(&state_lock);
   return result;
@@ -1797,8 +1804,10 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
 {
   import_fn function = (import_fn)cuinterposer_lookup_real_symbol("cuMemImportFromShareableHandle");
   properties_fn get_properties;
+  release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
   struct cuinterposer_posix_ticket ticket;
   struct allocation* allocation;
+  struct handle* existing;
   CUmemGenericAllocationHandle logical;
   CUmemGenericAllocationHandle imported = 0;
   int raw_fd = -1;
@@ -1841,7 +1850,6 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
     return CUDA_ERROR_INVALID_HANDLE;
   result = function(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
   if (close(raw_fd) != 0 && result == CUDA_SUCCESS) {
-    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
     if (release != NULL)
       (void)release(imported);
     return CUDA_ERROR_UNKNOWN;
@@ -1850,7 +1858,6 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
     return result;
   pthread_mutex_lock(&state_lock);
   if (current_phase != PHASE_ACTIVE) {
-    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
     if (release != NULL)
       (void)release(imported);
     pthread_mutex_unlock(&state_lock);
@@ -1873,11 +1880,20 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
   }
   if (allocation != NULL)
     allocation->shared = true;
+  existing = allocation != NULL ? first_live_handle(allocation) : NULL;
   if (allocation == NULL || current_context(&allocation->context) != 0 ||
-      get_properties(&allocation->properties, imported) != CUDA_SUCCESS ||
-      add_managed_handle(allocation, imported, &logical) != 0) {
-    release_fn release = (release_fn)cuinterposer_lookup_real_symbol("cuMemRelease");
+      get_properties(&allocation->properties, imported) != CUDA_SUCCESS) {
     if (release != NULL)
+      (void)release(imported);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  if (existing != NULL && (release == NULL || release(imported) != CUDA_SUCCESS)) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_UNKNOWN;
+  }
+  if (add_managed_handle(allocation, existing != NULL ? existing->driver : imported, &logical) != 0) {
+    if (existing == NULL && release != NULL)
       (void)release(imported);
     pthread_mutex_unlock(&state_lock);
     return CUDA_ERROR_OUT_OF_MEMORY;

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -38,6 +38,8 @@ static pthread_mutex_t multicast_map_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t multicast_map_condition = PTHREAD_COND_INITIALIZER;
 static int block_multicast_map;
 static int multicast_map_entered;
+static int tracked_behavior;
+static int release_count;
 
 void
 fakeEnableBlockingMulticastMap(void)
@@ -68,6 +70,19 @@ fakeReleaseMulticastMap(void)
   pthread_mutex_unlock(&multicast_map_lock);
 }
 
+void
+fakeEnableTrackedBehavior(void)
+{
+  tracked_behavior = 1;
+  release_count = 0;
+}
+
+int
+fakeReleaseCount(void)
+{
+  return release_count;
+}
+
 CUresult CUDAAPI
 fakeCuMemCreateOriginal(
     CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties,
@@ -75,8 +90,10 @@ fakeCuMemCreateOriginal(
 {
   (void)size;
   (void)flags;
-  (void)properties;
   *output = 0xabc;
+  if (tracked_behavior && properties != NULL &&
+      properties->requestedHandleTypes == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_SUCCESS;
   return (CUresult)result_create;
 }
 
@@ -92,14 +109,19 @@ CUresult CUDAAPI
 cuMemRelease(CUmemGenericAllocationHandle handle)
 {
   (void)handle;
+  if (tracked_behavior) {
+    release_count++;
+    return CUDA_SUCCESS;
+  }
   return (CUresult)result_release;
 }
 
 CUresult CUDAAPI
 cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
 {
-  (void)address;
   *output = 0xdef;
+  if (tracked_behavior && address == (void*)(uintptr_t)0x1000)
+    return CUDA_SUCCESS;
   return (CUresult)result_retain;
 }
 
@@ -108,7 +130,6 @@ cuMemMap(
     CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle,
     unsigned long long flags)
 {
-  (void)address;
   (void)size;
   (void)offset;
   (void)flags;
@@ -121,6 +142,8 @@ cuMemMap(
     pthread_mutex_unlock(&multicast_map_lock);
     return CUDA_SUCCESS;
   }
+  if (tracked_behavior && address == 0x1000 && handle == 0xabc)
+    return CUDA_SUCCESS;
   return (CUresult)result_map;
 }
 
@@ -129,6 +152,8 @@ cuMemUnmap(CUdeviceptr address, size_t size)
 {
   (void)address;
   (void)size;
+  if (tracked_behavior)
+    return CUDA_SUCCESS;
   return (CUresult)result_unmap;
 }
 
@@ -139,6 +164,8 @@ cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descript
   (void)size;
   (void)descriptors;
   (void)count;
+  if (tracked_behavior)
+    return CUDA_SUCCESS;
   return (CUresult)result_access;
 }
 

--- a/agent/cmd/cuinterpose/tests/multicast_forward_test.c
+++ b/agent/cmd/cuinterpose/tests/multicast_forward_test.c
@@ -28,6 +28,8 @@ extern CUresult CUDAAPI fakeCuMulticastCreateOriginal(
 extern void fakeEnableBlockingMulticastMap(void);
 extern int fakeMulticastMapEntered(void);
 extern void fakeReleaseMulticastMap(void);
+extern void fakeEnableTrackedBehavior(void);
+extern int fakeReleaseCount(void);
 
 struct map_call {
   CUmemGenericAllocationHandle handle;
@@ -154,6 +156,32 @@ test_multicast_map_releases_state_lock(void)
 }
 
 static void
+test_tracked_unicast_aliases(void)
+{
+  CUmemAllocationProp props = {0};
+  CUmemGenericAllocationHandle created = 0;
+  CUmemGenericAllocationHandle retained = 0;
+
+  props.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  props.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  fakeEnableTrackedBehavior();
+  require(cuMemCreate(&created, 4096, &props, 0) == CUDA_SUCCESS, "tracked cuMemCreate");
+  require_logical_handle(created, "tracked cuMemCreate logical handle");
+  require(cuMemMap(0x1000, 4096, 0, created, 0) == CUDA_SUCCESS, "tracked cuMemMap");
+  require(
+      cuMemRetainAllocationHandle(&retained, (void*)(uintptr_t)0x1000) == CUDA_SUCCESS,
+      "tracked cuMemRetainAllocationHandle");
+  require_logical_handle(retained, "tracked retained logical handle");
+  require(fakeReleaseCount() == 1, "retained driver reference collapsed");
+  require(cuMemRelease(retained) == CUDA_SUCCESS, "tracked retained logical release");
+  require(fakeReleaseCount() == 1, "alias release preserves shared backing reference");
+  require(cuMemRelease(created) == CUDA_SUCCESS, "tracked created logical release");
+  require(fakeReleaseCount() == 2, "last logical release drops backing reference");
+  require(cuMemUnmap(0x1000, 4096) == CUDA_SUCCESS, "tracked cuMemUnmap");
+}
+
+static void
 test_tracked_behavior(void)
 {
   CUmemGenericAllocationHandle handle = 0;
@@ -223,6 +251,7 @@ test_resolvers(void)
 int
 main(void)
 {
+  test_tracked_unicast_aliases();
   test_tracked_behavior();
   test_multicast_map_releases_state_lock();
   test_resolvers();


### PR DESCRIPTION
## Summary

- collapse redundant driver references acquired by `cuMemRetainAllocationHandle` when a tracked allocation already has a live backing handle
- apply the same one-backing-reference invariant to repeated tracked POSIX imports
- preserve distinct logical handles while releasing the redundant physical driver reference immediately
- add a fake-CUDA regression that verifies alias release keeps the backing alive and final release drops it exactly once

## Validation

- `make -C agent/cmd/cuinterpose clean test` in the CUDA test image
- `go test ./agent/internal/criu ./agent/internal/cuda -count=1`
- live 1 GiB A/B allocation test:
  - before: 1 GiB remained after releasing all three logical aliases
  - after: residual allocation was 0 bytes
- GLM-5.2-NVFP4 SGLang TP8/EP8, context length 32768, checkpoint captured successfully with all eight GMS devices saving 60,129,542,144 bytes
- two restored engines completed CUDA restore; active inference returned `42`
- after active-engine failure, the shadow acquired the lock in 135 ms, registered in 4.70 s, and post-failover inference returned `42`
- after active teardown, GPU memory returned exactly to the single-engine baseline
