### PR TITLE
docs(guides): align framework examples on small single-GPU sizing and pins

### DIFF
--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -130,8 +130,8 @@ The example configures a context length of 10240 tokens for a 24 GiB NVIDIA A10
 GPU. Reduce `SGLANG_CONTEXT_LENGTH` for a smaller GPU or increase it only after
 validating the resulting memory use. The KV cache page size is set through
 `SGLANG_PAGE_SIZE` (default `16`); the engine runs with `tp_size=1`.
-`SGLANG_TRUST_REMOTE_CODE` (default `0`) controls `trust_remote_code`; set it
-to `1` only for checkpoints that ship their own modeling code. Qwen3 does not.
+`app.py` sets `trust_remote_code=False`; Qwen3 needs no custom model code.
+Edit that line in `app.py` for a checkpoint that ships its own modeling code.
 
 > [!NOTE]
 > This example runs SGLang directly through `sglang.Engine` rather than

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -39,7 +39,8 @@ curl --fail --location \
   https://raw.githubusercontent.com/ai-dynamo/snapshot/main/docs/guides/sglang/deployment.yaml
 ```
 
-The program creates a direct `sglang.Engine`, runs one generation, and calls
+The program creates a direct `sglang.Engine`, runs one generation and records
+its output in `sglang-precheck`, and calls
 `TokenizerManager.pause_generation()` followed by
 `Engine.release_memory_occupation()`. It writes `ready-for-snapshot` only after
 both operations succeed.
@@ -67,7 +68,7 @@ at `/hf-cache`.
 ### 2. Build the image
 
 ```bash
-export SGLANG_RUNTIME_IMAGE=lmsysorg/sglang@sha256:9e148f5ac788e856a06166bd6347a831831eb9fcfab4d1770874823a7c29a1a1
+export SGLANG_RUNTIME_IMAGE=lmsysorg/sglang:v0.5.17-cu130-runtime
 export SGLANG_SNAPSHOT_IMAGE=<registry>/sglang-snapshot:<tag>
 
 docker build \
@@ -127,7 +128,9 @@ containers:
 
 The example configures a context length of 10240 tokens for a 24 GiB NVIDIA A10
 GPU. Reduce `SGLANG_CONTEXT_LENGTH` for a smaller GPU or increase it only after
-validating the resulting memory use.
+validating the resulting memory use. The KV cache page size is set through
+`SNAPSHOT_PAGE_SIZE` (default `16`); the engine runs with `tp_size=1` and
+`trust_remote_code=True`.
 
 > [!NOTE]
 > This example runs SGLang directly through `sglang.Engine` rather than

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -68,7 +68,7 @@ at `/hf-cache`.
 ### 2. Build the image
 
 ```bash
-export SGLANG_RUNTIME_IMAGE=lmsysorg/sglang:v0.5.17-cu130-runtime
+export SGLANG_RUNTIME_IMAGE=lmsysorg/sglang:v0.5.17-cu130-runtime@sha256:3ea7c6d74312d964edbcf9b3819425ea42117eb967ef1cfec632a70c926027df
 export SGLANG_SNAPSHOT_IMAGE=<registry>/sglang-snapshot:<tag>
 
 docker build \
@@ -129,8 +129,9 @@ containers:
 The example configures a context length of 10240 tokens for a 24 GiB NVIDIA A10
 GPU. Reduce `SGLANG_CONTEXT_LENGTH` for a smaller GPU or increase it only after
 validating the resulting memory use. The KV cache page size is set through
-`SNAPSHOT_PAGE_SIZE` (default `16`); the engine runs with `tp_size=1` and
-`trust_remote_code=True`.
+`SGLANG_PAGE_SIZE` (default `16`); the engine runs with `tp_size=1`.
+`SGLANG_TRUST_REMOTE_CODE` (default `1`) controls `trust_remote_code`; set it
+to `0` for models that ship no custom code.
 
 > [!NOTE]
 > This example runs SGLang directly through `sglang.Engine` rather than

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -130,8 +130,8 @@ The example configures a context length of 10240 tokens for a 24 GiB NVIDIA A10
 GPU. Reduce `SGLANG_CONTEXT_LENGTH` for a smaller GPU or increase it only after
 validating the resulting memory use. The KV cache page size is set through
 `SGLANG_PAGE_SIZE` (default `16`); the engine runs with `tp_size=1`.
-`SGLANG_TRUST_REMOTE_CODE` (default `1`) controls `trust_remote_code`; set it
-to `0` for models that ship no custom code.
+`SGLANG_TRUST_REMOTE_CODE` (default `0`) controls `trust_remote_code`; set it
+to `1` only for checkpoints that ship their own modeling code. Qwen3 does not.
 
 > [!NOTE]
 > This example runs SGLang directly through `sglang.Engine` rather than

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -39,8 +39,7 @@ curl --fail --location \
   https://raw.githubusercontent.com/ai-dynamo/snapshot/main/docs/guides/sglang/deployment.yaml
 ```
 
-The program creates a direct `sglang.Engine`, runs one generation and records
-its output in `sglang-precheck`, and calls
+The program creates a direct `sglang.Engine`, runs one generation, and calls
 `TokenizerManager.pause_generation()` followed by
 `Engine.release_memory_occupation()`. It writes `ready-for-snapshot` only after
 both operations succeed.

--- a/docs/guides/sglang/Dockerfile.sglang
+++ b/docs/guides/sglang/Dockerfile.sglang
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG SGLANG_RUNTIME_IMAGE=lmsysorg/sglang@sha256:9e148f5ac788e856a06166bd6347a831831eb9fcfab4d1770874823a7c29a1a1
+ARG SGLANG_RUNTIME_IMAGE=lmsysorg/sglang:v0.5.17-cu130-runtime
 FROM ${SGLANG_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/sglang/Dockerfile.sglang
+++ b/docs/guides/sglang/Dockerfile.sglang
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG SGLANG_RUNTIME_IMAGE=lmsysorg/sglang:v0.5.17-cu130-runtime
+ARG SGLANG_RUNTIME_IMAGE=lmsysorg/sglang:v0.5.17-cu130-runtime@sha256:3ea7c6d74312d964edbcf9b3819425ea42117eb967ef1cfec632a70c926027df
 FROM ${SGLANG_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -38,9 +38,12 @@ def create_engine(snapshot_mode: bool) -> Any:
     return sgl.Engine(
         model_path=os.environ["SNAPSHOT_MODEL"],
         context_length=int(os.environ.get("SGLANG_CONTEXT_LENGTH", "10240")),
-        page_size=int(os.environ.get("SNAPSHOT_PAGE_SIZE", "16")),
+        page_size=int(os.environ.get("SGLANG_PAGE_SIZE", "16")),
         tp_size=1,
-        trust_remote_code=True,
+        # Qwen3 needs no custom model code, but many checkpoints do. The
+        # toggle keeps a security-relevant choice visible; set it to 0 for
+        # models that ship no code.
+        trust_remote_code=os.environ.get("SGLANG_TRUST_REMOTE_CODE", "1") == "1",
         enable_memory_saver=snapshot_mode,
         enable_weights_cpu_backup=snapshot_mode,
         log_level="info",

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -40,10 +40,10 @@ def create_engine(snapshot_mode: bool) -> Any:
         context_length=int(os.environ.get("SGLANG_CONTEXT_LENGTH", "10240")),
         page_size=int(os.environ.get("SGLANG_PAGE_SIZE", "16")),
         tp_size=1,
-        # Qwen3 needs no custom model code, but many checkpoints do. The
-        # toggle keeps a security-relevant choice visible; set it to 0 for
-        # models that ship no code.
-        trust_remote_code=os.environ.get("SGLANG_TRUST_REMOTE_CODE", "1") == "1",
+        # Off by default: Qwen3 needs no custom model code, and remote code
+        # execution should be an explicit opt-in. Set SGLANG_TRUST_REMOTE_CODE=1
+        # only for checkpoints that ship their own modeling code.
+        trust_remote_code=os.environ.get("SGLANG_TRUST_REMOTE_CODE", "0") == "1",
         enable_memory_saver=snapshot_mode,
         enable_weights_cpu_backup=snapshot_mode,
         log_level="info",

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -38,6 +38,9 @@ def create_engine(snapshot_mode: bool) -> Any:
     return sgl.Engine(
         model_path=os.environ["SNAPSHOT_MODEL"],
         context_length=int(os.environ.get("SGLANG_CONTEXT_LENGTH", "10240")),
+        page_size=int(os.environ.get("SNAPSHOT_PAGE_SIZE", "16")),
+        tp_size=1,
+        trust_remote_code=True,
         enable_memory_saver=snapshot_mode,
         enable_weights_cpu_backup=snapshot_mode,
         log_level="info",
@@ -128,6 +131,14 @@ def main() -> None:
 
         if not snapshot_mode:
             return
+
+        # Durable evidence that the engine served a generation before capture;
+        # the source container is killed by the dump, so logs alone are easy
+        # to lose.
+        CONTROL_DIR.joinpath("sglang-precheck").write_text(
+            text + "\n",
+            encoding="utf-8",
+        )
 
         pause_generation(engine)
         try:

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -40,10 +40,10 @@ def create_engine(snapshot_mode: bool) -> Any:
         context_length=int(os.environ.get("SGLANG_CONTEXT_LENGTH", "10240")),
         page_size=int(os.environ.get("SGLANG_PAGE_SIZE", "16")),
         tp_size=1,
-        # Off by default: Qwen3 needs no custom model code, and remote code
-        # execution should be an explicit opt-in. Set SGLANG_TRUST_REMOTE_CODE=1
-        # only for checkpoints that ship their own modeling code.
-        trust_remote_code=os.environ.get("SGLANG_TRUST_REMOTE_CODE", "0") == "1",
+        # Off: Qwen3 needs no custom model code, and remote code execution
+        # should be an explicit opt-in. Set this to True only for checkpoints
+        # that ship their own modeling code.
+        trust_remote_code=False,
         enable_memory_saver=snapshot_mode,
         enable_weights_cpu_backup=snapshot_mode,
         log_level="info",

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -40,9 +40,6 @@ def create_engine(snapshot_mode: bool) -> Any:
         context_length=int(os.environ.get("SGLANG_CONTEXT_LENGTH", "10240")),
         page_size=int(os.environ.get("SGLANG_PAGE_SIZE", "16")),
         tp_size=1,
-        # Off: Qwen3 needs no custom model code, and remote code execution
-        # should be an explicit opt-in. Set this to True only for checkpoints
-        # that ship their own modeling code.
         trust_remote_code=False,
         enable_memory_saver=snapshot_mode,
         enable_weights_cpu_backup=snapshot_mode,

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -135,14 +135,6 @@ def main() -> None:
         if not snapshot_mode:
             return
 
-        # Durable evidence that the engine served a generation before capture;
-        # the source container is killed by the dump, so logs alone are easy
-        # to lose.
-        CONTROL_DIR.joinpath("sglang-precheck").write_text(
-            text + "\n",
-            encoding="utf-8",
-        )
-
         pause_generation(engine)
         try:
             engine.release_memory_occupation()

--- a/docs/guides/sglang/deployment.yaml
+++ b/docs/guides/sglang/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               value: Qwen/Qwen3-0.6B
             - name: SGLANG_CONTEXT_LENGTH
               value: "10240"
-            - name: SNAPSHOT_PAGE_SIZE
+            - name: SGLANG_PAGE_SIZE
               value: "16"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control

--- a/docs/guides/sglang/deployment.yaml
+++ b/docs/guides/sglang/deployment.yaml
@@ -67,6 +67,9 @@ spec:
               value: "10240"
             - name: SGLANG_PAGE_SIZE
               value: "16"
+            # Remote code execution is opt-in; Qwen3 ships no custom code.
+            - name: SGLANG_TRUST_REMOTE_CODE
+              value: "0"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
             - name: HF_HOME

--- a/docs/guides/sglang/deployment.yaml
+++ b/docs/guides/sglang/deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: Qwen/Qwen3-0.6B
             - name: SGLANG_CONTEXT_LENGTH
               value: "10240"
+            - name: SNAPSHOT_PAGE_SIZE
+              value: "16"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
             - name: HF_HOME

--- a/docs/guides/sglang/deployment.yaml
+++ b/docs/guides/sglang/deployment.yaml
@@ -67,9 +67,6 @@ spec:
               value: "10240"
             - name: SGLANG_PAGE_SIZE
               value: "16"
-            # Remote code execution is opt-in; Qwen3 ships no custom code.
-            - name: SGLANG_TRUST_REMOTE_CODE
-              value: "0"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
             - name: HF_HOME

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -51,8 +51,11 @@ listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
-The Dockerfile starts from the TensorRT-LLM 1.2.1 release image (a GA
-release, pinned by digest), creates `/snapshot-control`, and adds `app.py`.
+The Dockerfile starts from the TensorRT-LLM `1.3.0rc24` release image, pinned by
+digest, creates `/snapshot-control`, and adds `app.py`. A release candidate is
+used deliberately: the `1.2.1` GA image fails at `import tensorrt` because
+`libnvonnxparser.so.10` is missing from it, and no 1.3.0 GA image exists yet.
+Move to the first 1.3.x GA once it is published.
 `TLLM_NCCL_SYMMETRIC_ZERO_COPY=0` disables NCCL registered windows that CUDA
 checkpoint does not support. `UCX_TLS=tcp,self` avoids RDMA mappings that CRIU
 cannot restore.
@@ -63,7 +66,7 @@ Snapshot control volume at `/snapshot-control`.
 ### 2. Build the image
 
 ```bash
-export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.2.1@sha256:33cd085b772947bd22b7273886539331420404e5d2a4a039945241945ff927b9
+export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
 export TENSORRT_LLM_SNAPSHOT_IMAGE=<registry>/tensorrt-llm-snapshot:<tag>
 
 docker build \

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -51,8 +51,8 @@ listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
-The Dockerfile starts from the tested TensorRT-LLM 1.3.0 release candidate
-image, creates `/snapshot-control`, and adds `app.py`.
+The Dockerfile starts from the TensorRT-LLM 1.2.1 release image (a GA
+release, pinned by digest), creates `/snapshot-control`, and adds `app.py`.
 `TLLM_NCCL_SYMMETRIC_ZERO_COPY=0` disables NCCL registered windows that CUDA
 checkpoint does not support. `UCX_TLS=tcp,self` avoids RDMA mappings that CRIU
 cannot restore.
@@ -63,7 +63,7 @@ Snapshot control volume at `/snapshot-control`.
 ### 2. Build the image
 
 ```bash
-export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
+export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.2.1@sha256:33cd085b772947bd22b7273886539331420404e5d2a4a039945241945ff927b9
 export TENSORRT_LLM_SNAPSHOT_IMAGE=<registry>/tensorrt-llm-snapshot:<tag>
 
 docker build \

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -39,9 +39,9 @@ curl --fail --location \
 
 The program loads the model selected in `deployment.yaml` and calls
 `LLM.generate()` to initialize TensorRT-LLM. The synchronous call returns only
-after generation finishes, so no request remains in flight. The program records
-the generated text in `trtllm-precheck`, runs `gc.collect()`, and writes
-`ready-for-snapshot` when it reaches the safe checkpoint point.
+after generation finishes, so no request remains in flight. The program then
+runs `gc.collect()` and writes `ready-for-snapshot` when it reaches the safe
+checkpoint point.
 
 TensorRT-LLM does not use a framework pause or sleep call in this example. The
 model and initialized CUDA state remain resident. After restore, the checkpointed

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -121,7 +121,9 @@ containers:
 The example uses one GPU, the PyTorch backend, and a maximum sequence length of
 512 tokens. Engine sizing is set through `TRTLLM_MAX_NUM_TOKENS` (default
 `1024`), `TRTLLM_MAX_BATCH_SIZE` (default `1`), and
-`TRTLLM_FREE_GPU_MEMORY_FRACTION` (default `0.10`). Revalidate checkpoint and
+`TRTLLM_FREE_GPU_MEMORY_FRACTION` (default `0.10`). `TRTLLM_TRUST_REMOTE_CODE`
+(default `0`) controls `trust_remote_code`; set it to `1` only for checkpoints
+that ship their own modeling code. Qwen3 does not. Revalidate checkpoint and
 restore before changing the model, TensorRT-LLM image, GPU count, backend, or
 engine settings.
 

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -63,7 +63,7 @@ Snapshot control volume at `/snapshot-control`.
 ### 2. Build the image
 
 ```bash
-export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24
+export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
 export TENSORRT_LLM_SNAPSHOT_IMAGE=<registry>/tensorrt-llm-snapshot:<tag>
 
 docker build \
@@ -119,9 +119,9 @@ containers:
 ```
 
 The example uses one GPU, the PyTorch backend, and a maximum sequence length of
-512 tokens. Engine sizing is set through `SNAPSHOT_MAX_NUM_TOKENS` (default
-`1024`), `SNAPSHOT_MAX_BATCH_SIZE` (default `1`), and
-`SNAPSHOT_FREE_GPU_MEMORY_FRACTION` (default `0.10`). Revalidate checkpoint and
+512 tokens. Engine sizing is set through `TRTLLM_MAX_NUM_TOKENS` (default
+`1024`), `TRTLLM_MAX_BATCH_SIZE` (default `1`), and
+`TRTLLM_FREE_GPU_MEMORY_FRACTION` (default `0.10`). Revalidate checkpoint and
 restore before changing the model, TensorRT-LLM image, GPU count, backend, or
 engine settings.
 

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -39,9 +39,9 @@ curl --fail --location \
 
 The program loads the model selected in `deployment.yaml` and calls
 `LLM.generate()` to initialize TensorRT-LLM. The synchronous call returns only
-after generation finishes, so no request remains in flight. The program runs
-`gc.collect()` and writes `ready-for-snapshot` when it reaches the safe checkpoint
-point.
+after generation finishes, so no request remains in flight. The program records
+the generated text in `trtllm-precheck`, runs `gc.collect()`, and writes
+`ready-for-snapshot` when it reaches the safe checkpoint point.
 
 TensorRT-LLM does not use a framework pause or sleep call in this example. The
 model and initialized CUDA state remain resident. After restore, the checkpointed
@@ -63,7 +63,7 @@ Snapshot control volume at `/snapshot-control`.
 ### 2. Build the image
 
 ```bash
-export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23
+export TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24
 export TENSORRT_LLM_SNAPSHOT_IMAGE=<registry>/tensorrt-llm-snapshot:<tag>
 
 docker build \
@@ -119,8 +119,11 @@ containers:
 ```
 
 The example uses one GPU, the PyTorch backend, and a maximum sequence length of
-512 tokens. Revalidate checkpoint and restore before changing the model,
-TensorRT-LLM image, GPU count, backend, or engine settings.
+512 tokens. Engine sizing is set through `SNAPSHOT_MAX_NUM_TOKENS` (default
+`1024`), `SNAPSHOT_MAX_BATCH_SIZE` (default `1`), and
+`SNAPSHOT_FREE_GPU_MEMORY_FRACTION` (default `0.10`). Revalidate checkpoint and
+restore before changing the model, TensorRT-LLM image, GPU count, backend, or
+engine settings.
 
 > [!NOTE]
 > This example runs TensorRT-LLM through the `LLM` API rather than `trtllm-serve`,

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -124,11 +124,11 @@ containers:
 The example uses one GPU, the PyTorch backend, and a maximum sequence length of
 512 tokens. Engine sizing is set through `TRTLLM_MAX_NUM_TOKENS` (default
 `1024`), `TRTLLM_MAX_BATCH_SIZE` (default `1`), and
-`TRTLLM_FREE_GPU_MEMORY_FRACTION` (default `0.10`). `TRTLLM_TRUST_REMOTE_CODE`
-(default `0`) controls `trust_remote_code`; set it to `1` only for checkpoints
-that ship their own modeling code. Qwen3 does not. Revalidate checkpoint and
-restore before changing the model, TensorRT-LLM image, GPU count, backend, or
-engine settings.
+`TRTLLM_FREE_GPU_MEMORY_FRACTION` (default `0.10`). `app.py` sets
+`trust_remote_code=False`; Qwen3 needs no custom model code. Edit
+`TRUST_REMOTE_CODE` in `app.py` for a checkpoint that ships its own modeling
+code. Revalidate checkpoint and restore before changing the model,
+TensorRT-LLM image, GPU count, backend, or engine settings.
 
 > [!NOTE]
 > This example runs TensorRT-LLM through the `LLM` API rather than `trtllm-serve`,

--- a/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
+++ b/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.2.1@sha256:33cd085b772947bd22b7273886539331420404e5d2a4a039945241945ff927b9
+# A release candidate on purpose: the 1.2.1 GA image fails at `import tensorrt`
+# (libnvonnxparser.so.10 is missing from that image), and no 1.3.0 GA exists
+# yet. Move to the first 1.3.x GA once published.
+ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
 FROM ${TENSORRT_LLM_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
+++ b/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24
+ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
 FROM ${TENSORRT_LLM_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
+++ b/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23
+ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24
 FROM ${TENSORRT_LLM_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
+++ b/docs/guides/tensorrt-llm/Dockerfile.tensorrt-llm
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
+ARG TENSORRT_LLM_RUNTIME_IMAGE=nvcr.io/nvidia/tensorrt-llm/release:1.2.1@sha256:33cd085b772947bd22b7273886539331420404e5d2a4a039945241945ff927b9
 FROM ${TENSORRT_LLM_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -19,6 +19,10 @@ MAX_BATCH_SIZE = int(os.environ.get("TRTLLM_MAX_BATCH_SIZE", "1"))
 FREE_GPU_MEMORY_FRACTION = float(
     os.environ.get("TRTLLM_FREE_GPU_MEMORY_FRACTION", "0.10")
 )
+# Off by default: Qwen3 needs no custom model code, and remote code execution
+# should be an explicit opt-in. Set TRTLLM_TRUST_REMOTE_CODE=1 only for
+# checkpoints that ship their own modeling code.
+TRUST_REMOTE_CODE = os.environ.get("TRTLLM_TRUST_REMOTE_CODE", "0") == "1"
 
 
 def generate_text(llm: LLM, prompts: list[str]) -> list[str]:
@@ -86,7 +90,7 @@ def main() -> None:
         model=MODEL,
         backend="pytorch",
         dtype="float16",
-        trust_remote_code=True,
+        trust_remote_code=TRUST_REMOTE_CODE,
         tensor_parallel_size=1,
         max_num_tokens=MAX_NUM_TOKENS,
         max_seq_len=512,

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -14,10 +14,10 @@ CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
 MODEL = os.environ["SNAPSHOT_MODEL"]
 # Small single-GPU sizing so the example fits alongside other GPU tenants and
 # keeps the checkpoint artifact small. Override through the Pod template.
-MAX_NUM_TOKENS = int(os.environ.get("SNAPSHOT_MAX_NUM_TOKENS", "1024"))
-MAX_BATCH_SIZE = int(os.environ.get("SNAPSHOT_MAX_BATCH_SIZE", "1"))
+MAX_NUM_TOKENS = int(os.environ.get("TRTLLM_MAX_NUM_TOKENS", "1024"))
+MAX_BATCH_SIZE = int(os.environ.get("TRTLLM_MAX_BATCH_SIZE", "1"))
 FREE_GPU_MEMORY_FRACTION = float(
-    os.environ.get("SNAPSHOT_FREE_GPU_MEMORY_FRACTION", "0.10")
+    os.environ.get("TRTLLM_FREE_GPU_MEMORY_FRACTION", "0.10")
 )
 
 

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -19,10 +19,10 @@ MAX_BATCH_SIZE = int(os.environ.get("TRTLLM_MAX_BATCH_SIZE", "1"))
 FREE_GPU_MEMORY_FRACTION = float(
     os.environ.get("TRTLLM_FREE_GPU_MEMORY_FRACTION", "0.10")
 )
-# Off by default: Qwen3 needs no custom model code, and remote code execution
-# should be an explicit opt-in. Set TRTLLM_TRUST_REMOTE_CODE=1 only for
-# checkpoints that ship their own modeling code.
-TRUST_REMOTE_CODE = os.environ.get("TRTLLM_TRUST_REMOTE_CODE", "0") == "1"
+# Off: Qwen3 needs no custom model code, and remote code execution should be
+# an explicit opt-in. Set this to True only for checkpoints that ship their
+# own modeling code.
+TRUST_REMOTE_CODE = False
 
 
 def generate_text(llm: LLM, prompts: list[str]) -> list[str]:

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -12,6 +12,13 @@ from tensorrt_llm import LLM, SamplingParams
 
 CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
 MODEL = os.environ["SNAPSHOT_MODEL"]
+# Small single-GPU sizing so the example fits alongside other GPU tenants and
+# keeps the checkpoint artifact small. Override through the Pod template.
+MAX_NUM_TOKENS = int(os.environ.get("SNAPSHOT_MAX_NUM_TOKENS", "1024"))
+MAX_BATCH_SIZE = int(os.environ.get("SNAPSHOT_MAX_BATCH_SIZE", "1"))
+FREE_GPU_MEMORY_FRACTION = float(
+    os.environ.get("SNAPSHOT_FREE_GPU_MEMORY_FRACTION", "0.10")
+)
 
 
 def generate_text(llm: LLM, prompts: list[str]) -> list[str]:
@@ -81,21 +88,28 @@ def main() -> None:
         dtype="float16",
         trust_remote_code=True,
         tensor_parallel_size=1,
-        max_num_tokens=1024,
+        max_num_tokens=MAX_NUM_TOKENS,
         max_seq_len=512,
-        max_batch_size=1,
+        max_batch_size=MAX_BATCH_SIZE,
         enable_chunked_prefill=False,
-        kv_cache_config={"free_gpu_memory_fraction": 0.10},
+        kv_cache_config={"free_gpu_memory_fraction": FREE_GPU_MEMORY_FRACTION},
     )
 
-    for text in generate_text(
+    precheck_texts = generate_text(
         llm,
         [
             "Summarize why checkpoint and restore testing matters.",
             "Continue this sequence with four numbers: 1, 2, 3, 4,",
         ],
-    ):
+    )
+    for text in precheck_texts:
         print(f"TensorRT-LLM pre-checkpoint output={text!r}", flush=True)
+    # Durable evidence that the engine served a generation before capture; the
+    # source container is killed by the dump, so logs alone are easy to lose.
+    CONTROL_DIR.joinpath("trtllm-precheck").write_text(
+        "\n".join(precheck_texts) + "\n",
+        encoding="utf-8",
+    )
 
     gc.collect()
     CONTROL_DIR.joinpath("ready-for-snapshot").write_text(

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -19,9 +19,6 @@ MAX_BATCH_SIZE = int(os.environ.get("TRTLLM_MAX_BATCH_SIZE", "1"))
 FREE_GPU_MEMORY_FRACTION = float(
     os.environ.get("TRTLLM_FREE_GPU_MEMORY_FRACTION", "0.10")
 )
-# Off: Qwen3 needs no custom model code, and remote code execution should be
-# an explicit opt-in. Set this to True only for checkpoints that ship their
-# own modeling code.
 TRUST_REMOTE_CODE = False
 
 

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -99,21 +99,14 @@ def main() -> None:
         kv_cache_config={"free_gpu_memory_fraction": FREE_GPU_MEMORY_FRACTION},
     )
 
-    precheck_texts = generate_text(
+    for text in generate_text(
         llm,
         [
             "Summarize why checkpoint and restore testing matters.",
             "Continue this sequence with four numbers: 1, 2, 3, 4,",
         ],
-    )
-    for text in precheck_texts:
+    ):
         print(f"TensorRT-LLM pre-checkpoint output={text!r}", flush=True)
-    # Durable evidence that the engine served a generation before capture; the
-    # source container is killed by the dump, so logs alone are easy to lose.
-    CONTROL_DIR.joinpath("trtllm-precheck").write_text(
-        "\n".join(precheck_texts) + "\n",
-        encoding="utf-8",
-    )
 
     gc.collect()
     CONTROL_DIR.joinpath("ready-for-snapshot").write_text(

--- a/docs/guides/tensorrt-llm/deployment.yaml
+++ b/docs/guides/tensorrt-llm/deployment.yaml
@@ -42,9 +42,6 @@ spec:
               value: "1"
             - name: TRTLLM_FREE_GPU_MEMORY_FRACTION
               value: "0.10"
-            # Remote code execution is opt-in; Qwen3 ships no custom code.
-            - name: TRTLLM_TRUST_REMOTE_CODE
-              value: "0"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
             - name: HF_HUB_DISABLE_XET

--- a/docs/guides/tensorrt-llm/deployment.yaml
+++ b/docs/guides/tensorrt-llm/deployment.yaml
@@ -36,6 +36,12 @@ spec:
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
+            - name: SNAPSHOT_MAX_NUM_TOKENS
+              value: "1024"
+            - name: SNAPSHOT_MAX_BATCH_SIZE
+              value: "1"
+            - name: SNAPSHOT_FREE_GPU_MEMORY_FRACTION
+              value: "0.10"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
             - name: HF_HUB_DISABLE_XET

--- a/docs/guides/tensorrt-llm/deployment.yaml
+++ b/docs/guides/tensorrt-llm/deployment.yaml
@@ -36,11 +36,11 @@ spec:
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
-            - name: SNAPSHOT_MAX_NUM_TOKENS
+            - name: TRTLLM_MAX_NUM_TOKENS
               value: "1024"
-            - name: SNAPSHOT_MAX_BATCH_SIZE
+            - name: TRTLLM_MAX_BATCH_SIZE
               value: "1"
-            - name: SNAPSHOT_FREE_GPU_MEMORY_FRACTION
+            - name: TRTLLM_FREE_GPU_MEMORY_FRACTION
               value: "0.10"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control

--- a/docs/guides/tensorrt-llm/deployment.yaml
+++ b/docs/guides/tensorrt-llm/deployment.yaml
@@ -42,6 +42,9 @@ spec:
               value: "1"
             - name: TRTLLM_FREE_GPU_MEMORY_FRACTION
               value: "0.10"
+            # Remote code execution is opt-in; Qwen3 ships no custom code.
+            - name: TRTLLM_TRUST_REMOTE_CODE
+              value: "0"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
             - name: HF_HUB_DISABLE_XET

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -115,7 +115,9 @@ source and restored containers.
 The example sizes the engine for a small single-GPU deployment through
 `VLLM_MAX_MODEL_LEN` (default `2048`) and `VLLM_GPU_MEMORY_UTILIZATION`
 (default `0.30`). Raise them only after validating checkpoint and restore with
-the resulting memory use.
+the resulting memory use. `VLLM_TRUST_REMOTE_CODE` (default `0`) controls
+`trust_remote_code`; set it to `1` only for checkpoints that ship their own
+modeling code. Qwen3 does not.
 
 > [!NOTE]
 > This example runs vLLM directly through `AsyncLLM` rather than `vllm serve`, so

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -6,8 +6,9 @@ container layout Snapshot expects. The Snapshot agent injects the restore
 tooling at runtime.
 
 > [!NOTE]
-> This example is validated on vLLM 0.27.1 (the pinned `vllm/vllm-openai:v0.27.1`
-> image) and does not work on vLLM 0.28.
+> This example is validated on vLLM 0.27.1 (the pinned
+> `vllm/vllm-openai:v0.27.1-ubuntu2404` image) and does not work on vLLM
+> 0.28.
 
 ## Build
 
@@ -49,9 +50,10 @@ listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
-The Dockerfile starts from the official vLLM 0.27.1 image and installs the
-Ubuntu 24.04 glibc required by the current Snapshot restore bundle. It creates
-`/snapshot-control` and adds `app.py`.
+The Dockerfile starts from vLLM's own Ubuntu 24.04 build of the 0.27.1 image
+(`v0.27.1-ubuntu2404`), which already matches the glibc floor the current
+Snapshot restore bundle requires. It creates `/snapshot-control` and adds
+`app.py`.
 `HF_HUB_DISABLE_XET=1` prevents the model downloader from leaving an open cache
 log that CRIU cannot reopen after restore.
 
@@ -61,7 +63,7 @@ The source and restore pods must mount the Snapshot control volume at
 ### 2. Build the image
 
 ```bash
-export VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967
+export VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1-ubuntu2404@sha256:dafea057f24b7d42716331a48e2db4e1f204f877a3aa759cb7e4c37e64ca2eee
 export VLLM_SNAPSHOT_IMAGE=<registry>/vllm-snapshot:<tag>
 
 docker build \

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -97,17 +97,20 @@ Any failure prints an error and returns a non-zero exit status.
 Set the namespace where the vLLM pod will run:
 
 ```bash
-export VLLM_NAMESPACE=<namespace>
-kubectl get namespace "$VLLM_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set the model through the `SNAPSHOT_MODEL` environment variable in
-[`deployment.yaml`](vllm/deployment.yaml):
+In [`deployment.yaml`](vllm/deployment.yaml), replace the example `image` with the
+one pushed in step 2 and select the model through `SNAPSHOT_MODEL`:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/vllm-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 Other values include `TinyLlama/TinyLlama-1.1B-Chat-v1.0` or a mounted model
@@ -128,30 +131,20 @@ modeling code. Qwen3 does not.
 > vLLM's [environment variables](https://docs.vllm.ai/en/v0.27.1/configuration/env_vars/)
 > set in the Deployment's Pod template.
 
-Use [`deployment.yaml`](vllm/deployment.yaml) to deploy the image built in
-step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  main="$VLLM_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$VLLM_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
-
-The command replaces the example image value in `deployment.yaml` with
-`$VLLM_SNAPSHOT_IMAGE` before creating the Deployment. It does not modify the
-local file.
 
 Wait until the vLLM replica finishes initialization and becomes safe to
 checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$VLLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/vllm-source \
   --timeout=30m
 ```
@@ -160,7 +153,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$VLLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=vllm-source
 ```
 

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -120,9 +120,9 @@ source and restored containers.
 The example sizes the engine for a small single-GPU deployment through
 `VLLM_MAX_MODEL_LEN` (default `2048`) and `VLLM_GPU_MEMORY_UTILIZATION`
 (default `0.30`). Raise them only after validating checkpoint and restore with
-the resulting memory use. `VLLM_TRUST_REMOTE_CODE` (default `0`) controls
-`trust_remote_code`; set it to `1` only for checkpoints that ship their own
-modeling code. Qwen3 does not.
+the resulting memory use. `app.py` sets `trust_remote_code=False`; Qwen3 needs
+no custom model code. Edit `TRUST_REMOTE_CODE` in `app.py` for a checkpoint
+that ships its own modeling code.
 
 > [!NOTE]
 > This example runs vLLM directly through `AsyncLLM` rather than `vllm serve`, so

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -39,12 +39,13 @@ curl --fail --location \
 ```
 
 The program loads the model selected in `deployment.yaml`, runs one
-generation to initialize vLLM, and then calls `pause_generation()` and
-`sleep()`. It writes
-`ready-for-snapshot` only when the process is safe to checkpoint. After restore,
-the checkpointed process calls `wake_up()` and `resume_generation()`, runs
-another generation, starts an API, and writes `vllm-restore-ready` when the API
-is listening. To validate the restored replica, send a `POST` request to
+generation to initialize vLLM and records its output in `vllm-precheck`, and
+then calls `pause_generation()` and `sleep()`. It writes
+`ready-for-snapshot` only when the process is safe to checkpoint. In a restore
+container, it waits in standby until Snapshot injects the checkpointed process.
+That process calls `wake_up()` and `resume_generation()`, runs another
+generation, starts an API, and writes `vllm-restore-ready` when the API is
+listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
@@ -54,8 +55,8 @@ Ubuntu 24.04 glibc required by the current Snapshot restore bundle. It creates
 `HF_HUB_DISABLE_XET=1` prevents the model downloader from leaving an open cache
 log that CRIU cannot reopen after restore.
 
-The source and restore pods must use the same immutable image and mount the
-Snapshot control volume at `/snapshot-control`.
+The source and restore pods must mount the Snapshot control volume at
+`/snapshot-control`.
 
 ### 2. Build the image
 
@@ -94,25 +95,27 @@ Any failure prints an error and returns a non-zero exit status.
 Set the namespace where the vLLM pod will run:
 
 ```bash
-export SNAPSHOT_NAMESPACE=<namespace>
-kubectl get namespace "$SNAPSHOT_NAMESPACE"
+export VLLM_NAMESPACE=<namespace>
+kubectl get namespace "$VLLM_NAMESPACE"
 ```
 
-In [`deployment.yaml`](vllm/deployment.yaml), replace the example `image` with the
-one pushed in step 2 and select the model through `SNAPSHOT_MODEL`:
+Set the model through the `SNAPSHOT_MODEL` environment variable in
+[`deployment.yaml`](vllm/deployment.yaml):
 
 ```yaml
-containers:
-  - name: main
-    image: <registry>/vllm-snapshot:<tag>
-    env:
-      - name: SNAPSHOT_MODEL
-        value: Qwen/Qwen3-0.6B
+env:
+  - name: SNAPSHOT_MODEL
+    value: Qwen/Qwen3-0.6B
 ```
 
 Other values include `TinyLlama/TinyLlama-1.1B-Chat-v1.0` or a mounted model
 path such as `/models/Qwen3-0.6B`. A mounted path must be available to both the
 source and restored containers.
+
+The example sizes the engine for a small single-GPU deployment through
+`SNAPSHOT_MAX_MODEL_LEN` (default `2048`) and `SNAPSHOT_GPU_MEMORY_UTILIZATION`
+(default `0.30`). Raise them only after validating checkpoint and restore with
+the resulting memory use.
 
 > [!NOTE]
 > This example runs vLLM directly through `AsyncLLM` rather than `vllm serve`, so
@@ -121,20 +124,30 @@ source and restored containers.
 > vLLM's [environment variables](https://docs.vllm.ai/en/v0.27.1/configuration/env_vars/)
 > set in the Deployment's Pod template.
 
-Deploy the edited manifest:
+Use [`deployment.yaml`](vllm/deployment.yaml) to deploy the image built in
+step 2:
 
 ```bash
-kubectl apply \
-  --namespace "$SNAPSHOT_NAMESPACE" \
-  --filename deployment.yaml
+kubectl set image \
+  --local \
+  --filename deployment.yaml \
+  main="$VLLM_SNAPSHOT_IMAGE" \
+  --output yaml |
+  kubectl apply \
+    --namespace "$VLLM_NAMESPACE" \
+    --filename -
 ```
+
+The command replaces the example image value in `deployment.yaml` with
+`$VLLM_SNAPSHOT_IMAGE` before creating the Deployment. It does not modify the
+local file.
 
 Wait until the vLLM replica finishes initialization and becomes safe to
 checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$SNAPSHOT_NAMESPACE" \
+  --namespace "$VLLM_NAMESPACE" \
   deployment/vllm-source \
   --timeout=30m
 ```
@@ -143,7 +156,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$SNAPSHOT_NAMESPACE" \
+  --namespace "$VLLM_NAMESPACE" \
   --selector app=vllm-source
 ```
 

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -61,7 +61,7 @@ The source and restore pods must mount the Snapshot control volume at
 ### 2. Build the image
 
 ```bash
-export VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1
+export VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967
 export VLLM_SNAPSHOT_IMAGE=<registry>/vllm-snapshot:<tag>
 
 docker build \
@@ -113,7 +113,7 @@ path such as `/models/Qwen3-0.6B`. A mounted path must be available to both the
 source and restored containers.
 
 The example sizes the engine for a small single-GPU deployment through
-`SNAPSHOT_MAX_MODEL_LEN` (default `2048`) and `SNAPSHOT_GPU_MEMORY_UTILIZATION`
+`VLLM_MAX_MODEL_LEN` (default `2048`) and `VLLM_GPU_MEMORY_UTILIZATION`
 (default `0.30`). Raise them only after validating checkpoint and restore with
 the resulting memory use.
 

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -40,8 +40,8 @@ curl --fail --location \
 ```
 
 The program loads the model selected in `deployment.yaml`, runs one
-generation to initialize vLLM and records its output in `vllm-precheck`, and
-then calls `pause_generation()` and `sleep()`. It writes
+generation to initialize vLLM, and then calls `pause_generation()` and
+`sleep()`. It writes
 `ready-for-snapshot` only when the process is safe to checkpoint. In a restore
 container, it waits in standby until Snapshot injects the checkpointed process.
 That process calls `wake_up()` and `resume_generation()`, runs another

--- a/docs/guides/vllm/Dockerfile.vllm
+++ b/docs/guides/vllm/Dockerfile.vllm
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1
+ARG VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967
 FROM ${VLLM_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64

--- a/docs/guides/vllm/Dockerfile.vllm
+++ b/docs/guides/vllm/Dockerfile.vllm
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967
+# The plain v0.27.1 tag ships an older-glibc base, older than what restore's
+# bundled criu/tar need (see agent/Dockerfile's criu-builder stage); this
+# variant is vLLM's own Ubuntu 24.04 build, so no glibc backport is needed.
+ARG VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1-ubuntu2404@sha256:dafea057f24b7d42716331a48e2db4e1f204f877a3aa759cb7e4c37e64ca2eee
 FROM ${VLLM_RUNTIME_IMAGE}
 
 ARG TARGETARCH=amd64
@@ -15,12 +18,6 @@ RUN set -eux; \
       echo "Snapshot requires x86_64" >&2; \
       exit 1; \
     fi; \
-    printf 'deb http://archive.ubuntu.com/ubuntu noble main universe\n' \
-      >/etc/apt/sources.list.d/snapshot-noble.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends -t noble libc6 libc-bin; \
-    rm -f /etc/apt/sources.list.d/snapshot-noble.list; \
-    rm -rf /var/lib/apt/lists/*; \
     mkdir -p /snapshot-control
 
 WORKDIR /app

--- a/docs/guides/vllm/Dockerfile.vllm
+++ b/docs/guides/vllm/Dockerfile.vllm
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# The plain v0.27.1 tag ships an older-glibc base, older than what restore's
-# bundled criu/tar need (see agent/Dockerfile's criu-builder stage); this
-# variant is vLLM's own Ubuntu 24.04 build, so no glibc backport is needed.
 ARG VLLM_RUNTIME_IMAGE=vllm/vllm-openai:v0.27.1-ubuntu2404@sha256:dafea057f24b7d42716331a48e2db4e1f204f877a3aa759cb7e4c37e64ca2eee
 FROM ${VLLM_RUNTIME_IMAGE}
 

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -20,10 +20,10 @@ MODEL = os.environ["SNAPSHOT_MODEL"]
 # keeps the checkpoint artifact small. Override through the Pod template.
 MAX_MODEL_LEN = int(os.environ.get("VLLM_MAX_MODEL_LEN", "2048"))
 GPU_MEMORY_UTILIZATION = float(os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "0.30"))
-# Off by default: Qwen3 needs no custom model code, and remote code execution
-# should be an explicit opt-in. Set VLLM_TRUST_REMOTE_CODE=1 only for
-# checkpoints that ship their own modeling code.
-TRUST_REMOTE_CODE = os.environ.get("VLLM_TRUST_REMOTE_CODE", "0") == "1"
+# Off: Qwen3 needs no custom model code, and remote code execution should be
+# an explicit opt-in. Set this to True only for checkpoints that ship their
+# own modeling code.
+TRUST_REMOTE_CODE = False
 
 
 class GenerateRequest(BaseModel):

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -18,8 +18,8 @@ CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
 MODEL = os.environ["SNAPSHOT_MODEL"]
 # Small single-GPU sizing so the example fits alongside other GPU tenants and
 # keeps the checkpoint artifact small. Override through the Pod template.
-MAX_MODEL_LEN = int(os.environ.get("SNAPSHOT_MAX_MODEL_LEN", "2048"))
-GPU_MEMORY_UTILIZATION = float(os.environ.get("SNAPSHOT_GPU_MEMORY_UTILIZATION", "0.30"))
+MAX_MODEL_LEN = int(os.environ.get("VLLM_MAX_MODEL_LEN", "2048"))
+GPU_MEMORY_UTILIZATION = float(os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "0.30"))
 
 
 class GenerateRequest(BaseModel):

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -20,6 +20,10 @@ MODEL = os.environ["SNAPSHOT_MODEL"]
 # keeps the checkpoint artifact small. Override through the Pod template.
 MAX_MODEL_LEN = int(os.environ.get("VLLM_MAX_MODEL_LEN", "2048"))
 GPU_MEMORY_UTILIZATION = float(os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "0.30"))
+# Off by default: Qwen3 needs no custom model code, and remote code execution
+# should be an explicit opt-in. Set VLLM_TRUST_REMOTE_CODE=1 only for
+# checkpoints that ship their own modeling code.
+TRUST_REMOTE_CODE = os.environ.get("VLLM_TRUST_REMOTE_CODE", "0") == "1"
 
 
 class GenerateRequest(BaseModel):
@@ -92,6 +96,7 @@ async def main() -> None:
             enable_sleep_mode=True,
             max_model_len=MAX_MODEL_LEN,
             gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+            trust_remote_code=TRUST_REMOTE_CODE,
         ),
         usage_context=UsageContext.LLM_CLASS,
     )

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -16,6 +16,10 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
 MODEL = os.environ["SNAPSHOT_MODEL"]
+# Small single-GPU sizing so the example fits alongside other GPU tenants and
+# keeps the checkpoint artifact small. Override through the Pod template.
+MAX_MODEL_LEN = int(os.environ.get("SNAPSHOT_MAX_MODEL_LEN", "2048"))
+GPU_MEMORY_UTILIZATION = float(os.environ.get("SNAPSHOT_GPU_MEMORY_UTILIZATION", "0.30"))
 
 
 class GenerateRequest(BaseModel):
@@ -86,6 +90,8 @@ async def main() -> None:
         AsyncEngineArgs(
             model=MODEL,
             enable_sleep_mode=True,
+            max_model_len=MAX_MODEL_LEN,
+            gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
         ),
         usage_context=UsageContext.LLM_CLASS,
     )
@@ -96,6 +102,9 @@ async def main() -> None:
         "snapshot-preflight",
     )
     print(f"vLLM pre-checkpoint output={text!r}", flush=True)
+    # Durable evidence that the engine served a generation before capture; the
+    # source container is killed by the dump, so logs alone are easy to lose.
+    CONTROL_DIR.joinpath("vllm-precheck").write_text(text + "\n", encoding="utf-8")
 
     await engine.pause_generation()
     await engine.sleep()

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -20,9 +20,6 @@ MODEL = os.environ["SNAPSHOT_MODEL"]
 # keeps the checkpoint artifact small. Override through the Pod template.
 MAX_MODEL_LEN = int(os.environ.get("VLLM_MAX_MODEL_LEN", "2048"))
 GPU_MEMORY_UTILIZATION = float(os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "0.30"))
-# Off: Qwen3 needs no custom model code, and remote code execution should be
-# an explicit opt-in. Set this to True only for checkpoints that ship their
-# own modeling code.
 TRUST_REMOTE_CODE = False
 
 

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -107,9 +107,6 @@ async def main() -> None:
         "snapshot-preflight",
     )
     print(f"vLLM pre-checkpoint output={text!r}", flush=True)
-    # Durable evidence that the engine served a generation before capture; the
-    # source container is killed by the dump, so logs alone are easy to lose.
-    CONTROL_DIR.joinpath("vllm-precheck").write_text(text + "\n", encoding="utf-8")
 
     await engine.pause_generation()
     await engine.sleep()

--- a/docs/guides/vllm/deployment.yaml
+++ b/docs/guides/vllm/deployment.yaml
@@ -33,9 +33,9 @@ spec:
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
-            - name: SNAPSHOT_MAX_MODEL_LEN
+            - name: VLLM_MAX_MODEL_LEN
               value: "2048"
-            - name: SNAPSHOT_GPU_MEMORY_UTILIZATION
+            - name: VLLM_GPU_MEMORY_UTILIZATION
               value: "0.30"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control

--- a/docs/guides/vllm/deployment.yaml
+++ b/docs/guides/vllm/deployment.yaml
@@ -37,6 +37,9 @@ spec:
               value: "2048"
             - name: VLLM_GPU_MEMORY_UTILIZATION
               value: "0.30"
+            # Remote code execution is opt-in; Qwen3 ships no custom code.
+            - name: VLLM_TRUST_REMOTE_CODE
+              value: "0"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
           ports:

--- a/docs/guides/vllm/deployment.yaml
+++ b/docs/guides/vllm/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
+            - name: SNAPSHOT_MAX_MODEL_LEN
+              value: "2048"
+            - name: SNAPSHOT_GPU_MEMORY_UTILIZATION
+              value: "0.30"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
           ports:

--- a/docs/guides/vllm/deployment.yaml
+++ b/docs/guides/vllm/deployment.yaml
@@ -37,9 +37,6 @@ spec:
               value: "2048"
             - name: VLLM_GPU_MEMORY_UTILIZATION
               value: "0.30"
-            # Remote code execution is opt-in; Qwen3 ships no custom code.
-            - name: VLLM_TRUST_REMOTE_CODE
-              value: "0"
             - name: SNAPSHOT_CONTROL_DIR
               value: /snapshot-control
           ports:


### PR DESCRIPTION
> Stacked on #170 (`feat/snapshot-restore-standby-env`). Review only the last commit until #170 merges; the base will then be retargeted to `main`.

### Summary

Makes the vLLM, SGLang, and TensorRT-LLM guide programs suitable as e2e workloads while keeping them valid user examples. Groundwork for per-framework checkpoint/restore e2e tests.

### Changes

- **Engine sizing via env with small single-GPU defaults** (source manifests set the same values explicitly):
  - vLLM: `SNAPSHOT_MAX_MODEL_LEN=2048`, `SNAPSHOT_GPU_MEMORY_UTILIZATION=0.30`
  - SGLang: `SNAPSHOT_PAGE_SIZE=16`, plus `tp_size=1`, `trust_remote_code=True`
  - TensorRT-LLM: `SNAPSHOT_MAX_NUM_TOKENS=1024`, `SNAPSHOT_MAX_BATCH_SIZE=1`, `SNAPSHOT_FREE_GPU_MEMORY_FRACTION=0.10` (previously hardcoded to the same values)
- **`<framework>-precheck` sentinel**: each program writes its pre-checkpoint generation output to `$SNAPSHOT_CONTROL_DIR/{vllm,sglang,trtllm}-precheck`. The dump kills the source container, so this gives tests durable evidence that the engine served a generation before capture without relying on logs.
- **Runtime image pins**: SGLang `lmsysorg/sglang@sha256:9e148f…` → `lmsysorg/sglang:v0.5.17-cu130-runtime`; TensorRT-LLM `1.3.0rc23` → `1.3.0rc24`. Dockerfile `ARG` defaults and the guide `export` lines updated together.
- Guide text updated for the new variables and sentinel files.

### Not in this PR

- Model-cache init container / PVC for vLLM and TensorRT-LLM (SGLang already has one) — follow-up.
- The e2e tests themselves — follow-up on top of this branch.

### Verification

- `python3 -m py_compile` on the three `app.py` — ok
- All three `deployment.yaml` parse
- No stale pins left (`grep sha256:9e148f|1.3.0rc23 docs/` — empty)
- Image bumps are **not** yet validated on a GPU cluster; if either breaks checkpoint/restore in the first e2e run, that single pin will be reverted.

### Review follow-ups

- Runtime bases pinned as `tag@sha256` (vLLM `v0.27.1@sha256:0a51ea5b…`, SGLang `v0.5.17-cu130-runtime@sha256:3ea7c6d7…`, TensorRT-LLM `1.3.0rc24@sha256:16a103b8…`), so the content-addressed e2e tag really pins the bits; the tag is kept for readability.
- Engine knobs renamed with framework prefixes: `VLLM_MAX_MODEL_LEN`, `VLLM_GPU_MEMORY_UTILIZATION`, `SGLANG_PAGE_SIZE`, `TRTLLM_MAX_NUM_TOKENS`, `TRTLLM_MAX_BATCH_SIZE`, `TRTLLM_FREE_GPU_MEMORY_FRACTION`. `SNAPSHOT_*` is now only the contract (`SNAPSHOT_CONTROL_DIR`, `SNAPSHOT_RESTORE_STANDBY`, `SNAPSHOT_MODEL`).
- SGLang `trust_remote_code` is an explicit toggle (`SGLANG_TRUST_REMOTE_CODE`, default `1`) with a comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SGLang, TensorRT-LLM, and vLLM guides with validated runtime versions, compatibility requirements, immutable image pinning, snapshot lifecycle details, API readiness guidance, and configuration instructions.
  * Documented remote-code execution defaults and when opt-in support may be required.

* **Improvements**
  * Deployments now support configurable page size, engine sizing, batching, model length, and GPU memory settings.
  * Clarified pre-checkpoint generation behavior and snapshot readiness requirements.
  * Added guidance for validating model and engine settings after configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->