### PR TITLE
fix(agent): rewrite bound abstract UNIX sockets on clone restore

### DIFF
--- a/agent/internal/criu/restore_images.go
+++ b/agent/internal/criu/restore_images.go
@@ -4,7 +4,6 @@
 package criu
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -24,8 +23,8 @@ import (
 const (
 	filesImageFilename            = "files.img"
 	placeholderMountNamespacePath = "/proc/self/ns/mnt"
-	cudaUVMFDSocketNamePrefix     = "\x00cuda-uvmfd-"
 	linuxUnixSocketStateListen    = 10
+	linuxUnixSocketStateClose     = 7
 	linuxTCPStateEstablished      = 1
 	linuxTCPStateClose            = 7
 	linuxTCPStateListen           = 10
@@ -137,15 +136,38 @@ func rewriteSocketMetadata(image *crit.CriuImage, restoreID uint64) ([]int, bool
 		forbiddenPorts[port] = struct{}{}
 	}
 
-	rewritten := false
+	unixSockets := make(map[uint32]*sk_unix.UnixSkEntry)
 	for i, entry := range image.Entries {
 		fileEntry, ok := entry.Message.(*fdinfo.FileEntry)
 		if !ok {
 			closeFDs(reservationFDs)
 			return nil, false, fmt.Errorf("unexpected %s entry %d type %T", filesImageFilename, i, entry.Message)
 		}
-		if fileEntry.GetType() == fdinfo.FdTypes_UNIXSK && fileEntry.Usk != nil &&
-			rewriteCloneConflictingUnixSocketAddress(fileEntry.Usk, restoreID) {
+		if fileEntry.GetType() == fdinfo.FdTypes_UNIXSK && fileEntry.Usk != nil {
+			unixSockets[fileEntry.Usk.GetIno()] = fileEntry.Usk
+		}
+	}
+
+	rewritten := false
+	for _, socket := range unixSockets {
+		if !isBoundAbstractUnixSocket(socket) {
+			continue
+		}
+		if socket.Ino == nil || socket.Peer == nil {
+			closeFDs(reservationFDs)
+			return nil, false, fmt.Errorf("bound abstract UNIX socket is missing inode or peer metadata")
+		}
+		if peer := socket.GetPeer(); peer != 0 {
+			if _, ok := unixSockets[peer]; !ok {
+				closeFDs(reservationFDs)
+				return nil, false, fmt.Errorf(
+					"bound abstract UNIX socket inode %d has unresolved peer inode %d",
+					socket.GetIno(),
+					peer,
+				)
+			}
+		}
+		if rewriteCloneConflictingUnixSocketAddress(socket, restoreID) {
 			rewritten = true
 		}
 	}
@@ -403,11 +425,10 @@ func closeFDs(fds []int) {
 }
 
 func rewriteCloneConflictingUnixSocketAddress(entry *sk_unix.UnixSkEntry, restoreID uint64) bool {
-	if !isCUDAUVMFDListener(entry) {
+	if !isBoundAbstractUnixSocket(entry) {
 		return false
 	}
 
-	// CUDA retains this listener's FD, so only its clone-private address changes.
 	input := make([]byte, 8+len(entry.Name))
 	binary.BigEndian.PutUint64(input, restoreID)
 	copy(input[8:], entry.Name)
@@ -416,13 +437,7 @@ func rewriteCloneConflictingUnixSocketAddress(entry *sk_unix.UnixSkEntry, restor
 	return true
 }
 
-func isCUDAUVMFDListener(entry *sk_unix.UnixSkEntry) bool {
-	return entry != nil &&
-		entry.Type != nil &&
-		entry.State != nil &&
-		entry.Peer != nil &&
-		*entry.Type == uint32(unix.SOCK_SEQPACKET) &&
-		*entry.State == linuxUnixSocketStateListen &&
-		*entry.Peer == 0 &&
-		bytes.HasPrefix(entry.Name, []byte(cudaUVMFDSocketNamePrefix))
+func isBoundAbstractUnixSocket(entry *sk_unix.UnixSkEntry) bool {
+	// The leading NUL is the abstract-namespace marker; a bare NUL is unbound.
+	return entry != nil && len(entry.Name) > 1 && entry.Name[0] == 0
 }

--- a/agent/internal/criu/restore_images.go
+++ b/agent/internal/criu/restore_images.go
@@ -23,6 +23,7 @@ import (
 const (
 	filesImageFilename            = "files.img"
 	placeholderMountNamespacePath = "/proc/self/ns/mnt"
+	criuUnixSocketUflagExternal   = 1 << 0
 	linuxUnixSocketStateListen    = 10
 	linuxUnixSocketStateClose     = 7
 	linuxTCPStateEstablished      = 1
@@ -144,18 +145,28 @@ func rewriteSocketMetadata(image *crit.CriuImage, restoreID uint64) ([]int, bool
 			return nil, false, fmt.Errorf("unexpected %s entry %d type %T", filesImageFilename, i, entry.Message)
 		}
 		if fileEntry.GetType() == fdinfo.FdTypes_UNIXSK && fileEntry.Usk != nil {
-			unixSockets[fileEntry.Usk.GetIno()] = fileEntry.Usk
+			socket := fileEntry.Usk
+			if socket.Ino == nil {
+				closeFDs(reservationFDs)
+				return nil, false, fmt.Errorf("UNIX socket entry %d is missing inode metadata", i)
+			}
+			if _, ok := unixSockets[socket.GetIno()]; ok {
+				closeFDs(reservationFDs)
+				return nil, false, fmt.Errorf("duplicate UNIX socket inode %d", socket.GetIno())
+			}
+			unixSockets[socket.GetIno()] = socket
 		}
 	}
 
 	rewritten := false
 	for _, socket := range unixSockets {
-		if !isBoundAbstractUnixSocket(socket) {
+		// CRIU uses external entries as connection targets; it does not bind them.
+		if !isBoundAbstractUnixSocket(socket) || isExternalUnixSocket(socket) {
 			continue
 		}
-		if socket.Ino == nil || socket.Peer == nil {
+		if socket.Peer == nil {
 			closeFDs(reservationFDs)
-			return nil, false, fmt.Errorf("bound abstract UNIX socket is missing inode or peer metadata")
+			return nil, false, fmt.Errorf("bound abstract UNIX socket is missing peer metadata")
 		}
 		if peer := socket.GetPeer(); peer != 0 {
 			if _, ok := unixSockets[peer]; !ok {
@@ -425,7 +436,7 @@ func closeFDs(fds []int) {
 }
 
 func rewriteCloneConflictingUnixSocketAddress(entry *sk_unix.UnixSkEntry, restoreID uint64) bool {
-	if !isBoundAbstractUnixSocket(entry) {
+	if !isBoundAbstractUnixSocket(entry) || isExternalUnixSocket(entry) {
 		return false
 	}
 
@@ -438,6 +449,9 @@ func rewriteCloneConflictingUnixSocketAddress(entry *sk_unix.UnixSkEntry, restor
 }
 
 func isBoundAbstractUnixSocket(entry *sk_unix.UnixSkEntry) bool {
-	// The leading NUL is the abstract-namespace marker; a bare NUL is unbound.
-	return entry != nil && len(entry.Name) > 1 && entry.Name[0] == 0
+	return entry != nil && len(entry.Name) > 0 && entry.Name[0] == 0
+}
+
+func isExternalUnixSocket(entry *sk_unix.UnixSkEntry) bool {
+	return entry != nil && entry.GetUflags()&criuUnixSocketUflagExternal != 0
 }

--- a/agent/internal/criu/restore_images_test.go
+++ b/agent/internal/criu/restore_images_test.go
@@ -21,6 +21,70 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func TestRewriteSocketMetadataRewritesInternalUnixSocketPair(t *testing.T) {
+	first := newUnixSocketEntry(1, []byte("\x00first"), 101, unix.SOCK_DGRAM, linuxTCPStateEstablished)
+	second := newUnixSocketEntry(2, []byte("\x00second"), 102, unix.SOCK_DGRAM, linuxTCPStateEstablished)
+	first.Usk.Peer = proto.Uint32(second.Usk.GetIno())
+	second.Usk.Peer = proto.Uint32(first.Usk.GetIno())
+	image := &crit.CriuImage{
+		Entries: []*crit.CriuEntry{
+			{Message: first},
+			{Message: second},
+		},
+	}
+
+	reservationFDs, rewritten, err := rewriteSocketMetadata(image, 987654321)
+	if err != nil {
+		t.Fatalf("rewrite socket metadata: %v", err)
+	}
+	closeFDs(reservationFDs)
+	if !rewritten {
+		t.Fatal("connected abstract UNIX socket pair was not rewritten")
+	}
+	for i, entry := range []*fdinfo.FileEntry{first, second} {
+		if !bytes.HasPrefix(entry.Usk.Name, []byte("\x00dynamo-")) {
+			t.Fatalf("endpoint %d address = %q, want Dynamo abstract address", i, entry.Usk.Name)
+		}
+	}
+	if bytes.Equal(first.Usk.Name, second.Usk.Name) {
+		t.Fatal("distinct connected UNIX socket addresses were rewritten to the same address")
+	}
+	if got := first.Usk.GetPeer(); got != second.Usk.GetIno() {
+		t.Fatalf("first peer inode = %d, want %d", got, second.Usk.GetIno())
+	}
+	if got := second.Usk.GetPeer(); got != first.Usk.GetIno() {
+		t.Fatalf("second peer inode = %d, want %d", got, first.Usk.GetIno())
+	}
+}
+
+func TestRewriteSocketMetadataRejectsExternalUnixSocketPeer(t *testing.T) {
+	entry := newUnixSocketEntry(1, []byte("\x00external"), 101, unix.SOCK_DGRAM, linuxTCPStateEstablished)
+	entry.Usk.Peer = proto.Uint32(4242)
+	image := &crit.CriuImage{
+		Entries: []*crit.CriuEntry{{Message: entry}},
+	}
+
+	reservationFDs, rewritten, err := rewriteSocketMetadata(image, 987654321)
+	if err == nil || !strings.Contains(err.Error(), "unresolved peer inode 4242") {
+		t.Fatalf("rewrite socket metadata error = %v", err)
+	}
+	if rewritten || reservationFDs != nil {
+		t.Fatalf("rewrite result = (%v, %v), want no reservations or rewrite", reservationFDs, rewritten)
+	}
+}
+
+func TestRewriteCloneConflictingUnixSocketAddressSkipsUnbound(t *testing.T) {
+	for name, raw := range map[string][]byte{
+		"empty":    {},
+		"bare NUL": {0},
+	} {
+		entry := newUnixSocketEntry(1, raw, 101, unix.SOCK_DGRAM, linuxUnixSocketStateClose)
+		if rewriteCloneConflictingUnixSocketAddress(entry.Usk, 987654321) {
+			t.Fatalf("%s address must not be rewritten", name)
+		}
+	}
+}
+
 func TestPrepareRestoreImageDirRewritesObservedSocketTopology(t *testing.T) {
 	checkpointPath := t.TempDir()
 	entries := observedSocketTopology()
@@ -48,6 +112,14 @@ func TestPrepareRestoreImageDirRewritesObservedSocketTopology(t *testing.T) {
 	if got := restored[0].Usk.Name; !bytes.HasPrefix(got, []byte("\x00dynamo-")) {
 		t.Fatalf("CUDA listener address = %q, want Dynamo abstract address", got)
 	}
+	for _, index := range []int{2, 3} {
+		if got := restored[index].Usk.Name; !bytes.HasPrefix(got, []byte("\x00dynamo-")) {
+			t.Fatalf("abstract datagram address %d = %q, want Dynamo abstract address", index, got)
+		}
+	}
+	if bytes.Equal(restored[2].Usk.Name, restored[3].Usk.Name) {
+		t.Fatal("distinct NCCL datagram addresses were rewritten to the same address")
+	}
 	clientPort := restored[5].Isk.GetSrcPort()
 	if clientPort == entries[5].Isk.GetSrcPort() {
 		t.Fatalf("TCP client port was not rewritten")
@@ -71,6 +143,8 @@ func TestPrepareRestoreImageDirRewritesObservedSocketTopology(t *testing.T) {
 		want := proto.Clone(original).(*fdinfo.FileEntry)
 		switch i {
 		case 0:
+			want.Usk.Name = restored[i].Usk.Name
+		case 2, 3:
 			want.Usk.Name = restored[i].Usk.Name
 		case 5:
 			want.Isk.SrcPort = proto.Uint32(clientPort)
@@ -277,8 +351,8 @@ func observedSocketTopology() []*fdinfo.FileEntry {
 	return []*fdinfo.FileEntry{
 		newUnixSocketEntry(1, []byte("\x00cuda-uvmfd-4026554902-1195\x00"), 101, unix.SOCK_SEQPACKET, linuxUnixSocketStateListen),
 		newUnixSocketEntry(2, []byte("/tmp/4c85f2c6-ea0e-45cb-b7ee-fd519aba82d0\x00"), 102, unix.SOCK_STREAM, linuxUnixSocketStateListen),
-		newUnixSocketEntry(3, []byte("\x00047f9"), 103, unix.SOCK_DGRAM, 7),
-		newUnixSocketEntry(4, []byte("\x00047ff"), 104, unix.SOCK_DGRAM, 7),
+		newUnixSocketEntry(3, paddedUnixSocketName("\x00tmp/nccl-socket-2-fe65a3cdb8ee726d"), 103, unix.SOCK_DGRAM, linuxUnixSocketStateClose),
+		newUnixSocketEntry(4, []byte("\x00e587b"), 104, unix.SOCK_DGRAM, linuxUnixSocketStateClose),
 		listener,
 		client,
 		server,
@@ -287,6 +361,12 @@ func observedSocketTopology() []*fdinfo.FileEntry {
 		dualStackClient,
 		dualStackServer,
 	}
+}
+
+func paddedUnixSocketName(name string) []byte {
+	result := make([]byte, 108)
+	copy(result, name)
+	return result
 }
 
 func newUnixSocketEntry(id uint32, name []byte, inode uint32, socketType int, state uint32) *fdinfo.FileEntry {

--- a/agent/internal/criu/restore_images_test.go
+++ b/agent/internal/criu/restore_images_test.go
@@ -57,12 +57,35 @@ func TestRewriteSocketMetadataRewritesInternalUnixSocketPair(t *testing.T) {
 	}
 }
 
-func TestRewriteSocketMetadataRejectsExternalUnixSocketPeer(t *testing.T) {
-	entry := newUnixSocketEntry(1, []byte("\x00external"), 101, unix.SOCK_DGRAM, linuxTCPStateEstablished)
-	entry.Usk.Peer = proto.Uint32(4242)
+func TestRewriteSocketMetadataPreservesExternalUnixSocketPeer(t *testing.T) {
+	client := newUnixSocketEntry(1, []byte("\x00client"), 101, unix.SOCK_DGRAM, linuxTCPStateEstablished)
+	external := newUnixSocketEntry(2, []byte("\x00external"), 4242, unix.SOCK_DGRAM, linuxUnixSocketStateListen)
+	client.Usk.Peer = proto.Uint32(external.Usk.GetIno())
+	external.Usk.Uflags = proto.Uint32(criuUnixSocketUflagExternal)
 	image := &crit.CriuImage{
-		Entries: []*crit.CriuEntry{{Message: entry}},
+		Entries: []*crit.CriuEntry{{Message: client}, {Message: external}},
 	}
+
+	reservationFDs, rewritten, err := rewriteSocketMetadata(image, 987654321)
+	if err != nil {
+		t.Fatalf("rewrite socket metadata: %v", err)
+	}
+	closeFDs(reservationFDs)
+	if !rewritten {
+		t.Fatal("client address was not rewritten")
+	}
+	if !bytes.HasPrefix(client.Usk.Name, []byte("\x00dynamo-")) {
+		t.Fatalf("client address = %q, want Dynamo abstract address", client.Usk.Name)
+	}
+	if got, want := external.Usk.Name, []byte("\x00external"); !bytes.Equal(got, want) {
+		t.Fatalf("external address = %q, want %q", got, want)
+	}
+}
+
+func TestRewriteSocketMetadataRejectsMissingUnixSocketPeer(t *testing.T) {
+	entry := newUnixSocketEntry(1, []byte("\x00client"), 101, unix.SOCK_DGRAM, linuxTCPStateEstablished)
+	entry.Usk.Peer = proto.Uint32(4242)
+	image := &crit.CriuImage{Entries: []*crit.CriuEntry{{Message: entry}}}
 
 	reservationFDs, rewritten, err := rewriteSocketMetadata(image, 987654321)
 	if err == nil || !strings.Contains(err.Error(), "unresolved peer inode 4242") {
@@ -73,15 +96,27 @@ func TestRewriteSocketMetadataRejectsExternalUnixSocketPeer(t *testing.T) {
 	}
 }
 
+func TestRewriteSocketMetadataRejectsMissingUnixSocketInode(t *testing.T) {
+	entry := newUnixSocketEntry(1, []byte("\x00client"), 101, unix.SOCK_DGRAM, linuxTCPStateEstablished)
+	entry.Usk.Ino = nil
+
+	_, _, err := rewriteSocketMetadata(&crit.CriuImage{
+		Entries: []*crit.CriuEntry{{Message: entry}},
+	}, 987654321)
+	if err == nil || !strings.Contains(err.Error(), "missing inode metadata") {
+		t.Fatalf("rewrite socket metadata error = %v", err)
+	}
+}
+
 func TestRewriteCloneConflictingUnixSocketAddressSkipsUnbound(t *testing.T) {
-	for name, raw := range map[string][]byte{
-		"empty":    {},
-		"bare NUL": {0},
-	} {
-		entry := newUnixSocketEntry(1, raw, 101, unix.SOCK_DGRAM, linuxUnixSocketStateClose)
-		if rewriteCloneConflictingUnixSocketAddress(entry.Usk, 987654321) {
-			t.Fatalf("%s address must not be rewritten", name)
-		}
+	entry := newUnixSocketEntry(1, nil, 101, unix.SOCK_DGRAM, linuxUnixSocketStateClose)
+	if rewriteCloneConflictingUnixSocketAddress(entry.Usk, 987654321) {
+		t.Fatal("empty address must not be rewritten")
+	}
+
+	entry.Usk.Name = []byte{0}
+	if !rewriteCloneConflictingUnixSocketAddress(entry.Usk, 987654321) {
+		t.Fatal("bound bare-NUL abstract address was not rewritten")
 	}
 }
 


### PR DESCRIPTION
## Summary

- broaden clone-restore socket rewriting from the CUDA UVM FD listener only to every retained bound abstract UNIX socket
- detect bound abstract sockets by the leading NUL namespace marker (`len(name) > 1 && name[0] == 0`); skip unbound sockets (empty name or bare `\0`)
- index UNIX sockets by inode before rewriting so connected pairs keep peer links and receive distinct clone-private `dynamo-` addresses derived from the restore ID and original name
- fail restore preparation when a bound abstract socket references a peer inode missing from the checkpoint image
- leave filesystem-path UNIX sockets and TCP port rewriting unchanged

The previous rewrite matched only `SOCK_SEQPACKET` CUDA UVM FD listeners with no peer. Retained NCCL datagram sockets (for example `\0tmp/nccl-socket-…`) and other bound abstract endpoints otherwise restore with their original addresses and collide with `EADDRINUSE` when a second clone lands on the same node.

## Validation

- `go test ./agent/internal/criu ./agent/internal/cuda -count=1`
- A/B restore on the same checkpoint and node:
  - without rewriting retained NCCL datagram addresses, the second clone failed with `Address already in use`
  - with the rewrite, both GLM-5.2-NVFP4 SGLang TP8/EP8 engines restored successfully
- active inference returned `42`; after killing the active restored engine, the shadow registered in 4.70 s and returned `42`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of abstract UNIX sockets by correctly rewriting addresses for connected internal socket pairs.
  - Preserved connections to externally managed sockets.
  - Skipped unbound sockets and rejected incomplete socket metadata to prevent invalid restorations.
  - Improved handling of distinct datagram socket addresses during restoration.

- **Tests**
  - Added coverage for UNIX socket rewriting, external peers, missing metadata, unbound sockets, and long socket names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->