### PR TITLE
docs: pin install instructions to v0.1.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Snapshot can be installed:
 
 ### From a release
 
-Find the latest version on the [releases page](https://github.com/ai-dynamo/snapshot/releases),
-then install the published chart, replacing `<VERSION>`:
+Install the published chart (see the [releases page](https://github.com/ai-dynamo/snapshot/releases)
+for other versions):
 
 ```bash
 helm install snapshot oci://ghcr.io/ai-dynamo/snapshot/snapshot \
-  --version <VERSION> \
+  --version 0.1.0-rc.1 \
   --namespace snapshot --create-namespace
 ```
 

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -8,13 +8,12 @@ Review the [prerequisites](../../README.md#prerequisites) before installing.
 
 ## Install from a release
 
-Find the latest version on the
-[releases page](https://github.com/ai-dynamo/snapshot/releases), then install the
-published chart, replacing `<VERSION>`:
+Install the published chart (see the
+[releases page](https://github.com/ai-dynamo/snapshot/releases) for other versions):
 
 ```bash
 helm install snapshot oci://ghcr.io/ai-dynamo/snapshot/snapshot \
-  --version <VERSION> \
+  --version 0.1.0-rc.1 \
   --namespace snapshot --create-namespace
 ```
 


### PR DESCRIPTION
## Summary
- Replaces the `<VERSION>` placeholder in README.md and docs/operations/install.md with the latest release, `0.1.0-rc.1`, so the `helm install` command can be copy-pasted directly
- Feedback: users were copy-pasting the command with the literal placeholder instead of replacing it first

## Test plan
- [x] Docs-only change, no build/test impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to specify release version `0.1.0-rc.1`.
  - Added guidance for finding and installing other versions from the releases page.
  - Replaced placeholder-based version instructions with explicit release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->