### PR TITLE
ci: publish content-addressed framework e2e images

### DIFF
--- a/.github/workflows/e2e-framework-images.yaml
+++ b/.github/workflows/e2e-framework-images.yaml
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E Framework Images
+
+# Builds the framework guide images (docs/guides/<framework>/) that the
+# framework e2e tests run as workloads. Tags are content-addressed over the
+# image inputs (hack/framework-image-tag.py), so a run only builds when the
+# guide's Dockerfile or program changed and the resulting tag is not yet in
+# GHCR. Pull requests publish too: the tag is derived from the PR's content, so
+# the e2e run for that PR can pull exactly what it changed.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/guides/**'
+      - 'hack/framework-image-tag.py'
+      - '.github/workflows/e2e-framework-images.yaml'
+  pull_request:
+    paths:
+      - 'docs/guides/**'
+      - 'hack/framework-image-tag.py'
+      - '.github/workflows/e2e-framework-images.yaml'
+  workflow_dispatch:
+    inputs:
+      framework:
+        description: Framework to build (all, vllm, sglang, tensorrt-llm)
+        required: false
+        default: all
+        type: choice
+        options: [all, vllm, sglang, tensorrt-llm]
+      force:
+        description: Rebuild and push even if the tag is already published
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: e2e-framework-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.framework }} image
+    # Fork PRs cannot push to GHCR with the default token; they still get the
+    # tag resolution step below so the failure is explicit rather than a 403.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [vllm, sglang, tensorrt-llm]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Skip frameworks not selected by dispatch
+        id: selected
+        env:
+          SELECTED: ${{ inputs.framework || 'all' }}
+        run: |
+          set -euo pipefail
+          if [[ "${SELECTED}" == "all" || "${SELECTED}" == "${{ matrix.framework }}" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.framework }}: dispatch selected ${SELECTED}"
+          fi
+
+      - name: Resolve image tag
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        id: image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 hack/framework-image-tag.py "${{ matrix.framework }}" \
+            --check --allow-missing --github-output
+
+      - name: Report already-published image
+        if: ${{ steps.selected.outputs.run == 'true' && steps.image.outputs.exists == 'true' && !inputs.force }}
+        run: |
+          echo "::notice::${{ steps.image.outputs.image }} is already published; nothing to build."
+
+      # The runtime base images are 10-30 GB. Reclaim the preinstalled toolchains
+      # the hosted runner ships with so the build does not run out of disk.
+      - name: Free runner disk space
+        if: ${{ steps.selected.outputs.run == 'true' && (steps.image.outputs.exists != 'true' || inputs.force) }}
+        run: |
+          set -euo pipefail
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          df -h / | tail -1
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.selected.outputs.run == 'true' && (steps.image.outputs.exists != 'true' || inputs.force) }}
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to GHCR
+        if: ${{ steps.selected.outputs.run == 'true' && (steps.image.outputs.exists != 'true' || inputs.force) }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # --platform=linux/amd64: the guide Dockerfiles exit 1 on other arches.
+      - name: Build and push image
+        if: ${{ steps.selected.outputs.run == 'true' && (steps.image.outputs.exists != 'true' || inputs.force) }}
+        timeout-minutes: 75
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          DOCKERFILE: ${{ steps.image.outputs.dockerfile }}
+          CONTEXT: ${{ steps.image.outputs.context }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform=linux/amd64 \
+            --file "${DOCKERFILE}" \
+            --tag "${IMAGE}" \
+            --push \
+            --cache-from="type=gha,scope=e2e-${{ matrix.framework }}" \
+            --cache-to="type=gha,scope=e2e-${{ matrix.framework }},mode=max" \
+            "${CONTEXT}"
+          echo "::notice::Published ${IMAGE}"

--- a/.github/workflows/e2e-framework-images.yaml
+++ b/.github/workflows/e2e-framework-images.yaml
@@ -12,7 +12,12 @@ name: E2E Framework Images
 
 on:
   push:
-    branches: [main]
+    # main, plus the copy-pr-bot mirror branches: the mirror push is the
+    # trusted event for every PR (including forks), and it is what the
+    # framework e2e workflow also runs on.
+    branches:
+      - main
+      - 'pull-request/[0-9]+'
     paths:
       - 'docs/guides/**'
       - 'hack/framework-image-tag.py'
@@ -47,8 +52,9 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.framework }} image
-    # Fork PRs cannot push to GHCR with the default token; they still get the
-    # tag resolution step below so the failure is explicit rather than a 403.
+    # A fork's pull_request event has no GHCR write token, so skip the whole
+    # job for it; the copy-pr-bot mirror push (push trigger above) builds the
+    # fork PR's image instead.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -130,7 +136,5 @@ jobs:
             --file "${DOCKERFILE}" \
             --tag "${IMAGE}" \
             --push \
-            --cache-from="type=gha,scope=e2e-${{ matrix.framework }}" \
-            --cache-to="type=gha,scope=e2e-${{ matrix.framework }},mode=max" \
             "${CONTEXT}"
           echo "::notice::Published ${IMAGE}"

--- a/.github/workflows/e2e-framework-images.yaml
+++ b/.github/workflows/e2e-framework-images.yaml
@@ -131,10 +131,16 @@ jobs:
           CONTEXT: ${{ steps.image.outputs.context }}
         run: |
           set -euo pipefail
+          # Provenance labels are not hash inputs, so they never change the
+          # content tag; they make a published image self-describing
+          # (docker inspect) instead of requiring the tag to be recomputed
+          # against candidate commits.
           docker buildx build \
             --platform=linux/amd64 \
             --file "${DOCKERFILE}" \
             --tag "${IMAGE}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
             --push \
             "${CONTEXT}"
           echo "::notice::Published ${IMAGE}"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -134,3 +134,31 @@ the test verifies that the restored process and files report the source token,
 not the restore token. The worker also appends periodic observations to
 `/tmp/e2e-state/observations.log`; the observation count is only a liveness
 check that the restored process continues running after restore.
+
+## Framework Images
+
+The framework e2e workloads are the guide programs under
+`docs/guides/<framework>/` (`vllm`, `sglang`, `tensorrt-llm`). Their images are
+published to `ghcr.io/ai-dynamo/snapshot/e2e-<framework>` with a
+content-addressed tag: a digest over the guide's Dockerfile and the files it
+copies. A guide change yields a new tag; unrelated commits reuse the published
+image, so nothing is rebuilt per commit.
+
+Resolve the image for the checked-out tree, and verify it is published:
+
+```bash
+python3 hack/framework-image-tag.py vllm
+GH_TOKEN="$(gh auth token)" python3 hack/framework-image-tag.py vllm --check
+```
+
+The `E2E Framework Images` workflow (`.github/workflows/e2e-framework-images.yaml`)
+builds and pushes missing tags on pushes to `main` and on pull requests that
+touch `docs/guides/**`. Dispatch it with `force=true` to rebuild a tag that
+already exists. To build locally instead:
+
+```bash
+IMAGE="$(python3 hack/framework-image-tag.py vllm)"
+docker buildx build --platform linux/amd64 \
+  --file docs/guides/vllm/Dockerfile.vllm \
+  --tag "$IMAGE" --push docs/guides/vllm
+```

--- a/hack/framework-image-tag.py
+++ b/hack/framework-image-tag.py
@@ -54,7 +54,13 @@ def image_inputs(framework: str) -> list[Path]:
 
 
 def dockerfile(framework: str) -> Path:
-    return image_inputs(framework)[0]
+    # Named, not positional: the hash-input tuple has no ordering contract,
+    # and building from the wrong file would still publish a validly tagged
+    # image.
+    path = GUIDES_DIR / framework / f"Dockerfile.{framework}"
+    if path.name not in FRAMEWORKS[framework]:
+        raise ValueError(f"{path.name} is not a hash input for {framework}")
+    return path
 
 
 def inputs_digest(framework: str) -> str:

--- a/hack/framework-image-tag.py
+++ b/hack/framework-image-tag.py
@@ -30,7 +30,7 @@ import urllib.request
 from pathlib import Path
 
 GITHUB_API_VERSION = "2022-11-28"
-MAX_PAGES = 5
+PAGE_SIZE = 100
 ORG = "ai-dynamo"
 REGISTRY = f"ghcr.io/{ORG}/snapshot"
 TAG_LENGTH = 12
@@ -81,10 +81,15 @@ def image_ref(framework: str) -> tuple[str, str]:
 def package_has_tag(package: str, tag: str, headers: dict[str, str]) -> bool:
     encoded = urllib.parse.quote(package, safe="")
 
-    for page in range(1, MAX_PAGES + 1):
+    # Page until the listing is exhausted: content-addressed tags accumulate
+    # (one per guide change, never pruned), so a fixed page budget would
+    # eventually report a still-valid tag as unpublished.
+    page = 0
+    while True:
+        page += 1
         url = (
             f"https://api.github.com/orgs/{ORG}/packages/container/"
-            f"{encoded}/versions?per_page=100&page={page}"
+            f"{encoded}/versions?per_page={PAGE_SIZE}&page={page}"
         )
         request = urllib.request.Request(url, headers=headers)
         try:
@@ -97,14 +102,14 @@ def package_has_tag(package: str, tag: str, headers: dict[str, str]) -> bool:
             raise
 
         if not versions:
-            break
+            return False
 
         for version in versions:
             version_tags = version.get("metadata", {}).get("container", {}).get("tags", [])
             if tag in version_tags:
                 return True
-
-    return False
+        if len(versions) < PAGE_SIZE:
+            return False
 
 
 def github_headers() -> dict[str, str]:
@@ -175,11 +180,8 @@ def main() -> int:
             f"for {args.framework} (it builds docs/guides/{args.framework}/) or "
             "build and push it manually."
         )
-        if args.allow_missing:
-            print(message, file=sys.stderr)
-            return 0
         print(message, file=sys.stderr)
-        return 1
+        return 0 if args.allow_missing else 1
     return 0
 
 

--- a/hack/framework-image-tag.py
+++ b/hack/framework-image-tag.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve the content-addressed e2e image for a framework guide.
+
+The framework guides under docs/guides/<framework>/ are the workloads the
+framework e2e tests run. Their images are expensive to build (the runtime base
+images are tens of gigabytes), so they are published once per distinct set of
+image inputs rather than per commit: the tag is a digest over the Dockerfile
+and the files it copies. A guide change produces a new tag; an unrelated commit
+reuses the published image.
+
+    python3 hack/framework-image-tag.py vllm            # print the image ref
+    python3 hack/framework-image-tag.py vllm --check    # fail if unpublished
+
+With --github-output the script also appends image=, tag=, and exists= lines to
+$GITHUB_OUTPUT so a workflow can decide whether to build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+GITHUB_API_VERSION = "2022-11-28"
+MAX_PAGES = 5
+ORG = "ai-dynamo"
+REGISTRY = f"ghcr.io/{ORG}/snapshot"
+TAG_LENGTH = 12
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUIDES_DIR = REPO_ROOT / "docs" / "guides"
+
+# Files that end up in the image, per framework guide directory. The Dockerfile
+# carries the runtime base image pin, so a base bump changes the tag too.
+# Deployment manifests are deliberately excluded: they configure the Pod, not
+# the image, and must not force a rebuild.
+FRAMEWORKS: dict[str, tuple[str, ...]] = {
+    "vllm": ("Dockerfile.vllm", "app.py"),
+    "sglang": ("Dockerfile.sglang", "app.py"),
+    "tensorrt-llm": ("Dockerfile.tensorrt-llm", "app.py"),
+}
+
+
+def image_inputs(framework: str) -> list[Path]:
+    return [GUIDES_DIR / framework / name for name in FRAMEWORKS[framework]]
+
+
+def dockerfile(framework: str) -> Path:
+    return image_inputs(framework)[0]
+
+
+def inputs_digest(framework: str) -> str:
+    digest = hashlib.sha256()
+    for path in image_inputs(framework):
+        # Include the relative name so renaming a file changes the tag even if
+        # its content does not.
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()[:TAG_LENGTH]
+
+
+def package_name(framework: str) -> str:
+    return f"snapshot/e2e-{framework}"
+
+
+def image_ref(framework: str) -> tuple[str, str]:
+    tag = inputs_digest(framework)
+    return f"{REGISTRY}/e2e-{framework}:{tag}", tag
+
+
+def package_has_tag(package: str, tag: str, headers: dict[str, str]) -> bool:
+    encoded = urllib.parse.quote(package, safe="")
+
+    for page in range(1, MAX_PAGES + 1):
+        url = (
+            f"https://api.github.com/orgs/{ORG}/packages/container/"
+            f"{encoded}/versions?per_page=100&page={page}"
+        )
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                versions = json.load(response)
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                # The package itself does not exist yet: nothing published.
+                return False
+            raise
+
+        if not versions:
+            break
+
+        for version in versions:
+            version_tags = version.get("metadata", {}).get("container", {}).get("tags", [])
+            if tag in version_tags:
+                return True
+
+    return False
+
+
+def github_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def write_github_output(values: dict[str, str]) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with open(github_output, "a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("framework", choices=sorted(FRAMEWORKS))
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="query GHCR and fail unless the image is published",
+    )
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="with --check, report instead of failing when the image is missing",
+    )
+    parser.add_argument(
+        "--github-output",
+        action="store_true",
+        help="append image=, tag=, exists= (and dockerfile=, context=) to $GITHUB_OUTPUT",
+    )
+    args = parser.parse_args()
+
+    missing_inputs = [str(path) for path in image_inputs(args.framework) if not path.is_file()]
+    if missing_inputs:
+        print(f"Missing image inputs: {', '.join(missing_inputs)}", file=sys.stderr)
+        return 2
+
+    image, tag = image_ref(args.framework)
+    exists: bool | None = None
+    if args.check:
+        exists = package_has_tag(package_name(args.framework), tag, github_headers())
+
+    if args.github_output:
+        write_github_output(
+            {
+                "image": image,
+                "tag": tag,
+                "exists": "true" if exists else "false",
+                "dockerfile": str(dockerfile(args.framework).relative_to(REPO_ROOT)),
+                "context": str((GUIDES_DIR / args.framework).relative_to(REPO_ROOT)),
+            }
+        )
+
+    print(image)
+    if exists is False:
+        message = (
+            f"{image} is not published. Run the 'E2E Framework Images' workflow "
+            f"for {args.framework} (it builds docs/guides/{args.framework}/) or "
+            "build and push it manually."
+        )
+        if args.allow_missing:
+            print(message, file=sys.stderr)
+            return 0
+        print(message, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/framework-image-tag.py
+++ b/hack/framework-image-tag.py
@@ -23,6 +23,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -38,19 +39,69 @@ TAG_LENGTH = 12
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GUIDES_DIR = REPO_ROOT / "docs" / "guides"
 
-# Files that end up in the image, per framework guide directory. The Dockerfile
-# carries the runtime base image pin, so a base bump changes the tag too.
-# Deployment manifests are deliberately excluded: they configure the Pod, not
-# the image, and must not force a rebuild.
+# FRAMEWORKS is the contract for tag correctness: the tag is a digest over
+# exactly these files, so a file that reaches the image but is missing here
+# lets CI reuse a stale image for a changed guide. Every file in a guide
+# directory must be listed either here (image input) or in EXCLUDED (never
+# part of the image); validate_guide_files() fails on anything unclassified,
+# and validate_dockerfile_copies() fails if a Dockerfile COPY/ADD source is not
+# an input. The Dockerfile carries the runtime base image pin, so a base bump
+# changes the tag too.
 FRAMEWORKS: dict[str, tuple[str, ...]] = {
     "vllm": ("Dockerfile.vllm", "app.py"),
     "sglang": ("Dockerfile.sglang", "app.py"),
     "tensorrt-llm": ("Dockerfile.tensorrt-llm", "app.py"),
 }
 
+# Files in a guide directory that never enter the image. Deployment manifests
+# configure the Pod, not the image, and must not force a rebuild.
+EXCLUDED: dict[str, tuple[str, ...]] = {
+    "vllm": ("deployment.yaml", "restore-deployment.yaml"),
+    "sglang": (
+        "deployment.yaml",
+        "restore-deployment.yaml",
+        "model-cache-pvc.yaml",
+    ),
+    "tensorrt-llm": ("deployment.yaml", "restore-deployment.yaml"),
+}
+
+COPY_INSTRUCTION = re.compile(r"^\s*(?:COPY|ADD)\s+(?P<args>.+?)\s*$", re.IGNORECASE)
+
 
 def image_inputs(framework: str) -> list[Path]:
     return [GUIDES_DIR / framework / name for name in FRAMEWORKS[framework]]
+
+
+def validate_guide_files(framework: str) -> list[str]:
+    """Names of files in the guide directory that are neither inputs nor excluded."""
+    classified = set(FRAMEWORKS[framework]) | set(EXCLUDED[framework])
+    guide_dir = GUIDES_DIR / framework
+    present = {path.name for path in guide_dir.iterdir() if path.is_file()}
+    return sorted(present - classified)
+
+
+def validate_dockerfile_copies(framework: str) -> list[str]:
+    """COPY/ADD sources in the Dockerfile that are not hash inputs.
+
+    Sources from another build stage (--from=) do not come from the guide
+    directory and are skipped. Only single-file sources are supported; a
+    directory or glob would need its members enumerated in FRAMEWORKS.
+    """
+    inputs = set(FRAMEWORKS[framework])
+    unlisted: list[str] = []
+    for line in dockerfile(framework).read_text(encoding="utf-8").splitlines():
+        match = COPY_INSTRUCTION.match(line)
+        if not match:
+            continue
+        tokens = match.group("args").split()
+        flags = [token for token in tokens if token.startswith("--")]
+        if any(flag.startswith("--from=") for flag in flags):
+            continue
+        operands = [token for token in tokens if not token.startswith("--")]
+        for source in operands[:-1]:  # the last operand is the destination
+            if source.lstrip("./") not in inputs:
+                unlisted.append(source)
+    return unlisted
 
 
 def dockerfile(framework: str) -> Path:
@@ -161,6 +212,27 @@ def main() -> int:
     missing_inputs = [str(path) for path in image_inputs(args.framework) if not path.is_file()]
     if missing_inputs:
         print(f"Missing image inputs: {', '.join(missing_inputs)}", file=sys.stderr)
+        return 2
+
+    # Both checks run on every invocation, so they fail the PR-time --check
+    # step and not only a later build.
+    unclassified = validate_guide_files(args.framework)
+    if unclassified:
+        print(
+            f"Unclassified files in docs/guides/{args.framework}/: "
+            f"{', '.join(unclassified)}. Add each to FRAMEWORKS (it is copied into "
+            "the image) or to EXCLUDED (it is not) in hack/framework-image-tag.py.",
+            file=sys.stderr,
+        )
+        return 2
+    unlisted = validate_dockerfile_copies(args.framework)
+    if unlisted:
+        print(
+            f"Dockerfile.{args.framework} copies {', '.join(unlisted)} but "
+            "FRAMEWORKS does not list it as an image input; the tag would not "
+            "change when it does.",
+            file=sys.stderr,
+        )
         return 2
 
     image, tag = image_ref(args.framework)


### PR DESCRIPTION
> Stacked on #171 → #170 (stack #172). Review only the last commit until the lower PRs merge.

### Summary

Publishes the framework guide images (`docs/guides/{vllm,sglang,tensorrt-llm}/`) that the upcoming framework e2e tests run as workloads. Images are content-addressed, so they are built once per distinct set of image inputs, not per commit.

### Changes

- `hack/framework-image-tag.py <framework> [--check] [--allow-missing] [--github-output]`
  - Resolves `ghcr.io/ai-dynamo/snapshot/e2e-<framework>:<sha256[:12]>` over the guide Dockerfile (which carries the runtime base pin) and the files it copies. Deployment manifests are excluded so Pod-level edits never force a rebuild.
  - `--check` queries GHCR (404 on a not-yet-created package = not published) and fails unless the tag exists; `--github-output` appends `image/tag/exists/dockerfile/context`.
- `.github/workflows/e2e-framework-images.yaml`
  - Matrix `vllm | sglang | tensorrt-llm`, `ubuntu-latest`, 90-min cap. Resolves the tag → skips when published → frees hosted-runner disk (runtime bases are 10–30 GB) → `docker buildx build --platform linux/amd64 --push` with `type=gha` cache.
  - Triggers: `push` to `main` and `pull_request` on `docs/guides/**`, the script, and the workflow; `workflow_dispatch` with `framework` filter and `force`. Same-repo PRs publish (the tag is derived from the PR's content); fork PRs are skipped since the default token cannot push.
- `e2e/README.md`: "Framework Images" section (scheme, resolve/check, local build).

### Verification

- Script: deterministic tags for all three frameworks; `--check` correctly reports unpublished (exit 1 strict, 0 with `--allow-missing`); `GITHUB_OUTPUT` lines verified.
- Workflow YAML parses; first real run is this PR's own `E2E Framework Images` check — it will also be the first validation of the SGLang `v0.5.17-cu130-runtime` and TensorRT-LLM `1.3.0rc24` bumps from #171 building at all.

### Risks

- Hosted-runner disk: TensorRT-LLM's base is the largest. If the build still runs out of space after the cleanup step, the fallback is a larger runner label for that matrix entry.
- `nvcr.io/nvidia/tensorrt-llm/release` is pulled anonymously; if NGC requires auth for this tag the job will fail at `FROM` and a pull secret must be added.

### Review follow-ups

- `package_has_tag` pages the GHCR listing to exhaustion (early exit on match) instead of a fixed 5 pages, so accumulated content-addressed tags cannot push a valid tag out of the window.
- The images workflow also builds on pushes to `pull-request/[0-9]+` mirror branches, so fork PRs that touch a guide get an image from the trusted mirror push; the fork-PR job `if:` comment now describes what it does (early exit for the untrusted event).
- Dropped the buildx `type=gha` cache (only the app layers are new; `mode=max` uploads competed with the Go caches).
- "Not published" message printed once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated publishing of framework guide images for vLLM, SGLang, and TensorRT-LLM.
  - Added options to build all frameworks or select an individual framework, with an option to force rebuilding.
  - Added content-based image tags to identify images built from specific guide content.
  - Added checks to avoid rebuilding images that are already published.

- **Documentation**
  - Added guidance for resolving framework images, understanding image tags, and building images locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->