### PR TITLE
docs: document Datadog GPU monitoring as a known limitation

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -9,8 +9,9 @@ roadmap.
 - x86_64 nodes only.
 - vGPU is not supported.
 - Runs only on NVIDIA GPUs supported by the required CUDA driver.
-- Not compatible with tools that intercept `libcuda.so` calls (e.g. Datadog
-  GPU monitoring) — CUDA calls hang after restore. Disable such interception
-  for workloads that will be snapshotted.
+- The checkpointed workload must not have tools that intercept `libcuda.so`
+  calls (e.g. Datadog GPU monitoring) — CUDA calls may fail or hang after
+  restore, with undefined results. Disable such interception for workloads
+  that will be snapshotted.
 
 Multi-GPU and Arm support are on the roadmap.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -9,5 +9,8 @@ roadmap.
 - x86_64 nodes only.
 - vGPU is not supported.
 - Runs only on NVIDIA GPUs supported by the required CUDA driver.
+- Not compatible with tools that intercept `libcuda.so` calls (e.g. Datadog
+  GPU monitoring) — CUDA calls hang after restore. Disable such interception
+  for workloads that will be snapshotted.
 
 Multi-GPU and Arm support are on the roadmap.


### PR DESCRIPTION
## Summary
- Adds a known limitation: Snapshot does not support checkpoint/restore when tools like Datadog's GPU monitoring intercept/breakpoint `libcuda.so` calls
- Checkpointing with such interception in place captures the breakpoints in memory, so every CUDA call hangs on restore (root-caused in Slack thread, cc @Dan Feigin @Schwinn Saereesitthipitak)

## Test plan
- [x] Docs-only change, no build/test impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented a limitation affecting snapshot restoration: tools that intercept `libcuda.so` calls, including GPU monitoring tools such as Datadog, may cause CUDA calls to hang after restoration.
  * Workloads using snapshots must disable CUDA call interception and related GPU monitoring during snapshot operation and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->