### PR TITLE
ci(e2e): run framework checkpoint/restore tests on pull requests and nightly

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mirrors approved pull requests into same-repo `pull-request/<number>` branches.
+# The GPU runners admit only trusted events (push, schedule, workflow_dispatch),
+# not pull_request, so GPU-backed workflows trigger on pushes to those branches.
+# Maintainers' PRs are mirrored automatically; others need `/ok to test <sha>`.
+enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,23 @@ jobs:
             **/go.sum
             go.work.sum
       - run: make check
+
+  # Cluster-free e2e checks: the workload scripts and the framework guide
+  # manifests against the restore-pod contract. Seconds to run, so they gate
+  # every pull request rather than only the GPU-gated e2e workflows.
+  e2e-static:
+    runs-on: ubuntu-latest
+    env:
+      UV_LINK_MODE: copy
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.10.11"
+          checksum: "5a360b0de092ddf4131f5313d0411b48c4e95e8107e40c3f8f2e9fcb636b3583"
+          enable-cache: "false"
+          download-from-astral-mirror: "false"
+      - run: |
+          uv run --locked --project e2e pytest \
+            e2e/tests/test_framework_manifests.py \
+            e2e/tests/test_workload_scripts.py -vv

--- a/.github/workflows/e2e-frameworks.yaml
+++ b/.github/workflows/e2e-frameworks.yaml
@@ -69,13 +69,12 @@ permissions:
   packages: read
 
 jobs:
-  # Datadog's GPU monitoring (system-probe + NVML) attaches to GPU processes
-  # on the node and is a suspected interferer for CRIU/CUDA checkpoint and
-  # restore. Switch it off on the host cluster for the whole run, then restore
-  # it in a separate always-run job: the framework jobs run in parallel, so a
-  # per-job toggle would re-enable it under a sibling still restoring. The
-  # script keeps its state on the Datadog resources, so overlapping runs
-  # hand off correctly (see hack/datadog-gpu-monitoring.py).
+  # Datadog's GPU monitoring (system-probe + NVML) is a suspected interferer
+  # for CRIU/CUDA checkpoint and restore. Switch it off for the whole run in
+  # one gate, restore it in a separate always-run job -- a per-job toggle
+  # would re-enable it under a sibling still restoring (see
+  # hack/datadog-gpu-monitoring.py, which tracks state on the resources so
+  # overlapping runs hand off correctly).
   datadog-gate:
     name: datadog gpu monitoring off
     runs-on: prod-deploy-tester-v1
@@ -108,26 +107,21 @@ jobs:
     name: ${{ matrix.framework }}
     needs: datadog-gate
     runs-on: prod-deploy-tester-v1
-    # Sum of this job's own step timeout-minutes below (117 min, dominated by
-    # the 50-min test step) plus margin for the untimed steps and scheduling
-    # overhead. Must stay above that sum: a job-level timeout kills the whole
+    # Above the sum of this job's own step timeout-minutes (117, dominated by
+    # the 50-min test step) plus margin: a job-level timeout kills the whole
     # job, including the failure() diagnostics upload and always() vCluster
-    # cleanup below, which is exactly the safety net a slow run (the scenario
-    # this budget exists for) needs most. No image-build wait step anymore --
-    # the guides run the upstream framework images unmodified.
+    # cleanup, which is exactly the safety net a slow run needs most.
     timeout-minutes: 140
     strategy:
       fail-fast: false
       matrix:
         framework: [vllm, sglang, tensorrt-llm]
     concurrency:
-      # PR mirror branches: one group per branch (pull-request/N), so a new
-      # push to the PR cancels the stale run. Scheduled and dispatched runs
-      # share a fixed 'nightly' group per framework instead of github.run_id,
-      # so an overlapping nightly + workflow_dispatch (or two dispatches)
-      # queue rather than run concurrently on this GPU-scarce shared cluster
-      # -- cancel-in-progress stays false for these so a queued run still
-      # executes rather than being dropped.
+      # PR mirror branches get one group per branch, so a new push cancels
+      # the stale run. Scheduled/dispatched runs share a fixed 'nightly'
+      # group per framework so they queue instead of racing on this
+      # GPU-scarce cluster -- cancel-in-progress stays false there so a
+      # queued run executes instead of being dropped.
       group: snapshot-e2e-frameworks-${{ startsWith(github.ref, 'refs/heads/pull-request/') && github.ref_name || 'nightly' }}-${{ matrix.framework }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
     env:
@@ -149,13 +143,10 @@ jobs:
       SNAPSHOT_E2E_READY_TIMEOUT_SECONDS: "480"
       SNAPSHOT_E2E_RESULT_FILE: ${{ github.workspace }}/.snapshot-e2e-setup-result.json
       SNAPSHOT_E2E_FRAMEWORK: ${{ matrix.framework }}
-      # Shared CI model cache (Hugging Face cache layout on an NFS export):
-      # pods in this cluster cannot resolve huggingface.co, and downloading
-      # weights per run would cost minutes anyway. Set the repository
-      # variables SNAPSHOT_E2E_MODEL_CACHE_SERVER / _PATH to override; the
-      # literals below are this CI cluster's export and are only a fallback
-      # until the variables exist (the "Report model cache" step says which
-      # is in use).
+      # Shared CI model cache (HF cache layout on an NFS export): pods here
+      # can't resolve huggingface.co, and per-run downloads cost minutes
+      # anyway. Repository variables override the literals below, which are
+      # only a fallback until those variables exist.
       SNAPSHOT_E2E_MODEL_CACHE_SERVER: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_SERVER || 'dynamoinfracimodelcache.file.core.windows.net' }}
       SNAPSHOT_E2E_MODEL_CACHE_PATH: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_PATH || '/dynamoinfracimodelcache/models' }}
       SNAPSHOT_E2E_MODEL_CACHE_FROM_VARS: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_SERVER != '' && vars.SNAPSHOT_E2E_MODEL_CACHE_PATH != '' }}

--- a/.github/workflows/e2e-frameworks.yaml
+++ b/.github/workflows/e2e-frameworks.yaml
@@ -1,0 +1,430 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E Framework Tests
+
+# Checkpoint/restore of the inference framework guide workloads (vLLM, SGLang,
+# TensorRT-LLM), one vCluster per framework. The cluster setup mirrors
+# e2e.yaml; the differences are the 64Gi checkpoint PVC (framework artifacts
+# are multi-GB), the framework image resolution, and the diagnostics upload.
+#
+# Pull requests are tested through their copy-pr-bot mirror branch
+# (pull-request/<number>, see .github/copy-pr-bot.yaml): the GPU runners admit
+# push, schedule, and workflow_dispatch events but reject pull_request.
+#
+# Known-red on this gate, kept red on purpose (not this workflow's bug):
+#   - vLLM: intermittent CRIU restore segfault ("criu swrk failed: signal:
+#     segmentation fault"), a product defect in criu itself, not this repo's
+#     restore wiring -- see PR #179's discussion for the current investigation.
+#   - SGLang: occasional post-restore hang in resume_memory_occupation();
+#     largely resolved by switching to PauseGenerationReqInput(mode="retract")
+#     (this PR), but not eliminated.
+#   - TensorRT-LLM has been consistently green.
+# Do not re-diagnose these from scratch on a failing run; check whether the
+# failure matches one of the above first.
+
+on:
+  push:
+    branches:
+      - 'pull-request/[0-9]+'
+    # Only changes to the workloads, the tests, and this wiring gate a PR:
+    # mirror branches have no operator/agent images of their own, so a run
+    # here tests main's Snapshot and would say nothing about an agent/operator
+    # change. Those are covered nightly against main. The framework fixtures
+    # (app.py, deployment.yaml, ...) live under e2e/, not docs/guides/, so
+    # e2e/** alone covers them.
+    paths:
+      - 'e2e/**'
+      - 'hack/**'
+      - '.github/workflows/e2e-frameworks.yaml'
+  schedule:
+    # 01:00 Pacific Standard Time, after the nightly e2e.yaml run.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      framework:
+        description: Framework to test (all, vllm, sglang, tensorrt-llm)
+        required: false
+        default: all
+        type: choice
+        options: [all, vllm, sglang, tensorrt-llm]
+      snapshot_tag:
+        description: >-
+          Operator/agent image tag to install. Leave empty to resolve from the
+          commit under test (pull-request/* mirror branches fall back to the
+          newest main build when the commit has no published images).
+        required: false
+        type: string
+      datadog_gpu_monitoring:
+        description: >-
+          Datadog GPU monitoring on the host cluster during the run. "disable"
+          turns it off before the tests and back on afterwards if it was on.
+        required: false
+        default: disable
+        type: choice
+        options: [disable, leave]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # Datadog's GPU monitoring (system-probe + NVML) attaches to GPU processes
+  # on the node and is a suspected interferer for CRIU/CUDA checkpoint and
+  # restore. Switch it off on the host cluster for the whole run, then restore
+  # it in a separate always-run job: the framework jobs run in parallel, so a
+  # per-job toggle would re-enable it under a sibling still restoring. The
+  # script keeps its state on the Datadog resources, so overlapping runs
+  # hand off correctly (see hack/datadog-gpu-monitoring.py).
+  datadog-gate:
+    name: datadog gpu monitoring off
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 5
+    concurrency:
+      group: snapshot-e2e-frameworks-datadog-gate
+      cancel-in-progress: false
+    outputs:
+      mode: ${{ steps.mode.outputs.mode }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve mode
+        id: mode
+        env:
+          MODE: ${{ inputs.datadog_gpu_monitoring || 'disable' }}
+        run: echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+
+      - name: Report Datadog GPU monitoring state
+        run: python3 hack/datadog-gpu-monitoring.py status
+
+      - name: Disable Datadog GPU monitoring for this run
+        if: ${{ steps.mode.outputs.mode == 'disable' }}
+        run: python3 hack/datadog-gpu-monitoring.py disable --holder "${{ github.run_id }}-${{ github.run_attempt }}"
+
+  e2e:
+    name: ${{ matrix.framework }}
+    needs: datadog-gate
+    runs-on: prod-deploy-tester-v1
+    # Sum of this job's own step timeout-minutes below (117 min, dominated by
+    # the 50-min test step) plus margin for the untimed steps and scheduling
+    # overhead. Must stay above that sum: a job-level timeout kills the whole
+    # job, including the failure() diagnostics upload and always() vCluster
+    # cleanup below, which is exactly the safety net a slow run (the scenario
+    # this budget exists for) needs most. No image-build wait step anymore --
+    # the guides run the upstream framework images unmodified.
+    timeout-minutes: 140
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [vllm, sglang, tensorrt-llm]
+    concurrency:
+      # PR mirror branches: one group per branch (pull-request/N), so a new
+      # push to the PR cancels the stale run. Scheduled and dispatched runs
+      # share a fixed 'nightly' group per framework instead of github.run_id,
+      # so an overlapping nightly + workflow_dispatch (or two dispatches)
+      # queue rather than run concurrently on this GPU-scarce shared cluster
+      # -- cancel-in-progress stays false for these so a queued run still
+      # executes rather than being dropped.
+      group: snapshot-e2e-frameworks-${{ startsWith(github.ref, 'refs/heads/pull-request/') && github.ref_name || 'nightly' }}-${{ matrix.framework }}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
+    env:
+      HOST_NAMESPACE: snapshot-e2e-fw-${{ matrix.framework }}-${{ github.run_id }}-${{ github.run_attempt }}
+      VCLUSTER_NAME: snapshot-e2e-fw-${{ matrix.framework }}-${{ github.run_id }}-${{ github.run_attempt }}
+      TEST_NAMESPACE: snapshot-e2e
+      SNAPSHOT_E2E_HOST_NAMESPACE: snapshot-e2e-fw-${{ matrix.framework }}-${{ github.run_id }}-${{ github.run_attempt }}
+      SNAPSHOT_E2E_VCLUSTER_NAME: snapshot-e2e-fw-${{ matrix.framework }}-${{ github.run_id }}-${{ github.run_attempt }}
+      SNAPSHOT_E2E_TEST_NAMESPACE: snapshot-e2e
+      SNAPSHOT_E2E_TARGET_KUBECONFIG: ${{ github.workspace }}/.kubeconfig-snapshot-e2e
+      SNAPSHOT_E2E_SNAPSHOT_RELEASE: snapshot
+      SNAPSHOT_E2E_PVC_NAME: snapshot-pvc
+      SNAPSHOT_E2E_PVC_SIZE: 64Gi
+      SNAPSHOT_E2E_STORAGE_CLASS: azurefile-csi
+      SNAPSHOT_E2E_MODE: vcluster
+      SNAPSHOT_E2E_VCLUSTER_K8S_VERSION: v1.32.13
+      SNAPSHOT_E2E_VCLUSTER_LOCAL_PORT: "8443"
+      SNAPSHOT_E2E_HELM_TIMEOUT: 6m
+      SNAPSHOT_E2E_READY_TIMEOUT_SECONDS: "480"
+      SNAPSHOT_E2E_RESULT_FILE: ${{ github.workspace }}/.snapshot-e2e-setup-result.json
+      SNAPSHOT_E2E_FRAMEWORK: ${{ matrix.framework }}
+      # Shared CI model cache (Hugging Face cache layout on an NFS export):
+      # pods in this cluster cannot resolve huggingface.co, and downloading
+      # weights per run would cost minutes anyway. Set the repository
+      # variables SNAPSHOT_E2E_MODEL_CACHE_SERVER / _PATH to override; the
+      # literals below are this CI cluster's export and are only a fallback
+      # until the variables exist (the "Report model cache" step says which
+      # is in use).
+      SNAPSHOT_E2E_MODEL_CACHE_SERVER: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_SERVER || 'dynamoinfracimodelcache.file.core.windows.net' }}
+      SNAPSHOT_E2E_MODEL_CACHE_PATH: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_PATH || '/dynamoinfracimodelcache/models' }}
+      SNAPSHOT_E2E_MODEL_CACHE_FROM_VARS: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_SERVER != '' && vars.SNAPSHOT_E2E_MODEL_CACHE_PATH != '' }}
+      PYTHONUNBUFFERED: "1"
+      UV_LINK_MODE: copy
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Skip frameworks not selected by dispatch
+        id: selected
+        env:
+          SELECTED: ${{ inputs.framework || 'all' }}
+        run: |
+          set -euo pipefail
+          if [[ "${SELECTED}" == "all" || "${SELECTED}" == "${{ matrix.framework }}" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.framework }}: dispatch selected ${SELECTED}"
+          fi
+
+      - name: Capture host kubeconfig
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        id: host
+        run: |
+          echo "kubeconfig=${KUBECONFIG:-}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install vCluster CLI
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/install-vcluster-cli
+
+      - name: Cleanup stale e2e namespaces
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch="$(date -u -d '12 hours ago' +%s)"
+          kubectl get ns -l snapshot-e2e=true \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.creationTimestamp}{"\n"}{end}' |
+          while IFS=$'\t' read -r namespace created_at; do
+            if [[ -z "${namespace}" ]]; then
+              continue
+            fi
+            if [[ "${namespace}" == "${HOST_NAMESPACE}" ]]; then
+              echo "Keeping current namespace ${namespace}"
+              continue
+            fi
+
+            created_epoch="$(date -u -d "${created_at}" +%s)"
+            if (( created_epoch >= cutoff_epoch )); then
+              echo "Keeping recent namespace ${namespace} created at ${created_at}"
+              continue
+            fi
+
+            echo "Deleting stale Snapshot e2e namespace ${namespace} created at ${created_at}"
+            helm uninstall vcluster-hpm -n "${namespace}" || true
+            vcluster delete "${namespace}" --namespace "${namespace}" || true
+            kubectl delete namespace "${namespace}" --ignore-not-found --wait=false || true
+          done
+
+      - name: Install Python tooling (ARM64)
+        if: ${{ steps.selected.outputs.run == 'true' && runner.arch == 'ARM64' }}
+        timeout-minutes: 3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.10.11"
+          checksum: "23003df007937dd607409c8ddf010baa82bad2673e60e254632ca5b04edcce13"
+          enable-cache: "false"
+          download-from-astral-mirror: "false"
+
+      - name: Install Python tooling (X64)
+        if: ${{ steps.selected.outputs.run == 'true' && runner.arch == 'X64' }}
+        timeout-minutes: 3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.10.11"
+          checksum: "5a360b0de092ddf4131f5313d0411b48c4e95e8107e40c3f8f2e9fcb636b3583"
+          enable-cache: "false"
+          download-from-astral-mirror: "false"
+
+      - name: Resolve Snapshot image tag
+        if: ${{ steps.selected.outputs.run == 'true' && (inputs.snapshot_tag || '') == '' }}
+        timeout-minutes: 3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # push-artifacts publishes only main/release, so any other ref (a
+          # pull-request/* mirror branch, or a feature branch dispatched by
+          # hand) normally has no images of its own; fall back to main's,
+          # loudly. main and release refs stay strict: a nightly must test
+          # the commit it checked out.
+          case "${GITHUB_REF_NAME}" in
+            main|release/*) python3 hack/resolve-snapshot-image-tag.py ;;
+            *) python3 hack/resolve-snapshot-image-tag.py --fallback-main ;;
+          esac
+
+      - name: Use provided Snapshot image tag
+        if: ${{ steps.selected.outputs.run == 'true' && (inputs.snapshot_tag || '') != '' }}
+        timeout-minutes: 1
+        run: |
+          set -euo pipefail
+          echo "SNAPSHOT_E2E_SNAPSHOT_TAG=${{ inputs.snapshot_tag }}" >> "$GITHUB_ENV"
+          echo "Using provided Snapshot image tag: ${{ inputs.snapshot_tag }}"
+
+      - name: Report model cache
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        run: |
+          if [[ "${SNAPSHOT_E2E_MODEL_CACHE_FROM_VARS}" == "true" ]]; then
+            echo "Shared model cache from repository variables: ${SNAPSHOT_E2E_MODEL_CACHE_SERVER}:${SNAPSHOT_E2E_MODEL_CACHE_PATH}"
+          else
+            echo "::notice::Shared model cache uses the workflow default ${SNAPSHOT_E2E_MODEL_CACHE_SERVER}:${SNAPSHOT_E2E_MODEL_CACHE_PATH}; set repository variables SNAPSHOT_E2E_MODEL_CACHE_SERVER and SNAPSHOT_E2E_MODEL_CACHE_PATH to override."
+          fi
+
+      - name: Validate host GPU cluster
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 3
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e python -m snapshot_e2e.infra.setup \
+            --phase host-preflight
+
+      - name: Create vCluster target
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 12
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e python -m snapshot_e2e.infra.setup \
+            --phase vcluster
+
+      - name: Install Snapshot in vCluster
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 8
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e python -m snapshot_e2e.infra.setup \
+            --phase snapshot-install
+
+      - name: Wait for Snapshot components
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e python -m snapshot_e2e.infra.setup \
+            --phase snapshot-ready
+
+      - name: Export vCluster kubeconfig
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 3
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(Path(os.environ["SNAPSHOT_E2E_RESULT_FILE"]).read_text())
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env:
+              env.write(f"KUBECONFIG={result['target_kubeconfig']}\n")
+              env.write(f"SNAPSHOT_E2E_HOST_NAMESPACE={result.get('host_namespace', '')}\n")
+              env.write(f"SNAPSHOT_E2E_VCLUSTER_NAME={result.get('vcluster_name', '')}\n")
+              env.write(f"SNAPSHOT_E2E_TEST_NAMESPACE={result['test_namespace']}\n")
+              env.write(f"SNAPSHOT_E2E_TARGET_KUBECONFIG={result['target_kubeconfig']}\n")
+              env.write(f"SNAPSHOT_E2E_SNAPSHOT_RELEASE={result['snapshot_release']}\n")
+              env.write(f"SNAPSHOT_E2E_PVC_NAME={result['pvc_name']}\n")
+
+          print(f"Target kubeconfig: {result['target_kubeconfig']}")
+          PY
+
+      - name: Inspect vCluster target
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 3
+        run: |
+          set -euo pipefail
+          kubectl get nodes -o wide
+          kubectl get runtimeclass
+          kubectl get pods -n "${TEST_NAMESPACE}" -o wide
+          kubectl get pvc -n "${TEST_NAMESPACE}" -o wide
+
+      - name: Run environment validation
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e pytest e2e/tests -m environment -vv
+
+      # Must exceed the phase budgets in e2e/snapshot_e2e/frameworks.py plus the
+      # request timeout (~43 min with sglang's 600s restore_timeout_seconds
+      # override), or GitHub kills pytest before its dump runs.
+      - name: Run ${{ matrix.framework }} checkpoint/restore test
+        if: ${{ steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 50
+        run: |
+          set -euo pipefail
+          uv run --locked --project e2e pytest e2e/tests/test_frameworks.py -vv -s
+
+      # The test already prints its own dump; this preserves the raw cluster
+      # state and full agent logs, which do not fit in a job log.
+      - name: Collect diagnostics
+        if: ${{ failure() && steps.selected.outputs.run == 'true' }}
+        timeout-minutes: 5
+        run: |
+          set +e
+          out="${RUNNER_TEMP}/diagnostics"
+          mkdir -p "${out}"
+          kubectl get pods -n "${TEST_NAMESPACE}" -o yaml > "${out}/pods.yaml"
+          kubectl describe pods -n "${TEST_NAMESPACE}" > "${out}/pods-describe.txt"
+          kubectl get events -n "${TEST_NAMESPACE}" --sort-by=.lastTimestamp > "${out}/events.txt"
+          kubectl get podsnapshots -n "${TEST_NAMESPACE}" -o yaml > "${out}/podsnapshots.yaml"
+          kubectl get podsnapshotcontents -o yaml > "${out}/podsnapshotcontents.yaml"
+          kubectl logs -n "${TEST_NAMESPACE}" -l app.kubernetes.io/component=snapshot-agent \
+            --all-containers --tail=-1 --prefix > "${out}/snapshot-agent.log"
+          kubectl logs -n "${TEST_NAMESPACE}" -l app.kubernetes.io/component=snapshot-operator \
+            --all-containers --tail=-1 --prefix > "${out}/snapshot-operator.log"
+          for pod in $(kubectl get pods -n "${TEST_NAMESPACE}" -l snapshot-e2e-test -o name); do
+            kubectl logs -n "${TEST_NAMESPACE}" "${pod}" --all-containers --tail=-1 \
+              > "${out}/${pod#pod/}.log"
+          done
+          # Kernel trap lines are the only trace a crashed CRIU leaves; the
+          # agent is privileged with hostPID, so its dmesg is the node's.
+          for pod in $(kubectl get pods -n "${TEST_NAMESPACE}" -l app.kubernetes.io/component=snapshot-agent -o name); do
+            kubectl exec -n "${TEST_NAMESPACE}" "${pod}" -c agent -- \
+              sh -c 'dmesg -T 2>/dev/null | tail -300' > "${out}/dmesg-${pod#pod/}.txt" 2>&1 || true
+          done
+          echo "DIAGNOSTICS_DIR=${out}" >> "$GITHUB_ENV"
+
+      - name: Upload diagnostics
+        if: ${{ failure() && steps.selected.outputs.run == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-frameworks-${{ matrix.framework }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.DIAGNOSTICS_DIR }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Cleanup e2e vCluster
+        if: ${{ always() && steps.selected.outputs.run == 'true' }}
+        env:
+          KUBECONFIG: ${{ steps.host.outputs.kubeconfig }}
+        run: |
+          set +e
+          helm uninstall vcluster-hpm -n "${HOST_NAMESPACE}"
+          if command -v vcluster >/dev/null 2>&1; then
+            vcluster delete "${VCLUSTER_NAME}" --namespace "${HOST_NAMESPACE}"
+          fi
+          kubectl delete namespace "${HOST_NAMESPACE}" --ignore-not-found --wait=false
+
+  datadog-restore:
+    name: datadog gpu monitoring back on
+    needs: [datadog-gate, e2e]
+    # Run whether the tests passed, failed, or were cancelled; only skip when
+    # the gate never ran (then nothing was disabled and nothing is held).
+    if: ${{ always() && needs.datadog-gate.result == 'success' && needs.datadog-gate.outputs.mode == 'disable' }}
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 5
+    concurrency:
+      group: snapshot-e2e-frameworks-datadog-gate
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Restore Datadog GPU monitoring
+        run: python3 hack/datadog-gpu-monitoring.py restore --holder "${{ github.run_id }}-${{ github.run_attempt }}"

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ bin/
 # macOS
 .DS_Store
 
+# Python bytecode and tool caches (e2e package, hack/ scripts, guide programs)
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
 # E2E Python workspace
 e2e/.venv/
-e2e/__pycache__/
-e2e/**/*.py[cod]
-e2e/.pytest_cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -134,3 +134,64 @@ the test verifies that the restored process and files report the source token,
 not the restore token. The worker also appends periodic observations to
 `/tmp/e2e-state/observations.log`; the observation count is only a liveness
 check that the restored process continues running after restore.
+
+## Framework Tests
+
+`tests/test_frameworks.py` checkpoints and restores each framework guide
+workload (`vllm`, `sglang`, `tensorrt-llm`) with the guide's own program and
+manifests: source pod Ready (`ready-for-snapshot`, written only after a
+pre-capture generation) → `PodSnapshot` → restore pod pinned to the source node
+→ `nvidia.com/Restored=RestoreSucceeded` → `<framework>-restore-ready` →
+`POST /generate` answers → the placeholder never loaded a model itself.
+
+```bash
+# one framework (CI runs one per matrix job); omit the variable for all three
+SNAPSHOT_E2E_FRAMEWORK=vllm \
+  uv run --project e2e pytest e2e/tests/test_frameworks.py -vv -s
+
+# test a different image instead of the guide's own pinned image
+SNAPSHOT_E2E_FRAMEWORK=vllm SNAPSHOT_E2E_FRAMEWORK_IMAGE=<registry>/vllm-snapshot:dev \
+  uv run --project e2e pytest e2e/tests/test_frameworks.py -vv -s
+```
+
+Model weights come from one of two places:
+
+- **Shared model cache** (CI): set `SNAPSHOT_E2E_MODEL_CACHE_SERVER` and
+  `SNAPSHOT_E2E_MODEL_CACHE_PATH` to an NFS export holding a Hugging Face cache
+  in `HF_HOME` layout (`hub/models--<org>--<model>/...`). The test creates a
+  static `PersistentVolume`/`PersistentVolumeClaim` (`SNAPSHOT_E2E_MODEL_CACHE_PVC`,
+  default `model-cache`), mounts it at `/models` on every framework container,
+  sets `HF_HOME=/models` and `HF_HUB_OFFLINE=1`, and drops the guide's download
+  init container. In vCluster mode the setup enables `sync.toHost.persistentVolumes`
+  so the NFS mount options reach the node. The model must already be in the cache.
+- **Guide download** (default without the variables): the guide's own plumbing
+  runs unchanged. SGLang's init container downloads into its PVC, which the test
+  creates from the guide manifest if missing (with `SNAPSHOT_E2E_STORAGE_CLASS`
+  when set) and leaves in place; vLLM and TensorRT-LLM download in-process.
+  This needs working DNS and egress from the pods. A partial or stale SGLang
+  cache (for example after a killed run) is reset by deleting that PVC; the
+  next run recreates and refills it.
+
+`tests/test_framework_manifests.py` pins the guide manifests, and the cache
+rewrite, to the restore-pod contract without a cluster.
+
+## Framework Images
+
+The framework e2e workloads are the programs and manifests under
+`manifests/frameworks/<framework>/` (`vllm`, `sglang`, `tensorrt-llm`), owned
+by the e2e suite -- these are not the `docs/guides/` examples, which still
+document a build-and-push image flow and are updated separately. Each
+framework runs the upstream image unmodified -- the exact image reference is
+`spec.template.spec.containers[0].image` in that framework's own
+`deployment.yaml` -- with `app.py` mounted from a ConfigMap (`kubectl create
+configmap <framework>-app --from-file=app.py -n
+"${SNAPSHOT_E2E_TEST_NAMESPACE:-snapshot-e2e}"`) rather than baked into a
+Snapshot-built image. There is nothing under `manifests/frameworks/<framework>/`
+for Snapshot to build, push, or keep available; `frameworks.framework_image()`
+reads the image straight from that `deployment.yaml`, and
+`framework_workloads.app_configmap()` builds the ConfigMap from the same
+`app.py`.
+
+Point `SNAPSHOT_E2E_FRAMEWORK_IMAGE` at a different image to test an
+unpublished change (a fork of `vllm/vllm-openai`, for example) without
+editing `deployment.yaml`.

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -20,6 +20,7 @@ markers = [
   "snapshot_failure: functional snapshot/restore failure checks",
   "gpu: tests that require a GPU workload",
   "workload: cluster-free checks of the workload scripts themselves",
+  "framework: checkpoint/restore of an inference framework guide workload",
 ]
 testpaths = ["tests"]
 

--- a/e2e/snapshot_e2e/framework_workloads.py
+++ b/e2e/snapshot_e2e/framework_workloads.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pods for the framework e2e tests, derived from the framework manifests.
+
+manifests/frameworks/<name>/ ships Deployments. The tests need plain Pods
+they can name, label, pin to a node, and delete individually, so the
+Deployment's Pod template is lifted into a Pod with the minimum of edits:
+test identity, the image under test, e2e scheduling, and — for the restore
+pod — the PodSnapshot to restore from. Everything that makes the Pod
+checkpointable or restorable (control volume, probes, seccomp, device
+mounts, standby env) stays exactly as the manifest wrote it, so a framework
+definition that would not work does not pass here.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from snapshot_e2e import k8s
+from snapshot_e2e.frameworks import MODEL_CACHE_MOUNT
+from snapshot_e2e.frameworks import MODEL_CACHE_VOLUME
+from snapshot_e2e.frameworks import FrameworkSpec
+from snapshot_e2e.frameworks import SharedModelCache
+from snapshot_e2e.frameworks import framework_image
+from snapshot_e2e.frameworks import framework_image_overridden
+from snapshot_e2e.workloads import TestRun
+from snapshot_e2e.workloads import same_node_affinity
+from snapshot_e2e.workloads import workload_scheduling
+
+RESTORE_FROM_ANNOTATION = "nvidia.com/restore-from"
+# The guides' own cache plumbing, replaced when a shared cache is configured:
+# the init container downloads into the guide PVC, which the shared export
+# makes both unnecessary and impossible offline.
+GUIDE_CACHE_INIT_CONTAINER = "model-cache"
+MANIFESTS_DIR = Path(__file__).resolve().parent / "manifests"
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def source_pod(
+    *,
+    config: k8s.E2EConfig,
+    run: TestRun,
+    spec: FrameworkSpec,
+    image: str | None = None,
+    model_cache: SharedModelCache | None = None,
+) -> dict[str, Any]:
+    deployment = load_manifest(spec.deployment_manifest)
+    pod = pod_from_deployment(
+        deployment,
+        name=run.source_pod,
+        namespace=config.namespace,
+        labels=run.labels,
+        image=image or framework_image(spec),
+        model_cache=model_cache,
+    )
+    # The direct PodSnapshot flow: the test creates the PodSnapshot itself, so
+    # the source must carry no restore/snapshot annotations of its own.
+    pod["metadata"]["annotations"] = {}
+    return pod
+
+
+def restore_pod(
+    *,
+    config: k8s.E2EConfig,
+    run: TestRun,
+    spec: FrameworkSpec,
+    source_node: str,
+    image: str | None = None,
+    model_cache: SharedModelCache | None = None,
+) -> dict[str, Any]:
+    deployment = load_manifest(spec.restore_deployment_manifest)
+    pod = pod_from_deployment(
+        deployment,
+        name=run.restore_pod,
+        namespace=config.namespace,
+        labels=run.labels,
+        image=image or framework_image(spec),
+        model_cache=model_cache,
+    )
+    # The guide's placeholder annotation names its own PodSnapshot; this run's
+    # PodSnapshot is what must be restored. Restore is node-pinned: the agent
+    # that holds the artifact is the one on the source node.
+    pod["metadata"]["annotations"] = {RESTORE_FROM_ANNOTATION: run.snapshot_name}
+    pod["spec"]["affinity"] = same_node_affinity(source_node)
+    return pod
+
+
+def app_configmap(
+    *,
+    config: k8s.E2EConfig,
+    spec: FrameworkSpec,
+) -> dict[str, Any]:
+    """The ConfigMap the guide's deployment.yaml mounts app.py from.
+
+    Matches spec.app_configmap_name, the name the guide's own manifest
+    references, and the same `kubectl create configmap --from-file=app.py`
+    a user runs by hand -- read from the identical source file, so there is
+    nothing to keep in sync by hand.
+    """
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": spec.app_configmap_name, "namespace": config.namespace},
+        "data": {"app.py": spec.app_py.read_text(encoding="utf-8")},
+    }
+
+
+def model_cache_pvc(
+    *,
+    config: k8s.E2EConfig,
+    spec: FrameworkSpec,
+) -> dict[str, Any] | None:
+    path = spec.model_cache_manifest_path
+    if path is None:
+        return None
+    pvc = load_manifest(path)
+    pvc["metadata"]["namespace"] = config.namespace
+    storage_class = os.environ.get("SNAPSHOT_E2E_STORAGE_CLASS")
+    if storage_class:
+        pvc["spec"]["storageClassName"] = storage_class
+    return pvc
+
+
+def shared_model_cache_volume(
+    *,
+    config: k8s.E2EConfig,
+    cache: SharedModelCache,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """PersistentVolume and PersistentVolumeClaim for the shared NFS cache.
+
+    Capacity, mount options, and the static binding (empty storageClassName +
+    volumeName, Retain policy) live in the checked-in templates under
+    manifests/ so they can be tuned without touching this script; only the
+    per-run identity and NFS coordinates are filled in here.
+    """
+    pv = load_manifest(MANIFESTS_DIR / "shared-model-cache-pv.yaml")
+    pv["metadata"]["name"] = cache.pvc_name
+    pv["spec"]["nfs"] = {"server": cache.server, "path": cache.path}
+
+    pvc = load_manifest(MANIFESTS_DIR / "shared-model-cache-pvc.yaml")
+    pvc["metadata"]["name"] = cache.pvc_name
+    pvc["metadata"]["namespace"] = config.namespace
+    pvc["spec"]["volumeName"] = cache.pvc_name
+    return pv, pvc
+
+
+def pod_from_deployment(
+    deployment: dict[str, Any],
+    *,
+    name: str,
+    namespace: str,
+    labels: dict[str, str],
+    image: str,
+    model_cache: SharedModelCache | None = None,
+) -> dict[str, Any]:
+    template = copy.deepcopy(deployment["spec"]["template"])
+    metadata = template.get("metadata", {})
+    pod_spec = template["spec"]
+
+    # These are throwaway test pods: never restart (a restarted source would
+    # re-run the whole load and hide a crash), and do not wait out the default
+    # 30s grace period between tests.
+    pod_spec["restartPolicy"] = "Never"
+    pod_spec["terminationGracePeriodSeconds"] = 1
+
+    if model_cache is not None:
+        use_shared_model_cache(pod_spec, model_cache)
+
+    # Content-addressed tags are immutable, so a cached pull is correct and
+    # saves minutes on multi-GB images. An override (SNAPSHOT_E2E_FRAMEWORK_IMAGE)
+    # is typically a mutable dev tag, where a cached image would test stale bits.
+    pull_policy = "Always" if framework_image_overridden() else "IfNotPresent"
+    for container in pod_spec.get("initContainers", []) + pod_spec["containers"]:
+        container["image"] = image
+        container["imagePullPolicy"] = pull_policy
+
+    scheduling = workload_scheduling()
+    pod_spec["nodeSelector"] = {**pod_spec.get("nodeSelector", {}), **scheduling["nodeSelector"]}
+    pod_spec["tolerations"] = pod_spec.get("tolerations", []) + scheduling["tolerations"]
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": {**metadata.get("labels", {}), **labels},
+            "annotations": dict(metadata.get("annotations", {})),
+        },
+        "spec": pod_spec,
+    }
+
+
+def use_shared_model_cache(pod_spec: dict[str, Any], cache: SharedModelCache) -> None:
+    """Point the Pod at the shared cache instead of downloading.
+
+    Drops the guide's download init container, rebinds (or adds) the
+    model-cache volume to the shared claim, mounts it at MODEL_CACHE_MOUNT on
+    every remaining container, and sets HF_HOME there with HF_HUB_OFFLINE=1 so
+    a missing model fails immediately instead of hanging on the network.
+    """
+    pod_spec["initContainers"] = [
+        c for c in pod_spec.get("initContainers", []) if c["name"] != GUIDE_CACHE_INIT_CONTAINER
+    ]
+    if not pod_spec["initContainers"]:
+        del pod_spec["initContainers"]
+
+    volume = {
+        "name": MODEL_CACHE_VOLUME,
+        "persistentVolumeClaim": {"claimName": cache.pvc_name},
+    }
+    volumes = [v for v in pod_spec.get("volumes", []) if v["name"] != MODEL_CACHE_VOLUME]
+    pod_spec["volumes"] = volumes + [volume]
+
+    for container in pod_spec["containers"]:
+        mounts = [
+            m for m in container.get("volumeMounts", []) if m["name"] != MODEL_CACHE_VOLUME
+        ]
+        mounts.append({"name": MODEL_CACHE_VOLUME, "mountPath": MODEL_CACHE_MOUNT})
+        container["volumeMounts"] = mounts
+        set_env(container, "HF_HOME", MODEL_CACHE_MOUNT)
+        set_env(container, "HF_HUB_OFFLINE", "1")
+
+
+def set_env(container: dict[str, Any], name: str, value: str) -> None:
+    env = [item for item in container.get("env", []) if item.get("name") != name]
+    env.append({"name": name, "value": value})
+    container["env"] = env
+
+
+def main_container(pod: dict[str, Any]) -> dict[str, Any]:
+    for container in pod["spec"]["containers"]:
+        if container["name"] == "main":
+            return container
+    raise AssertionError("pod has no container named 'main'")
+
+
+def env_value(container: dict[str, Any], name: str) -> str | None:
+    for item in container.get("env", []):
+        if item.get("name") == name:
+            return item.get("value")
+    return None

--- a/e2e/snapshot_e2e/frameworks.py
+++ b/e2e/snapshot_e2e/frameworks.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inference framework workloads under e2e test.
+
+Each framework's program and manifests live under manifests/frameworks/<name>/,
+owned by the e2e suite (not docs/guides/, which still documents the
+build-and-push image flow and is updated separately). This module pins what
+the tests need to know about each one: which control-dir files it writes, how
+long each phase may take, and which model it serves.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+FRAMEWORKS_DIR = Path(__file__).resolve().parent / "manifests" / "frameworks"
+
+CONTAINER = "main"
+API_PORT = 8000
+
+# One small chat-style prompt is enough to prove the restored engine serves;
+# the guide APIs cap generation length themselves.
+PROMPT = "Reply with one short sentence confirming this restored worker can serve."
+REQUEST_TIMEOUT_SECONDS = 120
+
+# Phase budgets. The source budget covers image pull, model download or cache
+# load, engine load, compilation/CUDA-graph capture, and the warm-up
+# generation; the checkpoint budget covers the dump and artifact upload; the
+# restore budget covers the agent restore plus the program's own resume and
+# the first post-restore generation.
+#
+# The first run on a node pulls a 10-20 GB runtime image (observed: ~4 min on
+# the CI cluster) before the engine even starts, and vLLM then compiles and
+# captures CUDA graphs; 300s was exceeded with the engine still initializing.
+#
+# test_frameworks.py waits on restore_timeout_seconds twice in sequence
+# (wait_for_restored_condition, then wait_for_restore_outcome), so the restore
+# budget below counts double. The CI step running the test must exceed
+# SOURCE_READY_TIMEOUT_SECONDS + CHECKPOINT_TIMEOUT_SECONDS +
+# POD_DELETE_TIMEOUT_SECONDS + 2 * restore_timeout_seconds +
+# REQUEST_TIMEOUT_SECONDS, or GitHub kills pytest before the failure dump
+# runs; see the test step in e2e-frameworks.yaml. With sglang's 600s
+# restore_timeout_seconds override that's 900 + 300 + 180 + 2*600 + 120 =
+# 2700s (~45 min) today, the largest of the three frameworks' budgets.
+SOURCE_READY_TIMEOUT_SECONDS = 900
+CHECKPOINT_TIMEOUT_SECONDS = 300
+RESTORE_TIMEOUT_SECONDS = 300
+POD_DELETE_TIMEOUT_SECONDS = 180
+
+
+@dataclass(frozen=True)
+class FrameworkSpec:
+    name: str
+    model: str
+    # Written by the restored process once its API is listening; holds the
+    # first post-restore generation.
+    restore_ready_file: str
+    # Written by the restored process if resuming or serving raised; holds the
+    # traceback. The restored process keeps the dead source container's stdout,
+    # so this file is the only place such a failure is visible.
+    restore_error_file: str
+    # Guide PVC manifest for a persistent model cache, if the guide uses one.
+    model_cache_manifest: str | None = None
+    # Overrides RESTORE_TIMEOUT_SECONDS for this framework's restore-condition
+    # and restore-outcome waits.
+    restore_timeout_seconds: int = RESTORE_TIMEOUT_SECONDS
+
+    @property
+    def manifest_dir(self) -> Path:
+        return FRAMEWORKS_DIR / self.name
+
+    @property
+    def deployment_manifest(self) -> Path:
+        return self.manifest_dir / "deployment.yaml"
+
+    @property
+    def restore_deployment_manifest(self) -> Path:
+        return self.manifest_dir / "restore-deployment.yaml"
+
+    @property
+    def app_py(self) -> Path:
+        return self.manifest_dir / "app.py"
+
+    @property
+    def app_configmap_name(self) -> str:
+        # Matches the configMap.name this framework's own deployment.yaml
+        # references; see manifests/frameworks/<name>/deployment.yaml.
+        return f"{self.name}-app"
+
+    @property
+    def model_cache_manifest_path(self) -> Path | None:
+        if self.model_cache_manifest is None:
+            return None
+        return self.manifest_dir / self.model_cache_manifest
+
+
+FRAMEWORKS: dict[str, FrameworkSpec] = {
+    "vllm": FrameworkSpec(
+        name="vllm",
+        model="Qwen/Qwen3-0.6B",
+        restore_ready_file="/snapshot-control/vllm-restore-ready",
+        restore_error_file="/snapshot-control/vllm-restore-error",
+    ),
+    "sglang": FrameworkSpec(
+        name="sglang",
+        model="Qwen/Qwen3-0.6B",
+        restore_ready_file="/snapshot-control/sglang-restore-ready",
+        restore_error_file="/snapshot-control/sglang-restore-error",
+        model_cache_manifest="model-cache-pvc.yaml",
+        # engine.resume_memory_occupation() has come within seconds of the
+        # default 300s budget in CI; give it more room than the other
+        # frameworks need.
+        restore_timeout_seconds=600,
+    ),
+    "tensorrt-llm": FrameworkSpec(
+        name="tensorrt-llm",
+        model="Qwen/Qwen3-0.6B",
+        restore_ready_file="/snapshot-control/trtllm-restore-ready",
+        restore_error_file="/snapshot-control/trtllm-restore-error",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class SharedModelCache:
+    """An NFS export holding a Hugging Face cache in HF_HOME layout.
+
+    CI clusters commonly block or throttle model downloads from the pods, and
+    even where they work, pulling weights on every run is wasted minutes. With
+    a shared cache the framework pods mount the export at MODEL_CACHE_MOUNT,
+    point HF_HOME at it, and run offline; the guide's own per-deployment cache
+    (SGLang's download init container and PVC) is replaced, not duplicated.
+    """
+
+    server: str
+    path: str
+    pvc_name: str
+
+    @classmethod
+    def from_env(cls) -> "SharedModelCache | None":
+        server = os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_SERVER", "").strip()
+        path = os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_PATH", "").strip()
+        if not server and not path:
+            return None
+        if not (server and path):
+            raise RuntimeError(
+                "SNAPSHOT_E2E_MODEL_CACHE_SERVER and SNAPSHOT_E2E_MODEL_CACHE_PATH "
+                "must be set together"
+            )
+        return cls(
+            server=server,
+            path=path,
+            pvc_name=os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_PVC", "model-cache"),
+        )
+
+
+MODEL_CACHE_MOUNT = "/models"
+MODEL_CACHE_VOLUME = "model-cache"
+
+
+def selected_frameworks() -> list[str]:
+    """Frameworks to run, from SNAPSHOT_E2E_FRAMEWORK (comma-separated) or all."""
+    raw = os.environ.get("SNAPSHOT_E2E_FRAMEWORK", "").strip()
+    if not raw:
+        return sorted(FRAMEWORKS)
+    names = [name.strip() for name in raw.split(",") if name.strip()]
+    unknown = sorted(set(names) - set(FRAMEWORKS))
+    if unknown:
+        raise RuntimeError(
+            f"SNAPSHOT_E2E_FRAMEWORK names unknown frameworks {unknown}; "
+            f"known: {sorted(FRAMEWORKS)}"
+        )
+    return names
+
+
+def framework_image_overridden() -> bool:
+    return bool(os.environ.get("SNAPSHOT_E2E_FRAMEWORK_IMAGE"))
+
+
+def framework_image(spec: FrameworkSpec) -> str:
+    """The workload image: an explicit override, else the guide's own image.
+
+    SNAPSHOT_E2E_FRAMEWORK_IMAGE wins so a different image can be tested.
+    Otherwise the image is read straight from the guide's own
+    deployment.yaml -- one place to change it.
+    """
+    override = os.environ.get("SNAPSHOT_E2E_FRAMEWORK_IMAGE")
+    if override:
+        return override
+    with spec.deployment_manifest.open(encoding="utf-8") as handle:
+        deployment = yaml.safe_load(handle)
+    return deployment["spec"]["template"]["spec"]["containers"][0]["image"]

--- a/e2e/snapshot_e2e/frameworks.py
+++ b/e2e/snapshot_e2e/frameworks.py
@@ -28,25 +28,18 @@ API_PORT = 8000
 PROMPT = "Reply with one short sentence confirming this restored worker can serve."
 REQUEST_TIMEOUT_SECONDS = 120
 
-# Phase budgets. The source budget covers image pull, model download or cache
-# load, engine load, compilation/CUDA-graph capture, and the warm-up
-# generation; the checkpoint budget covers the dump and artifact upload; the
-# restore budget covers the agent restore plus the program's own resume and
-# the first post-restore generation.
+# Phase budgets: source covers image pull, model load, and warm-up generation
+# (300s was exceeded mid-init on a cold 10-20 GB image pull); checkpoint
+# covers the dump and upload; restore covers the agent restore plus resume
+# and the first post-restore generation.
 #
-# The first run on a node pulls a 10-20 GB runtime image (observed: ~4 min on
-# the CI cluster) before the engine even starts, and vLLM then compiles and
-# captures CUDA graphs; 300s was exceeded with the engine still initializing.
-#
-# test_frameworks.py waits on restore_timeout_seconds twice in sequence
-# (wait_for_restored_condition, then wait_for_restore_outcome), so the restore
-# budget below counts double. The CI step running the test must exceed
-# SOURCE_READY_TIMEOUT_SECONDS + CHECKPOINT_TIMEOUT_SECONDS +
-# POD_DELETE_TIMEOUT_SECONDS + 2 * restore_timeout_seconds +
-# REQUEST_TIMEOUT_SECONDS, or GitHub kills pytest before the failure dump
-# runs; see the test step in e2e-frameworks.yaml. With sglang's 600s
-# restore_timeout_seconds override that's 900 + 300 + 180 + 2*600 + 120 =
-# 2700s (~45 min) today, the largest of the three frameworks' budgets.
+# test_frameworks.py waits on restore_timeout_seconds twice (restored
+# condition, then restore outcome), so it counts double. The CI test step
+# (e2e-frameworks.yaml) must exceed SOURCE_READY_TIMEOUT_SECONDS +
+# CHECKPOINT_TIMEOUT_SECONDS + POD_DELETE_TIMEOUT_SECONDS +
+# 2 * restore_timeout_seconds + REQUEST_TIMEOUT_SECONDS, or GitHub kills
+# pytest before the failure dump runs -- e.g. sglang's 600s override makes
+# that 900+300+180+2*600+120 = 2700s (~45 min), the largest of the three.
 SOURCE_READY_TIMEOUT_SECONDS = 900
 CHECKPOINT_TIMEOUT_SECONDS = 300
 RESTORE_TIMEOUT_SECONDS = 300

--- a/e2e/snapshot_e2e/inference.py
+++ b/e2e/snapshot_e2e/inference.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inference requests against a framework guide program, from inside its pod.
+
+The guide programs expose `POST /generate` with `{"prompt": ...}` on port 8000
+and answer `{"text": ...}`. There is no Service in front of them, so the
+request is issued from inside the pod through exec. Python's standard library
+is used rather than curl because every framework runtime image ships Python
+and none is guaranteed to ship curl.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+
+from snapshot_e2e import k8s
+from snapshot_e2e.frameworks import API_PORT
+from snapshot_e2e.frameworks import REQUEST_TIMEOUT_SECONDS
+
+_CLIENT = """
+import json, sys, urllib.request
+payload = json.dumps({"prompt": sys.argv[1]}).encode()
+request = urllib.request.Request(
+    sys.argv[2],
+    data=payload,
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(request, timeout=float(sys.argv[3])) as response:
+    body = response.read().decode()
+print("__snapshot_e2e_generate__" + body)
+"""
+
+_MARKER = "__snapshot_e2e_generate__"
+
+
+def request_generate(
+    namespace: str,
+    pod: str,
+    prompt: str,
+    *,
+    timeout: int = REQUEST_TIMEOUT_SECONDS,
+    port: int = API_PORT,
+    container: str | None = None,
+) -> str:
+    """POSTs the prompt to the program's /generate and returns the generated text.
+
+    Raises AssertionError if the endpoint does not answer with non-empty text;
+    the raw exec output is included so a framework error is visible verbatim.
+    """
+    url = f"http://127.0.0.1:{port}/generate"
+    command = (
+        f"python3 -c {shlex.quote(_CLIENT)} {shlex.quote(prompt)} "
+        f"{shlex.quote(url)} {timeout}"
+    )
+    output = k8s.exec_command(namespace, pod, command, container=container)
+    marker_at = output.rfind(_MARKER)
+    if marker_at < 0:
+        raise AssertionError(
+            f"/generate on {namespace}/{pod} produced no response; exec output:\n{output}"
+        )
+    body = output[marker_at + len(_MARKER):].strip()
+    try:
+        text = json.loads(body)["text"]
+    except (ValueError, KeyError, TypeError) as exc:
+        raise AssertionError(
+            f"/generate on {namespace}/{pod} returned malformed body {body!r}: {exc}"
+        ) from exc
+    if not isinstance(text, str) or not text.strip():
+        raise AssertionError(f"/generate on {namespace}/{pod} returned empty text: {body!r}")
+    return text
+
+
+_FILE_MARKER = "__snapshot_e2e_file__"
+
+
+def read_control_file(
+    namespace: str, pod: str, path: str, *, container: str | None = None
+) -> str | None:
+    """Content of a control-directory file, or None when it does not exist.
+
+    exec merges stdout and stderr and hides the remote exit status, so a bare
+    `cat` of a missing file would come back as its error text and pass a
+    "non-empty" assertion. The marker is printed only when the file exists.
+    """
+    quoted = shlex.quote(path)
+    output = k8s.exec_command(
+        namespace,
+        pod,
+        f"if [[ -f {quoted} ]]; then printf '%s' {shlex.quote(_FILE_MARKER)}; cat {quoted}; fi",
+        container=container,
+    )
+    return parse_control_file(output)
+
+
+def parse_control_file(output: str) -> str | None:
+    if not output.startswith(_FILE_MARKER):
+        return None
+    return output[len(_FILE_MARKER):]

--- a/e2e/snapshot_e2e/inference.py
+++ b/e2e/snapshot_e2e/inference.py
@@ -71,31 +71,3 @@ def request_generate(
     if not isinstance(text, str) or not text.strip():
         raise AssertionError(f"/generate on {namespace}/{pod} returned empty text: {body!r}")
     return text
-
-
-_FILE_MARKER = "__snapshot_e2e_file__"
-
-
-def read_control_file(
-    namespace: str, pod: str, path: str, *, container: str | None = None
-) -> str | None:
-    """Content of a control-directory file, or None when it does not exist.
-
-    exec merges stdout and stderr and hides the remote exit status, so a bare
-    `cat` of a missing file would come back as its error text and pass a
-    "non-empty" assertion. The marker is printed only when the file exists.
-    """
-    quoted = shlex.quote(path)
-    output = k8s.exec_command(
-        namespace,
-        pod,
-        f"if [[ -f {quoted} ]]; then printf '%s' {shlex.quote(_FILE_MARKER)}; cat {quoted}; fi",
-        container=container,
-    )
-    return parse_control_file(output)
-
-
-def parse_control_file(output: str) -> str | None:
-    if not output.startswith(_FILE_MARKER):
-        return None
-    return output[len(_FILE_MARKER):]

--- a/e2e/snapshot_e2e/infra/setup.py
+++ b/e2e/snapshot_e2e/infra/setup.py
@@ -575,8 +575,8 @@ def vcluster_node_sync_selector_labels() -> dict[str, str]:
     for node in nodes:
         labels = node.metadata.labels or {}
         if labels.get(AKS_USER_NODE_LABEL) == AKS_USER_NODE_VALUE:
-            # This matches the current Dynamo AKS runner layout. If that cluster
-            # layout changes, revisit which host nodes the vCluster should sync.
+            # Matches the current AKS CI runner layout. If that cluster layout
+            # changes, revisit which host nodes the vCluster should sync.
             log(
                 "Using AKS user-node selector for vCluster node sync: "
                 f"{AKS_USER_NODE_LABEL}={AKS_USER_NODE_VALUE}"

--- a/e2e/snapshot_e2e/infra/setup.py
+++ b/e2e/snapshot_e2e/infra/setup.py
@@ -26,6 +26,7 @@ from kubernetes.client import ApiException
 from packaging.version import Version
 
 from snapshot_e2e import k8s
+from snapshot_e2e.frameworks import SharedModelCache
 from snapshot_e2e.infra import preflight
 
 
@@ -310,6 +311,7 @@ def setup_vcluster(args: argparse.Namespace, context: SetupContext) -> None:
         context.host_namespace,
         context.vcluster_name,
         args.vcluster_k8s_version,
+        model_cache=SharedModelCache.from_env(),
     )
     install_hostpath_mapper(
         context.host_namespace,
@@ -491,7 +493,13 @@ def ensure_vcluster_unused(namespace: str, name: str) -> None:
     log(f"vCluster name {namespace}/{name} is available")
 
 
-def create_vcluster(namespace: str, name: str, k8s_version: str) -> None:
+def create_vcluster(
+    namespace: str,
+    name: str,
+    k8s_version: str,
+    *,
+    model_cache: SharedModelCache | None = None,
+) -> None:
     log(f"Creating vCluster {namespace}/{name}")
     synced_nodes = {
         "enabled": True,
@@ -504,7 +512,7 @@ def create_vcluster(namespace: str, name: str, k8s_version: str) -> None:
     if node_selector:
         synced_nodes["selector"]["labels"] = node_selector
 
-    values = {
+    values: dict[str, Any] = {
         "controlPlane": {
             "hostPathMapper": {
                 "enabled": True,
@@ -522,6 +530,12 @@ def create_vcluster(namespace: str, name: str, k8s_version: str) -> None:
             },
         },
     }
+    if model_cache is not None:
+        # The framework tests create a static NFS PersistentVolume for the
+        # shared model cache. Sync it to the host so its mount options are
+        # honored by the node; without this vCluster rewrites the claim to a
+        # host-provisioned volume and the NFS spec is lost.
+        values["sync"]["toHost"] = {"persistentVolumes": {"enabled": True}}
     values_file = write_temp_yaml("snapshot-vcluster-values-", values)
     try:
         run(

--- a/e2e/snapshot_e2e/k8s.py
+++ b/e2e/snapshot_e2e/k8s.py
@@ -71,6 +71,25 @@ def create_pod(body: dict[str, Any]) -> client.V1Pod:
     )
 
 
+def apply_configmap(namespace: str, body: dict[str, Any]) -> client.V1ConfigMap:
+    """Create the ConfigMap, replacing it in place if it already exists.
+
+    A prior run in the same namespace (a local re-run, a retried CI job) can
+    leave a stale ConfigMap with the same name; replace rather than error, so
+    the test always deploys against the current app.py.
+    """
+    api = client.CoreV1Api()
+    name = body["metadata"]["name"]
+    try:
+        return api.create_namespaced_config_map(namespace=namespace, body=body)
+    except ApiException as exc:
+        if exc.status != 409:
+            raise
+        existing = api.read_namespaced_config_map(name=name, namespace=namespace)
+        body["metadata"]["resourceVersion"] = existing.metadata.resource_version
+        return api.replace_namespaced_config_map(name=name, namespace=namespace, body=body)
+
+
 def read_pod(namespace: str, name: str) -> client.V1Pod:
     return client.CoreV1Api().read_namespaced_pod(name=name, namespace=namespace)
 

--- a/e2e/snapshot_e2e/lifecycle.py
+++ b/e2e/snapshot_e2e/lifecycle.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import shlex
 import time
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 from kubernetes import client
@@ -214,6 +215,60 @@ def wait_for_file(namespace: str, pod: str, path: str, timeout: int = 180) -> No
         return f"last_error={last_error}" if last_error else "file not observed yet"
 
     wait_for(f"{namespace}/{pod}:{path}", exists, timeout, detail=detail)
+
+
+def wait_for_restore_outcome(
+    namespace: str,
+    pod: str,
+    *,
+    ready_file: str,
+    error_file: str,
+    timeout: int,
+) -> str:
+    """Waits for the restored program's success sentinel, failing fast on its
+    error sentinel. Returns the ready file's content.
+
+    The restored process writes one of the two files; anything else it prints
+    goes to the source container's stdout, which no longer exists. Polling for
+    the ready file alone turns every post-restore exception into a timeout.
+    """
+    marker = "__snapshot_e2e_outcome__"
+    last_error: str | None = None
+
+    def outcome() -> str | None:
+        nonlocal last_error
+        try:
+            output = k8s.exec_command(
+                namespace,
+                pod,
+                f"if [[ -f {shlex.quote(error_file)} ]]; then printf '%s:error\\n' {shlex.quote(marker)}; "
+                f"cat {shlex.quote(error_file)}; "
+                f"elif [[ -f {shlex.quote(ready_file)} ]]; then printf '%s:ready\\n' {shlex.quote(marker)}; "
+                f"cat {shlex.quote(ready_file)}; fi",
+            )
+            last_error = None
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            return None
+        if output.startswith(f"{marker}:error"):
+            body = output.split("\n", 1)[1] if "\n" in output else ""
+            raise AssertionError(
+                f"restored program in {namespace}/{pod} failed after restore "
+                f"({error_file}):\n{body}"
+            )
+        if output.startswith(f"{marker}:ready"):
+            return output.split("\n", 1)[1] if "\n" in output else ""
+        return None
+
+    def detail() -> str:
+        return f"last_error={last_error}" if last_error else "neither sentinel observed yet"
+
+    return wait_for(
+        f"{namespace}/{pod} restore outcome ({ready_file} or {error_file})",
+        outcome,
+        timeout,
+        detail=detail,
+    )
 
 
 def matching_observation_count(
@@ -444,7 +499,7 @@ def wait_for_restored_condition(
         except ApiException as exc:
             return f"api_error={k8s.api_error_detail(exc)}"
         restored = pod_condition(pod, "nvidia.com/Restored")
-        return f"nvidia.com/Restored={restored or '<unset>'}"
+        return f"nvidia.com/Restored={condition_summary(restored)}"
 
     return wait_for(
         f"nvidia.com/Restored={status}/{reason} on {namespace}/{pod_name}",
@@ -459,6 +514,40 @@ def pod_condition(pod: client.V1Pod, condition_type: str) -> client.V1PodConditi
         if item.type == condition_type:
             return item
     return None
+
+
+def condition_summary(cond: object) -> str:
+    """One-line, human-readable rendering of a Kubernetes condition.
+
+    The client's model objects repr as multi-line dicts with ``datetime``
+    objects, which is unreadable in a wait loop's progress line. Works for
+    typed models (``V1PodCondition``, ``V1JobCondition``) and for the plain
+    dicts custom objects return.
+    """
+    if cond is None:
+        return "<unset>"
+    if isinstance(cond, dict):
+        get = cond.get
+    else:
+        get = lambda key, default=None: getattr(cond, key, default)
+    at = get("last_transition_time") or get("lastTransitionTime")
+    if hasattr(at, "isoformat"):
+        at = at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    parts = [f"status={get('status')}", f"reason={get('reason')}"]
+    if get("message"):
+        parts.append(f"message={get('message')!r}")
+    if at:
+        parts.append(f"at={at}")
+    return " ".join(parts)
+
+
+def conditions_summary(conds: object) -> str:
+    if not conds:
+        return "[]"
+    return "[" + "; ".join(
+        f"{(c.get('type') if isinstance(c, dict) else getattr(c, 'type', None))}: {condition_summary(c)}"
+        for c in conds
+    ) + "]"
 
 
 def checkpoint_artifact_manifest(
@@ -540,6 +629,28 @@ def create_artifact_staging_file(
         checkpoint_agent_pod(config, node),
         f"mkdir -p {checkpoint_artifact_root(content_uid)}/.tmp && "
         f"printf orphan > {checkpoint_artifact_root(content_uid)}/.tmp/partial",
+    )
+
+
+def host_monitoring_agents(config: k8s.E2EConfig, node: str) -> str:
+    """Host-level monitoring agents (Datadog, DCGM) running on ``node``.
+
+    The snapshot agent is privileged with hostPID, so ``ps`` inside it lists
+    the node's processes, including agents that live in other clusters'
+    namespaces (the CI vcluster cannot see the host cluster's ``datadog``
+    namespace). Datadog's GPU monitoring attaches to GPU processes via
+    system-probe and NVML, which is a candidate interferer for CRIU/CUDA
+    checkpoint and restore; record whether it is present on every run so a
+    flaky failure can be correlated with it.
+    """
+    agent = checkpoint_agent_pod(config, node)
+    return k8s.exec_command(
+        config.namespace,
+        agent,
+        "ps -eo pid,ppid,user,comm,args --no-headers 2>/dev/null "
+        "| grep -iE 'datadog|dd-agent|system-probe|process-agent|trace-agent|security-agent|dcgm' "
+        "| grep -vE 'grep -iE' "
+        "|| echo '<no datadog/dcgm processes on host>'",
     )
 
 
@@ -782,7 +893,7 @@ def debug_dump_snapshotjob(config: k8s.E2EConfig, run: TestRun) -> None:
         print(
             f"source Job {job.metadata.name} active={job.status.active} "
             f"succeeded={job.status.succeeded} failed={job.status.failed} "
-            f"startTime={job.status.start_time} conditions={job.status.conditions}"
+            f"startTime={job.status.start_time} conditions={conditions_summary(job.status.conditions)}"
         )
     api = client.CustomObjectsApi()
     try:
@@ -809,6 +920,276 @@ def debug_dump_snapshotjob(config: k8s.E2EConfig, run: TestRun) -> None:
         }:
             print(f"event {involved.kind}/{involved.name} {event.reason}: {event.message}")
     print("--- end debug ---\n")
+
+
+def ensure_pvc(body: dict[str, Any]) -> None:
+    """Creates the PVC if it does not exist; an existing claim is left as is.
+
+    Framework model caches are meant to outlive a test run so later runs skip
+    the download, so this is create-if-missing rather than create-or-replace.
+    """
+    namespace = body["metadata"]["namespace"]
+    name = body["metadata"]["name"]
+    try:
+        client.CoreV1Api().create_namespaced_persistent_volume_claim(namespace, body)
+        print(f"created PVC {namespace}/{name}")
+    except ApiException as exc:
+        if exc.status != 409:
+            raise
+        print(f"PVC {namespace}/{name} already exists")
+
+
+def ensure_pv(body: dict[str, Any]) -> None:
+    """Creates the cluster-scoped PersistentVolume if it does not exist.
+
+    An existing PV must describe the same NFS export: the name is fixed and the
+    reclaim policy is Retain, so on a reused cluster a changed
+    SNAPSHOT_E2E_MODEL_CACHE_SERVER/PATH would otherwise keep mounting the old
+    export silently. Replacing a Retain PV is the operator's decision, not the
+    test's, so mismatch fails loudly instead.
+    """
+    name = body["metadata"]["name"]
+    api = client.CoreV1Api()
+    try:
+        api.create_persistent_volume(body)
+        print(f"created PV {name}")
+    except ApiException as exc:
+        if exc.status != 409:
+            raise
+        existing = api.read_persistent_volume(name)
+        wanted = body["spec"]["nfs"]
+        actual = {"server": existing.spec.nfs.server, "path": existing.spec.nfs.path} if existing.spec.nfs else None
+        if actual != wanted:
+            raise AssertionError(
+                f"PV {name} already exists with nfs={actual}, but the configured shared model "
+                f"cache is nfs={wanted}; delete the PV or point SNAPSHOT_E2E_MODEL_CACHE_* at it"
+            )
+        print(f"PV {name} already exists with the configured export")
+
+
+def debug_dump_framework(
+    config: k8s.E2EConfig,
+    run: TestRun,
+    *,
+    source_node: str | None = None,
+    image: str | None = None,
+) -> None:
+    """Failure dump for a framework workload run.
+
+    Framework programs log the framework's own diagnostics (engine load, CUDA
+    errors, sleep/wake failures) and the agent logs the CRIU/cuda-checkpoint
+    side; a failure is only actionable with both. Logs are kept long because
+    framework startup output easily exceeds the generic dump's 80 lines.
+    """
+    print("\n--- framework e2e debug ---")
+    print(f"namespace={config.namespace} test={run.suffix} framework_image={image or '<unknown>'}")
+    # Every section is isolated: the caller re-raises the original test
+    # failure after this returns, so nothing here may raise, and one section
+    # failing (a pod deleted mid-dump, an apiserver hiccup) must not hide the
+    # others.
+    _dump_section("pods", lambda: _dump_framework_pods(config, run))
+    _dump_section("custom objects", lambda: print_custom_objects(config, run))
+    _dump_section("controller logs", lambda: print_snapshot_controller_logs(config))
+    if source_node:
+        _dump_section(
+            "agent diagnostics", lambda: _dump_agent_diagnostics(config, run, source_node)
+        )
+    _dump_section("events", lambda: _dump_run_events(config, run))
+    print("--- end debug ---\n")
+
+
+def _dump_section(title: str, dump: Callable[[], None]) -> None:
+    try:
+        dump()
+    except Exception as exc:  # noqa: BLE001 - debug helper must never mask the real failure
+        print(f"{title} unavailable: {type(exc).__name__}: {exc}")
+
+
+def _dump_framework_pods(config: k8s.E2EConfig, run: TestRun) -> None:
+    pods = client.CoreV1Api().list_namespaced_pod(
+        config.namespace, label_selector=f"snapshot-e2e-test={run.suffix}"
+    ).items
+    if not pods:
+        print("no pods matched the e2e label")
+    for pod in pods:
+        name = pod.metadata.name
+        print(f"pod {name} phase={pod.status.phase} node={pod.spec.node_name}")
+        print(f"images={[c.image for c in pod.spec.containers]}")
+        print(f"annotations={pod.metadata.annotations or {}}")
+        print(f"conditions={[(c.type, c.status, c.reason) for c in pod.status.conditions or []]}")
+        for cs in list(pod.status.init_container_statuses or []) + list(
+            pod.status.container_statuses or []
+        ):
+            print(f"  container {cs.name} ready={cs.ready} restarts={cs.restart_count} state={cs.state}")
+        print(f"control dir: {snapshot_control_listing(config.namespace, name)}")
+        # The restored process tree is invisible in the container log; its
+        # process list, listening sockets, and any error sentinel are the only
+        # in-pod evidence of what it is doing.
+        _dump_section(f"runtime state {name}", lambda name=name: _dump_pod_runtime_state(config, name))
+        _dump_section(f"logs {name}", lambda name=name: _dump_pod_logs(config, name))
+
+
+def _dump_pod_runtime_state(config: k8s.E2EConfig, name: str) -> None:
+    print(f"--- processes / sockets / error sentinels in {name} ---")
+    print(pod_runtime_state(config.namespace, name))
+
+
+def _dump_pod_logs(config: k8s.E2EConfig, name: str) -> None:
+    print(f"--- logs {name} (tail 400) ---")
+    print(k8s.pod_logs(config.namespace, name, tail_lines=400))
+
+
+def _dump_agent_diagnostics(config: k8s.E2EConfig, run: TestRun, source_node: str) -> None:
+    agent = checkpoint_agent_pod(config, source_node)
+    _dump_section("agent logs", lambda: _dump_agent_logs(config, agent, source_node))
+    _dump_section("nvidia-smi", lambda: _dump_nvidia_smi(config, agent, source_node))
+    _dump_section("host monitoring agents", lambda: _dump_host_monitoring(config, source_node))
+    _dump_section("kernel log", lambda: _dump_kernel_log(config, agent, source_node))
+    _dump_section("checkpoint artifact", lambda: _dump_checkpoint_artifact(config, run, agent, source_node))
+
+
+def _dump_agent_logs(config: k8s.E2EConfig, agent: str, source_node: str) -> None:
+    print(f"--- agent {agent} on {source_node} (tail 200) ---")
+    print(k8s.pod_logs(config.namespace, agent, tail_lines=200))
+
+
+def _dump_nvidia_smi(config: k8s.E2EConfig, agent: str, source_node: str) -> None:
+    print(f"--- nvidia-smi on {source_node} ---")
+    print(k8s.exec_command(config.namespace, agent, "nvidia-smi 2>&1 || true"))
+
+
+def _dump_host_monitoring(config: k8s.E2EConfig, source_node: str) -> None:
+    print(f"--- host monitoring agents (datadog/dcgm) on {source_node} ---")
+    print(host_monitoring_agents(config, source_node))
+
+
+def _dump_kernel_log(config: k8s.E2EConfig, agent: str, source_node: str) -> None:
+    # A CRIU crash ("criu swrk failed: signal: segmentation fault") leaves
+    # no restore.log behind; the kernel's trap line is then the only
+    # record of where it died. The agent is privileged with hostPID, so
+    # its dmesg is the node's.
+    # Also match memory-pressure kills: a task in the seized tree dying with
+    # SIGKILL mid-dump is either the OOM killer (visible here) or a userspace
+    # killer (not visible here); the two need different investigations.
+    print(f"--- kernel log (criu/segfault/oom) on {source_node} ---")
+    print(
+        k8s.exec_command(
+            config.namespace,
+            agent,
+            "dmesg -T 2>/dev/null "
+            "| grep -iE 'criu|segfault|traps|nsrestore|cuda|out of memory|killed process|oom|memory cgroup' "
+            "| tail -40 || echo '<dmesg unavailable>'",
+        )
+    )
+
+
+def _dump_checkpoint_artifact(
+    config: k8s.E2EConfig, run: TestRun, agent: str, source_node: str
+) -> None:
+    content_uid = bound_content_uid(config, run.snapshot_name)
+    if not content_uid:
+        print("no bound PodSnapshotContent; nothing to list")
+        return
+    root = checkpoint_artifact_root(content_uid)
+    print(f"--- checkpoint artifact {content_uid} on {source_node} ---")
+    print(
+        k8s.exec_command(
+            config.namespace,
+            agent,
+            f"ls -la {root}/containers/* 2>&1 | grep -vE ' (core|pagemap|pages|fdinfo|ids|mm|sigacts|fs|tty-info|reg-files|inventory|pstree|files|cgroup|seccomp|timens|utsns|ipcns|netns|mnt|rseq|fanotify|inotify|tls|stats)-?[0-9]*\\.img' 2>&1; "
+            # The diff is applied into the placeholder's rootfs while
+            # the placeholder and then CRIU run from it. Anything under
+            # a library or binary path here is a candidate for
+            # corrupting code that is already mapped.
+            f"for t in {root}/containers/*/rootfs-diff.tar; do "
+            "  if [ -f \"$t\" ]; then echo \"== $t: $(tar -tf \"$t\" | wc -l) entries; libraries/binaries:\"; "
+            "    tar -tf \"$t\" | grep -E '(^|/)(usr/)?(lib|lib64|bin|sbin)/|\\.so(\\.|$)' | head -40; "
+            "    echo '   top-level dirs:'; tar -tf \"$t\" | cut -d/ -f1-2 | sort | uniq -c | sort -rn | head -12; fi; "
+            "done; "
+            # A failed checkpoint never leaves .tmp/, so its dump.log lives
+            # there; the agent log only carries a truncated tail of it.
+            f"for f in {root}/containers/*/restore.log {root}/containers/*/dump.log {root}/.tmp/*/dump.log; do "
+            "  if [ -f \"$f\" ]; then echo \"== $f (errors, then tail 60)\"; "
+            "    grep -E 'Error \\(|Warn  \\(' \"$f\" | tail -20; tail -60 \"$f\"; fi; "
+            "done",
+        )
+    )
+
+
+def _dump_run_events(config: k8s.E2EConfig, run: TestRun) -> None:
+    # Filter first, then order by time: the API returns events unordered, and
+    # in a namespace shared with the controllers the run's events need not be
+    # in any tail of the raw list.
+    names = {run.source_pod, run.restore_pod, run.snapshot_name}
+    events = [
+        event
+        for event in client.CoreV1Api().list_namespaced_event(config.namespace).items
+        if event.involved_object and event.involved_object.name in names
+    ]
+    events.sort(key=event_time)
+    for event in events[-60:]:
+        involved = event.involved_object
+        print(f"event {involved.kind}/{involved.name} {event.reason}: {event.message}")
+
+def event_time(event: client.CoreV1Event) -> datetime:
+    return (
+        event.last_timestamp
+        or event.event_time
+        or event.metadata.creation_timestamp
+        or datetime.min.replace(tzinfo=timezone.utc)
+    )
+
+def bound_content_uid(config: k8s.E2EConfig, snapshot_name: str) -> str | None:
+    """UID of the PodSnapshotContent bound to the run's PodSnapshot, if any."""
+    api = client.CustomObjectsApi()
+    try:
+        snap = api.get_namespaced_custom_object(
+            GROUP, VERSION, config.namespace, PODSNAPSHOTS, snapshot_name
+        )
+        content_name = snap.get("status", {}).get("boundSnapshotContentName")
+        if not content_name:
+            return None
+        content = api.get_cluster_custom_object(GROUP, VERSION, PODSNAPSHOTCONTENTS, content_name)
+        return content["metadata"]["uid"]
+    except ApiException:
+        return None
+
+
+def pod_runtime_state(namespace: str, pod: str) -> str:
+    """Process list, listening TCP sockets, and control-dir error sentinels, best-effort."""
+    command = (
+        "ps -eo pid,ppid,stat,etime,rss,cmd --sort=pid 2>/dev/null | cut -c1-200 | head -60 "
+        "|| echo '<ps unavailable>'; "
+        "echo '-- listening (/proc/net/tcp, hex ports) --'; "
+        "awk 'NR>1 && $4==\"0A\" {print $2}' /proc/net/tcp /proc/net/tcp6 2>/dev/null | sort -u; "
+        # Where each thread of the engine processes is blocked in the kernel:
+        # a stuck CUDA driver ioctl, a futex, or a socket read tell very
+        # different stories, and none of them reach the container log.
+        "echo '-- kernel wait channels (pid/tid state wchan) --'; "
+        "for p in $(ps -eo pid,cmd --sort=pid 2>/dev/null | awk 'NR>1 && ($2 ~ /python|sglang|vllm|trtllm/) {print $1}' | head -8); do "
+        "  for t in /proc/$p/task/*; do "
+        "    printf '%s/%s %s %s\\n' \"$p\" \"$(basename $t)\" \"$(awk '{print $3}' $t/stat 2>/dev/null)\" \"$(cat $t/wchan 2>/dev/null)\"; "
+        "  done; "
+        "done | sort | uniq -c | sort -rn | head -40; "
+        # Python stacks of every Python process (the guide images ship py-spy):
+        # the only way to see where a restored program blocks.
+        "echo '-- py-spy dumps --'; "
+        "if command -v py-spy >/dev/null 2>&1; then "
+        "  for p in $(ps -eo pid,cmd --sort=pid 2>/dev/null | awk 'NR>1 && $2 ~ /python/ {print $1}' | head -6); do "
+        "    echo \"== pid $p\"; timeout 20 py-spy dump --pid $p --nonblocking 2>&1 | head -60; "
+        "  done; "
+        "else echo '<py-spy not installed>'; fi; "
+        "echo '-- nvidia-smi --'; "
+        "nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv 2>&1 | head -3; "
+        "nvidia-smi --query-compute-apps=pid,used_memory --format=csv 2>&1 | head -6; "
+        f"for f in {CONTROL_DIR}/*-restore-progress {CONTROL_DIR}/*-restore-error; do "
+        "  if [ -f \"$f\" ]; then echo \"-- $f --\"; cat \"$f\"; fi; "
+        "done"
+    )
+    try:
+        return k8s.exec_command(namespace, pod, command).strip()
+    except Exception as exc:  # noqa: BLE001 - debug helper must never mask the real failure
+        return f"<unavailable: {type(exc).__name__}: {exc}>"
 
 
 def snapshot_control_listing(namespace: str, pod: str) -> str:

--- a/e2e/snapshot_e2e/lifecycle.py
+++ b/e2e/snapshot_e2e/lifecycle.py
@@ -206,7 +206,7 @@ def wait_for_file(namespace: str, pod: str, path: str, timeout: int = 180) -> No
             )
             response = k8s.exec_command(namespace, pod, command)
             last_error = None
-            return True if response == marker else None
+            return True if marker in response else None
         except Exception as exc:
             last_error = f"{type(exc).__name__}: {exc}"
             return None
@@ -250,14 +250,18 @@ def wait_for_restore_outcome(
         except Exception as exc:
             last_error = f"{type(exc).__name__}: {exc}"
             return None
-        if output.startswith(f"{marker}:error"):
-            body = output.split("\n", 1)[1] if "\n" in output else ""
+        marker_at = output.rfind(marker)
+        if marker_at < 0:
+            return None
+        tail = output[marker_at:]
+        body = tail.split("\n", 1)[1] if "\n" in tail else ""
+        if tail.startswith(f"{marker}:error"):
             raise AssertionError(
                 f"restored program in {namespace}/{pod} failed after restore "
                 f"({error_file}):\n{body}"
             )
-        if output.startswith(f"{marker}:ready"):
-            return output.split("\n", 1)[1] if "\n" in output else ""
+        if tail.startswith(f"{marker}:ready"):
+            return body
         return None
 
     def detail() -> str:

--- a/e2e/snapshot_e2e/manifests/frameworks/sglang/app.py
+++ b/e2e/snapshot_e2e/manifests/frameworks/sglang/app.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+import time
+import traceback
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("prime", "snapshot"), default="snapshot")
+    return parser.parse_args()
+
+
+def configure_capture_environment() -> None:
+    os.environ.update(
+        {
+            "NCCL_CUMEM_ENABLE": "0",
+            "NCCL_NVLS_ENABLE": "0",
+            "NCCL_IB_DISABLE": "1",
+            "NCCL_RAS_ENABLE": "0",
+            "TORCH_NCCL_ENABLE_MONITORING": "0",
+            "TORCH_NCCL_DUMP_ON_TIMEOUT": "0",
+            "HF_HUB_OFFLINE": "1",
+        }
+    )
+
+
+def create_engine(snapshot_mode: bool) -> Any:
+    import sglang as sgl
+
+    return sgl.Engine(
+        model_path=os.environ["SNAPSHOT_MODEL"],
+        context_length=int(os.environ.get("SGLANG_CONTEXT_LENGTH", "10240")),
+        page_size=int(os.environ.get("SGLANG_PAGE_SIZE", "16")),
+        tp_size=1,
+        trust_remote_code=False,
+        enable_memory_saver=snapshot_mode,
+        enable_weights_cpu_backup=snapshot_mode,
+        log_level="info",
+    )
+
+
+def generate_text(engine: Any, prompt: str) -> str:
+    result = engine.generate(
+        prompt,
+        sampling_params={"temperature": 0, "max_new_tokens": 16},
+    )
+    text = result.get("text", "").strip()
+    if not text:
+        raise RuntimeError("SGLang produced empty output")
+    return text
+
+
+def pause_generation(engine: Any) -> None:
+    from sglang.srt.managers.io_struct import PauseGenerationReqInput
+
+    # "retract" drains the scheduler before pausing: it processes any pending
+    # overlap result, clears last_batch and running_batch, and re-queues
+    # unfinished requests (there are none here; the warm-up generation has
+    # returned). release_memory_occupation() asserts is_fully_idle(), which
+    # also requires last_batch to be empty. The default "in_place" mode freezes
+    # scheduler state untouched, so pausing right after a generation leaves a
+    # stale last_batch and the release fails with "should be called only when
+    # server is idle" (SGLang 0.5.17).
+    engine.loop.run_until_complete(
+        engine.tokenizer_manager.pause_generation(PauseGenerationReqInput(mode="retract"))
+    )
+
+
+def continue_generation(engine: Any) -> None:
+    from sglang.srt.managers.io_struct import ContinueGenerationReqInput
+
+    engine.loop.run_until_complete(
+        engine.tokenizer_manager.continue_generation(ContinueGenerationReqInput())
+    )
+
+
+def serve_api(engine: Any, restored_text: str) -> None:
+    class GenerateHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            if self.path != "/generate":
+                self.send_error(404)
+                return
+
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(length))
+                prompt = payload["prompt"]
+                if not isinstance(prompt, str) or not prompt.strip():
+                    raise ValueError("prompt must be a non-empty string")
+                text = generate_text(engine, prompt)
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+                self.send_error(400, str(error))
+                return
+            except Exception as error:
+                self.send_error(500, str(error))
+                return
+
+            body = json.dumps({"text": text}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("0.0.0.0", 8000), GenerateHandler)
+    CONTROL_DIR.joinpath("sglang-restore-ready").write_text(
+        restored_text + "\n",
+        encoding="utf-8",
+    )
+    print("SGLang API listening on port 8000", flush=True)
+    server.serve_forever()
+
+
+def main() -> None:
+    args = parse_args()
+    snapshot_mode = args.mode == "snapshot"
+    if snapshot_mode:
+        configure_capture_environment()
+        CONTROL_DIR.joinpath("ready-for-snapshot").unlink(missing_ok=True)
+
+    engine = create_engine(snapshot_mode)
+    try:
+        text = generate_text(engine, "The capital city of France is")
+        print(f"SGLang pre-checkpoint output={text!r}", flush=True)
+
+        if not snapshot_mode:
+            return
+
+        pause_generation(engine)
+        try:
+            engine.release_memory_occupation()
+        except BaseException:
+            continue_generation(engine)
+            raise
+
+        CONTROL_DIR.joinpath("ready-for-snapshot").write_text(
+            "ready\n",
+            encoding="utf-8",
+        )
+
+        while not CONTROL_DIR.joinpath("restore-complete").exists():
+            time.sleep(1)
+
+        # The restored process keeps the source container's stdout, which is
+        # gone; a failure here would otherwise be invisible. Record it in the
+        # control directory next to the success sentinel.
+        try:
+            progress = CONTROL_DIR.joinpath("sglang-restore-progress")
+            engine.resume_memory_occupation()
+            progress.write_text("memory-resumed\n", encoding="utf-8")
+            continue_generation(engine)
+            progress.write_text("generation-continued\n", encoding="utf-8")
+
+            text = generate_text(engine, "The capital city of Germany is")
+            progress.write_text("generated\n", encoding="utf-8")
+            print(f"SGLang restored output={text!r}", flush=True)
+            serve_api(engine, text)
+        except Exception:
+            CONTROL_DIR.joinpath("sglang-restore-error").write_text(
+                traceback.format_exc(),
+                encoding="utf-8",
+            )
+            raise
+    finally:
+        engine.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/snapshot_e2e/manifests/frameworks/sglang/deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/sglang/deployment.yaml
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-source
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sglang-source
+  template:
+    metadata:
+      labels:
+        app: sglang-source
+        nvidia.com/snapshot-is-checkpoint-source: "true"
+    spec:
+      terminationGracePeriodSeconds: 1
+      runtimeClassName: nvidia
+      securityContext:
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/block-iouring.json
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      initContainers:
+        - name: model-cache
+          image: lmsysorg/sglang:v0.5.17-cu130-runtime@sha256:3ea7c6d74312d964edbcf9b3819425ea42117eb967ef1cfec632a70c926027df
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -c
+          args:
+            - |
+              import os
+              from pathlib import Path
+              from huggingface_hub import snapshot_download
+              model = os.environ["SNAPSHOT_MODEL"]
+              marker = Path("/hf-cache") / (".snapshot-model-" + model.replace("/", "--"))
+              if not marker.exists():
+                  snapshot_download(repo_id=model)
+                  marker.touch()
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: HF_HOME
+              value: /hf-cache
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /hf-cache
+      containers:
+        - name: main
+          image: lmsysorg/sglang:v0.5.17-cu130-runtime@sha256:3ea7c6d74312d964edbcf9b3819425ea42117eb967ef1cfec632a70c926027df
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -u
+            - /snapshot-app/app.py
+          args:
+            - --mode
+            - snapshot
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: SGLANG_CONTEXT_LENGTH
+              value: "10240"
+            - name: SGLANG_PAGE_SIZE
+              value: "16"
+            - name: SNAPSHOT_CONTROL_DIR
+              value: /snapshot-control
+            - name: HF_HOME
+              value: /hf-cache
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: NCCL_CUMEM_ENABLE
+              value: "0"
+            - name: NCCL_NVLS_ENABLE
+              value: "0"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_RAS_ENABLE
+              value: "0"
+            - name: TORCH_NCCL_ENABLE_MONITORING
+              value: "0"
+            - name: TORCH_NCCL_DUMP_ON_TIMEOUT
+              value: "0"
+          ports:
+            - name: api
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /snapshot-control/ready-for-snapshot
+            periodSeconds: 1
+            failureThreshold: 1800
+          volumeMounts:
+            - name: model-cache
+              mountPath: /hf-cache
+            - name: snapshot-control
+              mountPath: /snapshot-control
+              subPath: main
+            - name: tun
+              mountPath: /dev/net/tun
+            - name: app
+              mountPath: /snapshot-app
+              readOnly: true
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: sglang-model-cache
+        - name: snapshot-control
+          emptyDir: {}
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        # Created from app.py: kubectl create configmap sglang-app --from-file=app.py
+        - name: app
+          configMap:
+            name: sglang-app

--- a/e2e/snapshot_e2e/manifests/frameworks/sglang/model-cache-pvc.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/sglang/model-cache-pvc.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sglang-model-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/e2e/snapshot_e2e/manifests/frameworks/sglang/restore-deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/sglang/restore-deployment.yaml
@@ -64,9 +64,6 @@ spec:
             - /bin/sh
             - -c
             - exec sleep infinity
-          args:
-            - --mode
-            - snapshot
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B

--- a/e2e/snapshot_e2e/manifests/frameworks/sglang/restore-deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/sglang/restore-deployment.yaml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-restored
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sglang-restored
+  template:
+    metadata:
+      labels:
+        app: sglang-restored
+      annotations:
+        nvidia.com/restore-from: sglang-snapshot
+    spec:
+      terminationGracePeriodSeconds: 1
+      runtimeClassName: nvidia
+      securityContext:
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/block-iouring.json
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      initContainers:
+        - name: model-cache
+          image: lmsysorg/sglang:v0.5.17-cu130-runtime@sha256:3ea7c6d74312d964edbcf9b3819425ea42117eb967ef1cfec632a70c926027df
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -c
+          args:
+            - |
+              import os
+              from pathlib import Path
+              from huggingface_hub import snapshot_download
+              model = os.environ["SNAPSHOT_MODEL"]
+              marker = Path("/hf-cache") / (".snapshot-model-" + model.replace("/", "--"))
+              if not marker.exists():
+                  snapshot_download(repo_id=model)
+                  marker.touch()
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: HF_HOME
+              value: /hf-cache
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /hf-cache
+      containers:
+        - name: main
+          image: lmsysorg/sglang:v0.5.17-cu130-runtime@sha256:3ea7c6d74312d964edbcf9b3819425ea42117eb967ef1cfec632a70c926027df
+          imagePullPolicy: IfNotPresent
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
+          args:
+            - --mode
+            - snapshot
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: SGLANG_CONTEXT_LENGTH
+              value: "10240"
+            - name: SNAPSHOT_CONTROL_DIR
+              value: /snapshot-control
+            - name: HF_HOME
+              value: /hf-cache
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: NCCL_CUMEM_ENABLE
+              value: "0"
+            - name: NCCL_NVLS_ENABLE
+              value: "0"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_RAS_ENABLE
+              value: "0"
+            - name: TORCH_NCCL_ENABLE_MONITORING
+              value: "0"
+            - name: TORCH_NCCL_DUMP_ON_TIMEOUT
+              value: "0"
+          ports:
+            - name: api
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /snapshot-control/sglang-restore-ready
+            periodSeconds: 1
+            failureThreshold: 1800
+          volumeMounts:
+            - name: model-cache
+              mountPath: /hf-cache
+            - name: snapshot-control
+              mountPath: /snapshot-control
+              subPath: main
+            - name: tun
+              mountPath: /dev/net/tun
+            # The checkpointed process's mount namespace includes this
+            # mount (from the source Pod); restore recreates it here too,
+            # even though this placeholder's own command never reads it.
+            - name: app
+              mountPath: /snapshot-app
+              readOnly: true
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: sglang-model-cache
+        - name: snapshot-control
+          emptyDir: {}
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        - name: app
+          configMap:
+            name: sglang-app

--- a/e2e/snapshot_e2e/manifests/frameworks/tensorrt-llm/app.py
+++ b/e2e/snapshot_e2e/manifests/frameworks/tensorrt-llm/app.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import json
+import os
+import time
+import traceback
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+from tensorrt_llm import LLM, SamplingParams
+
+CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
+MODEL = os.environ["SNAPSHOT_MODEL"]
+# Small single-GPU sizing so the example fits alongside other GPU tenants and
+# keeps the checkpoint artifact small. Override through the Pod template.
+MAX_NUM_TOKENS = int(os.environ.get("TRTLLM_MAX_NUM_TOKENS", "1024"))
+MAX_BATCH_SIZE = int(os.environ.get("TRTLLM_MAX_BATCH_SIZE", "1"))
+FREE_GPU_MEMORY_FRACTION = float(
+    os.environ.get("TRTLLM_FREE_GPU_MEMORY_FRACTION", "0.10")
+)
+TRUST_REMOTE_CODE = False
+
+
+def generate_text(llm: LLM, prompts: list[str]) -> list[str]:
+    outputs = llm.generate(
+        prompts,
+        SamplingParams(temperature=0.0, max_tokens=16),
+        use_tqdm=False,
+    )
+    texts = []
+    for output in outputs:
+        if not output.outputs:
+            raise RuntimeError("TensorRT-LLM produced no output")
+        text = output.outputs[0].text.strip()
+        if not text:
+            raise RuntimeError("TensorRT-LLM produced empty output")
+        texts.append(text)
+    return texts
+
+
+def serve_api(llm: LLM, restored_text: str) -> None:
+    class GenerateHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            if self.path != "/generate":
+                self.send_error(404)
+                return
+
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(length))
+                prompt = payload["prompt"]
+                if not isinstance(prompt, str) or not prompt.strip():
+                    raise ValueError("prompt must be a non-empty string")
+                text = generate_text(llm, [prompt])[0]
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+                self.send_error(400, str(error))
+                return
+            except Exception as error:
+                self.send_error(500, str(error))
+                return
+
+            body = json.dumps({"text": text}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("0.0.0.0", 8000), GenerateHandler)
+    CONTROL_DIR.joinpath("trtllm-restore-ready").write_text(
+        restored_text + "\n",
+        encoding="utf-8",
+    )
+    print("TensorRT-LLM API listening on port 8000", flush=True)
+    server.serve_forever()
+
+
+def main() -> None:
+    CONTROL_DIR.joinpath("ready-for-snapshot").unlink(missing_ok=True)
+
+    llm = LLM(
+        model=MODEL,
+        backend="pytorch",
+        dtype="float16",
+        trust_remote_code=TRUST_REMOTE_CODE,
+        tensor_parallel_size=1,
+        max_num_tokens=MAX_NUM_TOKENS,
+        max_seq_len=512,
+        max_batch_size=MAX_BATCH_SIZE,
+        enable_chunked_prefill=False,
+        kv_cache_config={"free_gpu_memory_fraction": FREE_GPU_MEMORY_FRACTION},
+    )
+
+    for text in generate_text(
+        llm,
+        [
+            "Summarize why checkpoint and restore testing matters.",
+            "Continue this sequence with four numbers: 1, 2, 3, 4,",
+        ],
+    ):
+        print(f"TensorRT-LLM pre-checkpoint output={text!r}", flush=True)
+
+    gc.collect()
+    CONTROL_DIR.joinpath("ready-for-snapshot").write_text(
+        "ready\n",
+        encoding="utf-8",
+    )
+
+    while True:
+        if CONTROL_DIR.joinpath("restore-complete").exists():
+            # The restored process keeps the source container's stdout, which
+            # is gone; a failure here would otherwise be invisible. Record it
+            # in the control directory next to the success sentinel.
+            try:
+                progress = CONTROL_DIR.joinpath("trtllm-restore-progress")
+                text = generate_text(llm, ["Reply with one word: restored"])[0]
+                progress.write_text("generated\n", encoding="utf-8")
+                print(f"TensorRT-LLM restored output={text!r}", flush=True)
+                serve_api(llm, text)
+            except Exception:
+                CONTROL_DIR.joinpath("trtllm-restore-error").write_text(
+                    traceback.format_exc(),
+                    encoding="utf-8",
+                )
+                raise
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/snapshot_e2e/manifests/frameworks/tensorrt-llm/deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/tensorrt-llm/deployment.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tensorrt-llm-source
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tensorrt-llm-source
+  template:
+    metadata:
+      labels:
+        app: tensorrt-llm-source
+        nvidia.com/snapshot-is-checkpoint-source: "true"
+    spec:
+      terminationGracePeriodSeconds: 1
+      runtimeClassName: nvidia
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/block-iouring.json
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: main
+          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - /snapshot-app/app.py
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: TRTLLM_MAX_NUM_TOKENS
+              value: "1024"
+            - name: TRTLLM_MAX_BATCH_SIZE
+              value: "1"
+            - name: TRTLLM_FREE_GPU_MEMORY_FRACTION
+              value: "0.10"
+            - name: SNAPSHOT_CONTROL_DIR
+              value: /snapshot-control
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: TLLM_NCCL_SYMMETRIC_ZERO_COPY
+              value: "0"
+            - name: UCX_TLS
+              value: tcp,self
+          ports:
+            - name: api
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /snapshot-control/ready-for-snapshot
+            periodSeconds: 1
+            failureThreshold: 1800
+          volumeMounts:
+            - name: snapshot-control
+              mountPath: /snapshot-control
+              subPath: main
+            - name: tun
+              mountPath: /dev/net/tun
+            - name: app
+              mountPath: /snapshot-app
+              readOnly: true
+      volumes:
+        - name: snapshot-control
+          emptyDir: {}
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        # Created from app.py: kubectl create configmap tensorrt-llm-app --from-file=app.py
+        - name: app
+          configMap:
+            name: tensorrt-llm-app

--- a/e2e/snapshot_e2e/manifests/frameworks/tensorrt-llm/restore-deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/tensorrt-llm/restore-deployment.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tensorrt-llm-restored
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tensorrt-llm-restored
+  template:
+    metadata:
+      labels:
+        app: tensorrt-llm-restored
+      annotations:
+        nvidia.com/restore-from: tensorrt-llm-snapshot
+    spec:
+      terminationGracePeriodSeconds: 1
+      runtimeClassName: nvidia
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/block-iouring.json
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: main
+          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24@sha256:16a103b8b1b682d287e8043fc674d23fa52d5b5f2127da913bf6c0643db3a073
+          imagePullPolicy: IfNotPresent
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: SNAPSHOT_CONTROL_DIR
+              value: /snapshot-control
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: TLLM_NCCL_SYMMETRIC_ZERO_COPY
+              value: "0"
+            - name: UCX_TLS
+              value: tcp,self
+          ports:
+            - name: api
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /snapshot-control/trtllm-restore-ready
+            periodSeconds: 1
+            failureThreshold: 1800
+          volumeMounts:
+            - name: snapshot-control
+              mountPath: /snapshot-control
+              subPath: main
+            - name: tun
+              mountPath: /dev/net/tun
+            # The checkpointed process's mount namespace includes this
+            # mount (from the source Pod); restore recreates it here too,
+            # even though this placeholder's own command never reads it.
+            - name: app
+              mountPath: /snapshot-app
+              readOnly: true
+      volumes:
+        - name: snapshot-control
+          emptyDir: {}
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        - name: app
+          configMap:
+            name: tensorrt-llm-app

--- a/e2e/snapshot_e2e/manifests/frameworks/vllm/app.py
+++ b/e2e/snapshot_e2e/manifests/frameworks/vllm/app.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import os
+import traceback
+from pathlib import Path
+from uuid import uuid4
+
+# This script calls AsyncLLM directly rather than vLLM's CLI wrapper, which
+# sets this automatically when unset. Without it, worker startup defaults to
+# fork (or switches to spawn only if vLLM detects CUDA already initialized),
+# which is unreliable across checkpoint/restore.
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from vllm import SamplingParams
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.async_llm import AsyncLLM
+
+CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
+MODEL = os.environ["SNAPSHOT_MODEL"]
+# Small single-GPU sizing so the example fits alongside other GPU tenants and
+# keeps the checkpoint artifact small. Override through the Pod template.
+MAX_MODEL_LEN = int(os.environ.get("VLLM_MAX_MODEL_LEN", "2048"))
+GPU_MEMORY_UTILIZATION = float(os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "0.30"))
+TRUST_REMOTE_CODE = False
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(min_length=1)
+
+
+async def generate_text(
+    engine: AsyncLLM,
+    prompt: str,
+    request_id: str,
+) -> str:
+    result = None
+    async for output in engine.generate(
+        prompt,
+        SamplingParams(temperature=0.0, max_tokens=8),
+        request_id,
+    ):
+        result = output
+    if result is None or not result.outputs:
+        raise RuntimeError("vLLM produced no output")
+    text = result.outputs[0].text.strip()
+    if not text:
+        raise RuntimeError("vLLM produced empty output")
+    return text
+
+
+async def serve_api(engine: AsyncLLM, restored_text: str) -> None:
+    app = FastAPI()
+
+    @app.post("/generate")
+    async def generate(request: GenerateRequest) -> dict[str, str]:
+        text = await generate_text(
+            engine,
+            request.prompt,
+            f"request-{uuid4().hex}",
+        )
+        return {"text": text}
+
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host="0.0.0.0",
+            port=8000,
+        )
+    )
+    server_task = asyncio.create_task(server.serve())
+    while not server.started:
+        if server_task.done():
+            await server_task
+            raise RuntimeError("API stopped before startup")
+        await asyncio.sleep(0.1)
+
+    CONTROL_DIR.joinpath("vllm-restore-ready").write_text(
+        restored_text + "\n",
+        encoding="utf-8",
+    )
+    print("vLLM API listening on port 8000", flush=True)
+    await server_task
+
+
+async def main() -> None:
+    CONTROL_DIR.joinpath("ready-for-snapshot").unlink(missing_ok=True)
+
+    engine = AsyncLLM.from_engine_args(
+        AsyncEngineArgs(
+            model=MODEL,
+            enable_sleep_mode=True,
+            max_model_len=MAX_MODEL_LEN,
+            gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+            trust_remote_code=TRUST_REMOTE_CODE,
+        ),
+        usage_context=UsageContext.LLM_CLASS,
+    )
+
+    text = await generate_text(
+        engine,
+        "Reply with one word: ready",
+        "snapshot-preflight",
+    )
+    print(f"vLLM pre-checkpoint output={text!r}", flush=True)
+
+    await engine.pause_generation()
+    await engine.sleep()
+    CONTROL_DIR.joinpath("ready-for-snapshot").write_text(
+        "ready\n",
+        encoding="utf-8",
+    )
+
+    while True:
+        if CONTROL_DIR.joinpath("restore-complete").exists():
+            # The restored process keeps the source container's stdout, which
+            # is gone; a failure here would otherwise be invisible. Record it
+            # in the control directory next to the success sentinel.
+            try:
+                progress = CONTROL_DIR.joinpath("vllm-restore-progress")
+                await engine.wake_up()
+                progress.write_text("woken\n", encoding="utf-8")
+                await engine.resume_generation()
+                await engine.check_health()
+                progress.write_text("generation-resumed\n", encoding="utf-8")
+                text = await generate_text(
+                    engine,
+                    "Reply with one word: restored",
+                    "snapshot-restore-check",
+                )
+                progress.write_text("generated\n", encoding="utf-8")
+                print(f"vLLM restored output={text!r}", flush=True)
+                await serve_api(engine, text)
+            except Exception:
+                CONTROL_DIR.joinpath("vllm-restore-error").write_text(
+                    traceback.format_exc(),
+                    encoding="utf-8",
+                )
+                raise
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+    os._exit(0)

--- a/e2e/snapshot_e2e/manifests/frameworks/vllm/deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/vllm/deployment.yaml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-source
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: vllm-source
+  template:
+    metadata:
+      labels:
+        app: vllm-source
+        nvidia.com/snapshot-is-checkpoint-source: "true"
+    spec:
+      terminationGracePeriodSeconds: 1
+      runtimeClassName: nvidia
+      securityContext:
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/block-iouring.json
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: main
+          image: vllm/vllm-openai:v0.27.1-ubuntu2404@sha256:dafea057f24b7d42716331a48e2db4e1f204f877a3aa759cb7e4c37e64ca2eee
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - /snapshot-app/app.py
+          env:
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: VLLM_MAX_MODEL_LEN
+              value: "2048"
+            - name: VLLM_GPU_MEMORY_UTILIZATION
+              value: "0.30"
+            - name: SNAPSHOT_CONTROL_DIR
+              value: /snapshot-control
+          ports:
+            - name: api
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /snapshot-control/ready-for-snapshot
+            periodSeconds: 1
+            failureThreshold: 1200
+          volumeMounts:
+            - name: snapshot-control
+              mountPath: /snapshot-control
+              subPath: main
+            - name: tun
+              mountPath: /dev/net/tun
+            - name: app
+              mountPath: /snapshot-app
+              readOnly: true
+      volumes:
+        - name: snapshot-control
+          emptyDir: {}
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        # Created from app.py: kubectl create configmap vllm-app --from-file=app.py
+        - name: app
+          configMap:
+            name: vllm-app

--- a/e2e/snapshot_e2e/manifests/frameworks/vllm/restore-deployment.yaml
+++ b/e2e/snapshot_e2e/manifests/frameworks/vllm/restore-deployment.yaml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-restored
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: vllm-restored
+  template:
+    metadata:
+      labels:
+        app: vllm-restored
+      annotations:
+        nvidia.com/restore-from: vllm-snapshot
+    spec:
+      terminationGracePeriodSeconds: 1
+      runtimeClassName: nvidia
+      securityContext:
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/block-iouring.json
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: main
+          image: vllm/vllm-openai:v0.27.1-ubuntu2404@sha256:dafea057f24b7d42716331a48e2db4e1f204f877a3aa759cb7e4c37e64ca2eee
+          imagePullPolicy: IfNotPresent
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
+          env:
+            - name: SNAPSHOT_MODEL
+              value: Qwen/Qwen3-0.6B
+            - name: SNAPSHOT_CONTROL_DIR
+              value: /snapshot-control
+          ports:
+            - name: api
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /snapshot-control/vllm-restore-ready
+            periodSeconds: 1
+            failureThreshold: 1200
+          volumeMounts:
+            - name: snapshot-control
+              mountPath: /snapshot-control
+              subPath: main
+            - name: tun
+              mountPath: /dev/net/tun
+            # The checkpointed process's mount namespace includes this
+            # mount (from the source Pod); restore recreates it here too,
+            # even though this placeholder's own command never reads it.
+            - name: app
+              mountPath: /snapshot-app
+              readOnly: true
+      volumes:
+        - name: snapshot-control
+          emptyDir: {}
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        - name: app
+          configMap:
+            name: vllm-app

--- a/e2e/snapshot_e2e/manifests/shared-model-cache-pv.yaml
+++ b/e2e/snapshot_e2e/manifests/shared-model-cache-pv.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Static binding (empty storageClassName, matched by name to the PVC's
+# volumeName) so no provisioner is involved; Retain so deleting the claim can
+# never touch the export. metadata.name and spec.nfs are filled in from
+# SharedModelCache by shared_model_cache_volume().
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: PLACEHOLDER
+spec:
+  capacity:
+    storage: 1024Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  # Sized and mounted like a typical CI model share: read-mostly, many
+  # readers, large sequential reads of safetensors.
+  mountOptions:
+    - vers=4
+    - minorversion=1
+    - sec=sys
+    - nconnect=4
+    - rsize=1048576
+    - wsize=1048576
+    - hard
+  nfs:
+    server: PLACEHOLDER
+    path: PLACEHOLDER

--- a/e2e/snapshot_e2e/manifests/shared-model-cache-pvc.yaml
+++ b/e2e/snapshot_e2e/manifests/shared-model-cache-pvc.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Binds by name to shared-model-cache-pv.yaml (spec.volumeName). All fields
+# are filled in from SharedModelCache by shared_model_cache_volume().
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: PLACEHOLDER
+  namespace: PLACEHOLDER
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: PLACEHOLDER
+  resources:
+    requests:
+      storage: 1024Gi

--- a/e2e/tests/test_framework_manifests.py
+++ b/e2e/tests/test_framework_manifests.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cluster-free checks that the framework guides are usable as e2e workloads.
+
+The framework tests lift the guide Deployments into Pods with minimal edits, so
+anything the guide gets wrong about the checkpoint/restore contract fails on a
+GPU cluster minutes into a run. These checks pin the contract cheaply, on every
+pull request, without a cluster:
+
+- the source and restore pods carry the restore-pod contract pieces the agent
+  relies on (control volume at /snapshot-control with subPath main,
+  SNAPSHOT_CONTROL_DIR, io_uring seccomp profile, /dev/net/tun, nvidia
+  RuntimeClass, one GPU);
+- the restore pod is an inert placeholder (an explicit sleep command) that
+  restores this run's PodSnapshot;
+- the model the guide deploys is the one the tests expect;
+- the image tag is content-addressed and deterministic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from snapshot_e2e import framework_workloads as fw
+from snapshot_e2e import frameworks
+from snapshot_e2e import k8s
+from snapshot_e2e import workloads
+
+CONFIG = k8s.E2EConfig(
+    namespace="snapshot-e2e",
+    release="snapshot",
+    pvc_name="snapshot-pvc",
+    kubeconfig=None,
+)
+IMAGE = "framework-under-test:local"
+CACHE = frameworks.SharedModelCache(
+    server="nfs.example.internal", path="/exports/models", pvc_name="model-cache"
+)
+
+
+@pytest.fixture(autouse=True)
+def _workload_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    # TestRun.new resolves the generic workload image eagerly; these checks
+    # never schedule anything, so any value satisfies it.
+    monkeypatch.setenv("SNAPSHOT_E2E_WORKLOAD_IMAGE", "snapshot-workload:test")
+
+
+@pytest.fixture(params=sorted(frameworks.FRAMEWORKS))
+def spec(request: pytest.FixtureRequest) -> frameworks.FrameworkSpec:
+    return frameworks.FRAMEWORKS[request.param]
+
+
+def pods(spec: frameworks.FrameworkSpec) -> tuple[dict, dict, workloads.TestRun]:
+    run = workloads.TestRun.new("manifest")
+    source = fw.source_pod(config=CONFIG, run=run, spec=spec, image=IMAGE)
+    restore = fw.restore_pod(
+        config=CONFIG, run=run, spec=spec, source_node="gpu-node-0", image=IMAGE
+    )
+    return source, restore, run
+
+
+@pytest.mark.workload
+def test_guide_pods_satisfy_restore_pod_contract(spec: frameworks.FrameworkSpec) -> None:
+    source, restore, _ = pods(spec)
+    for pod in (source, restore):
+        pod_spec = pod["spec"]
+        assert pod_spec["runtimeClassName"] == "nvidia"
+        assert pod_spec["securityContext"]["seccompProfile"] == {
+            "type": "Localhost",
+            "localhostProfile": "profiles/block-iouring.json",
+        }
+        assert pod_spec["restartPolicy"] == "Never"
+
+        main = fw.main_container(pod)
+        assert main["image"] == IMAGE
+        assert main["resources"]["limits"]["nvidia.com/gpu"] == "1"
+        assert fw.env_value(main, "SNAPSHOT_CONTROL_DIR") == workloads.CONTROL_DIR
+        assert {
+            "name": "snapshot-control",
+            "mountPath": workloads.CONTROL_DIR,
+            "subPath": workloads.CONTAINER,
+        } in main["volumeMounts"]
+        assert any(mount["mountPath"] == "/dev/net/tun" for mount in main["volumeMounts"])
+        volumes = {volume["name"]: volume for volume in pod_spec["volumes"]}
+        assert volumes["snapshot-control"] == {"name": "snapshot-control", "emptyDir": {}}
+        assert volumes["tun"]["hostPath"] == {"path": "/dev/net/tun", "type": "CharDevice"}
+        for container in pod_spec.get("initContainers", []):
+            assert container["image"] == IMAGE
+
+
+@pytest.mark.workload
+def test_source_pod_is_checkpointable_and_unannotated(spec: frameworks.FrameworkSpec) -> None:
+    source, _, _ = pods(spec)
+    main = fw.main_container(source)
+    # Ready == checkpointable: the test waits for pod readiness before creating
+    # the PodSnapshot, which is only sound if readiness is gated on the file.
+    assert main["readinessProbe"]["exec"]["command"] == ["cat", workloads.SOURCE_READY]
+    assert fw.env_value(main, "SNAPSHOT_RESTORE_STANDBY") is None
+    assert source["metadata"]["annotations"] == {}
+
+
+@pytest.mark.workload
+def test_source_pod_mounts_app_py_from_the_named_configmap(
+    spec: frameworks.FrameworkSpec,
+) -> None:
+    source, _, _ = pods(spec)
+    main = fw.main_container(source)
+    volumes = {volume["name"]: volume for volume in source["spec"]["volumes"]}
+    assert volumes["app"]["configMap"] == {"name": spec.app_configmap_name}
+    assert {"name": "app", "mountPath": "/snapshot-app", "readOnly": True} in main[
+        "volumeMounts"
+    ]
+    # Runs the mounted copy, not anything baked into the image.
+    assert "/snapshot-app/app.py" in main["command"]
+
+
+@pytest.mark.workload
+def test_restore_pod_also_mounts_the_app_configmap(
+    spec: frameworks.FrameworkSpec,
+) -> None:
+    # CRIU recreates every mount from the source container's mount
+    # namespace, including this one, even though the placeholder's own
+    # command never reads it.
+    _, restore, _ = pods(spec)
+    main = fw.main_container(restore)
+    volumes = {volume["name"]: volume for volume in restore["spec"]["volumes"]}
+    assert volumes["app"]["configMap"] == {"name": spec.app_configmap_name}
+    assert {"name": "app", "mountPath": "/snapshot-app", "readOnly": True} in main[
+        "volumeMounts"
+    ]
+
+
+@pytest.mark.workload
+def test_app_configmap_matches_the_guide_program(
+    spec: frameworks.FrameworkSpec,
+) -> None:
+    configmap = fw.app_configmap(config=CONFIG, spec=spec)
+    assert configmap["metadata"]["name"] == spec.app_configmap_name
+    assert configmap["metadata"]["namespace"] == CONFIG.namespace
+    assert configmap["data"]["app.py"] == spec.app_py.read_text(encoding="utf-8")
+
+
+@pytest.mark.workload
+def test_restore_pod_is_standby_placeholder_for_this_run(spec: frameworks.FrameworkSpec) -> None:
+    _, restore, run = pods(spec)
+    main = fw.main_container(restore)
+    # The guide manifests keep the placeholder inert with an explicit sleep
+    # command; without it the guide program would load a model into the GPU
+    # while the agent restores into the same container.
+    assert main["command"] == ["/bin/sh", "-c", "exec sleep infinity"]
+    assert fw.env_value(main, "SNAPSHOT_RESTORE_STANDBY") is None
+    assert restore["metadata"]["annotations"] == {fw.RESTORE_FROM_ANNOTATION: run.snapshot_name}
+    node_terms = restore["spec"]["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"]
+    assert node_terms[0]["matchFields"][0]["values"] == ["gpu-node-0"]
+
+
+@pytest.mark.workload
+def test_guide_deploys_the_expected_model(spec: frameworks.FrameworkSpec) -> None:
+    source, restore, _ = pods(spec)
+    for pod in (source, restore):
+        for container in pod["spec"].get("initContainers", []) + pod["spec"]["containers"]:
+            model = fw.env_value(container, "SNAPSHOT_MODEL")
+            if model is not None:
+                assert model == spec.model, f"{container['name']} deploys {model}"
+    assert fw.env_value(fw.main_container(source), "SNAPSHOT_MODEL") == spec.model
+
+
+@pytest.mark.workload
+def test_e2e_scheduling_is_merged_into_guide_pods(spec: frameworks.FrameworkSpec) -> None:
+    source, restore, _ = pods(spec)
+    scheduling = workloads.workload_scheduling()
+    for pod in (source, restore):
+        for key, value in scheduling["nodeSelector"].items():
+            assert pod["spec"]["nodeSelector"][key] == value
+        for toleration in scheduling["tolerations"]:
+            assert toleration in pod["spec"]["tolerations"]
+
+
+@pytest.mark.workload
+def test_framework_image_comes_from_the_guide_manifest(
+    spec: frameworks.FrameworkSpec, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SNAPSHOT_E2E_FRAMEWORK_IMAGE", raising=False)
+    first = frameworks.framework_image(spec)
+    second = frameworks.framework_image(spec)
+    assert first == second
+    deployment = fw.load_manifest(spec.deployment_manifest)
+    assert first == deployment["spec"]["template"]["spec"]["containers"][0]["image"]
+    # The upstream framework image, not a Snapshot-built one: no guide-specific
+    # image to build, push, or keep available.
+    assert not first.startswith("ghcr.io/ai-dynamo/snapshot/")
+
+    monkeypatch.setenv("SNAPSHOT_E2E_FRAMEWORK_IMAGE", IMAGE)
+    assert frameworks.framework_image(spec) == IMAGE
+
+
+@pytest.mark.workload
+def test_shared_model_cache_replaces_guide_download(spec: frameworks.FrameworkSpec) -> None:
+    run = workloads.TestRun.new("cache")
+    source = fw.source_pod(config=CONFIG, run=run, spec=spec, image=IMAGE, model_cache=CACHE)
+    restore = fw.restore_pod(
+        config=CONFIG, run=run, spec=spec, source_node="n0", image=IMAGE, model_cache=CACHE
+    )
+    for pod in (source, restore):
+        pod_spec = pod["spec"]
+        # No download init container: the export is mounted read-mostly and the
+        # pod runs offline, so a downloader would fail or race the readers.
+        assert not any(
+            c["name"] == fw.GUIDE_CACHE_INIT_CONTAINER for c in pod_spec.get("initContainers", [])
+        )
+        volumes = {v["name"]: v for v in pod_spec["volumes"]}
+        assert volumes[frameworks.MODEL_CACHE_VOLUME]["persistentVolumeClaim"] == {
+            "claimName": CACHE.pvc_name
+        }
+        # The guide's own claim (SGLang's sglang-model-cache) must not linger.
+        assert sum(1 for v in pod_spec["volumes"] if v["name"] == frameworks.MODEL_CACHE_VOLUME) == 1
+        main = fw.main_container(pod)
+        assert {
+            "name": frameworks.MODEL_CACHE_VOLUME,
+            "mountPath": frameworks.MODEL_CACHE_MOUNT,
+        } in main["volumeMounts"]
+        assert fw.env_value(main, "HF_HOME") == frameworks.MODEL_CACHE_MOUNT
+        assert fw.env_value(main, "HF_HUB_OFFLINE") == "1"
+        # Exactly one HF_HOME even when the guide already set one (SGLang).
+        assert sum(1 for e in main["env"] if e["name"] == "HF_HOME") == 1
+        # Contract pieces are untouched by the cache rewrite.
+        assert fw.env_value(main, "SNAPSHOT_CONTROL_DIR") == workloads.CONTROL_DIR
+        assert any(m["mountPath"] == "/dev/net/tun" for m in main["volumeMounts"])
+
+
+@pytest.mark.workload
+def test_control_file_names_match_the_guide_program(spec: frameworks.FrameworkSpec) -> None:
+    """The sentinel paths in FrameworkSpec are copies of literals in the guide's
+    app.py. A rename on either side would otherwise surface only as a GPU run
+    timing out on "neither sentinel" minutes later.
+    """
+    program = (spec.manifest_dir / "app.py").read_text(encoding="utf-8")
+    sentinels = [spec.restore_ready_file]
+    error_file = getattr(spec, "restore_error_file", None)
+    if error_file:
+        sentinels.append(error_file)
+    for path in sentinels:
+        name = path.rsplit("/", 1)[-1]
+        assert f'"{name}"' in program, f"{spec.name}/app.py does not write {name!r}"

--- a/e2e/tests/test_framework_manifests.py
+++ b/e2e/tests/test_framework_manifests.py
@@ -149,6 +149,7 @@ def test_restore_pod_is_standby_placeholder_for_this_run(spec: frameworks.Framew
     # command; without it the guide program would load a model into the GPU
     # while the agent restores into the same container.
     assert main["command"] == ["/bin/sh", "-c", "exec sleep infinity"]
+    assert "args" not in main
     assert fw.env_value(main, "SNAPSHOT_RESTORE_STANDBY") is None
     assert restore["metadata"]["annotations"] == {fw.RESTORE_FROM_ANNOTATION: run.snapshot_name}
     node_terms = restore["spec"]["affinity"]["nodeAffinity"][

--- a/e2e/tests/test_frameworks.py
+++ b/e2e/tests/test_frameworks.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint/restore e2e for the inference framework guides.
+
+One test per framework (vLLM, SGLang, TensorRT-LLM), all with the same shape,
+driven by the guide's own program and manifests (see framework_workloads):
+
+1. The source pod loads the model, generates once, pauses the engine, and
+   writes ready-for-snapshot. The generation is synchronous and precedes the
+   sentinel, so Ready means the engine served before capture and the process
+   is checkpointable.
+2. A PodSnapshot captures it. The dump terminates the source process.
+3. A restore pod built from the guide's restore manifest is pinned to the
+   source node. Its own entrypoint stays inert (`sleep infinity`); the agent
+   restores the checkpointed process into it, which resumes the engine,
+   generates again, and serves /generate.
+4. The test asserts the restore condition, the restore-ready file, a live
+   /generate answer, and that the placeholder never loaded a model itself —
+   a restore that silently degraded to a cold start must not pass.
+
+Select frameworks with SNAPSHOT_E2E_FRAMEWORK=vllm[,sglang,...]; CI runs one
+per matrix job. Point SNAPSHOT_E2E_FRAMEWORK_IMAGE at a local build to test an
+unpublished guide change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from snapshot_e2e import framework_workloads as fw
+from snapshot_e2e import frameworks
+from snapshot_e2e import inference
+from snapshot_e2e import k8s
+from snapshot_e2e import lifecycle as snap
+
+
+@pytest.fixture(params=sorted(frameworks.FRAMEWORKS))
+def framework(request: pytest.FixtureRequest) -> frameworks.FrameworkSpec:
+    name = request.param
+    if name not in frameworks.selected_frameworks():
+        pytest.skip(f"{name} not selected by SNAPSHOT_E2E_FRAMEWORK")
+    return frameworks.FRAMEWORKS[name]
+
+
+@pytest.mark.framework
+@pytest.mark.gpu
+def test_framework_checkpoint_restore_serves_inference(
+    config: k8s.E2EConfig,
+    run: snap.TestRun,
+    framework: frameworks.FrameworkSpec,
+) -> None:
+    source_node: str | None = None
+    try:
+        # Shared NFS cache when configured (offline, no download); otherwise the
+        # guide's own cache plumbing, which downloads from Hugging Face.
+        model_cache = frameworks.SharedModelCache.from_env()
+        if model_cache is not None:
+            pv, pvc = fw.shared_model_cache_volume(config=config, cache=model_cache)
+            snap.ensure_pv(pv)
+            snap.ensure_pvc(pvc)
+        else:
+            guide_pvc = fw.model_cache_pvc(config=config, spec=framework)
+            if guide_pvc is not None:
+                snap.ensure_pvc(guide_pvc)
+
+        k8s.apply_configmap(config.namespace, fw.app_configmap(config=config, spec=framework))
+        k8s.create_pod(
+            fw.source_pod(config=config, run=run, spec=framework, model_cache=model_cache)
+        )
+        source = snap.wait_for_pod_ready(
+            config.namespace,
+            run.source_pod,
+            timeout=frameworks.SOURCE_READY_TIMEOUT_SECONDS,
+        )
+        source_node = source.spec.node_name
+        # Recorded on success too, so a flaky restore failure can be correlated
+        # with whether Datadog GPU monitoring was active on the node.
+        print(
+            f"[{framework.name}] host monitoring agents on {source_node}:\n"
+            f"{snap.host_monitoring_agents(config, source_node)}"
+        )
+
+        snap.create_podsnapshot(
+            config.namespace, run.snapshot_name, run.source_pod, source.metadata.uid
+        )
+        pod_snapshot, content = snap.wait_for_snapshot_ready(
+            config.namespace,
+            run.snapshot_name,
+            timeout=frameworks.CHECKPOINT_TIMEOUT_SECONDS,
+        )
+        assert pod_snapshot["status"]["boundSnapshotContentName"] == content["metadata"]["name"]
+        assert content["spec"]["source"]["nodeName"] == source_node
+
+        k8s.delete_pod(config.namespace, run.source_pod)
+        snap.wait_for_pod_deleted(
+            config.namespace, run.source_pod, timeout=frameworks.POD_DELETE_TIMEOUT_SECONDS
+        )
+
+        k8s.create_pod(
+            fw.restore_pod(
+                config=config,
+                run=run,
+                spec=framework,
+                source_node=source_node,
+                model_cache=model_cache,
+            )
+        )
+        snap.wait_for_restored_condition(
+            config.namespace,
+            run.restore_pod,
+            "True",
+            "RestoreSucceeded",
+            timeout=framework.restore_timeout_seconds,
+        )
+        restored_text = snap.wait_for_restore_outcome(
+            config.namespace,
+            run.restore_pod,
+            ready_file=framework.restore_ready_file,
+            error_file=framework.restore_error_file,
+            timeout=framework.restore_timeout_seconds,
+        ).strip()
+        assert restored_text, f"{framework.restore_ready_file} is empty"
+        print(f"[{framework.name}] first post-restore generation: {restored_text!r}")
+
+        answer = inference.request_generate(config.namespace, run.restore_pod, frameworks.PROMPT)
+        print(f"[{framework.name}] /generate after restore: {answer!r}")
+
+        # The placeholder's own entrypoint must have stayed in standby. If it
+        # had loaded a model, its log would show the pre-checkpoint line and
+        # the "restore" would be an ordinary cold start wearing a Restored
+        # condition.
+        restore_logs = k8s.pod_logs(config.namespace, run.restore_pod, tail_lines=2000)
+        assert "pre-checkpoint output=" not in restore_logs, (
+            "restore placeholder loaded a model itself instead of staying in standby"
+        )
+    except Exception:
+        try:
+            snap.debug_dump_framework(
+                config, run, source_node=source_node, image=frameworks.framework_image(framework)
+            )
+        except Exception as debug_exc:  # noqa: BLE001 - must not mask the original failure
+            print(f"framework debug dump failed: {type(debug_exc).__name__}: {debug_exc}")
+        raise

--- a/hack/datadog-gpu-monitoring.py
+++ b/hack/datadog-gpu-monitoring.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn Datadog GPU monitoring off for an e2e run and back on afterwards.
+
+Datadog's GPU monitoring (system-probe + NVML) attaches to GPU processes on
+the node and is a suspected interferer for CRIU/CUDA checkpoint and restore.
+The e2e workflow disables it on the host cluster before the framework jobs and
+restores it when they are done, but only if it was on to begin with.
+
+The Datadog operator exposes the switch in two places; both are handled:
+
+  DatadogAgentProfile  .spec.config.features.gpu.enabled   (per node profile)
+  DatadogAgent         .spec.features.gpu.enabled          (cluster default)
+
+State lives on the resources themselves, so overlapping workflow runs do not
+step on each other. `disable` records the original value in an annotation and
+adds the run to a holders list; `restore` removes the run from the list and
+re-enables only when the list is empty and the original value was on. A
+cluster without the Datadog CRDs is a no-op.
+
+Usage (KUBECONFIG must point at the host cluster):
+
+  datadog-gpu-monitoring.py status [--github-output]
+  datadog-gpu-monitoring.py disable --holder <run-id>
+  datadog-gpu-monitoring.py restore --holder <run-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ANNOTATION_PREFIX = "snapshot-e2e.nvidia.com/"
+WAS_ENABLED = ANNOTATION_PREFIX + "datadog-gpu-was-enabled"
+HOLDERS = ANNOTATION_PREFIX + "datadog-gpu-holders"
+
+# (kubectl resource, path to the gpu feature block)
+KINDS = (
+    ("datadogagentprofiles.datadoghq.com", ("spec", "config", "features", "gpu")),
+    ("datadogagents.datadoghq.com", ("spec", "features", "gpu")),
+)
+
+
+def kubectl(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["kubectl", *args], text=True, capture_output=True, check=check)
+
+
+def dig(obj: dict, path: tuple[str, ...]) -> dict | None:
+    cur: object = obj
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return None
+        cur = cur[key]
+    return cur if isinstance(cur, dict) else None
+
+
+class Target:
+    def __init__(self, resource: str, path: tuple[str, ...], item: dict) -> None:
+        self.resource = resource
+        self.path = path
+        meta = item["metadata"]
+        self.namespace = meta["namespace"]
+        self.name = meta["name"]
+        self.annotations = meta.get("annotations") or {}
+        gpu = dig(item, path) or {}
+        self.enabled = bool(gpu.get("enabled", False))
+
+    @property
+    def ref(self) -> str:
+        return f"{self.resource}/{self.name} -n {self.namespace}"
+
+    @property
+    def holders(self) -> list[str]:
+        raw = self.annotations.get(HOLDERS, "")
+        return [h for h in raw.split(",") if h]
+
+    def set_enabled(self, value: bool) -> None:
+        patch: dict = {"enabled": value}
+        for key in reversed(self.path):
+            patch = {key: patch}
+        kubectl(
+            "patch", self.resource, self.name, "-n", self.namespace,
+            "--type=merge", "-p", json.dumps(patch),
+        )
+
+    def annotate(self, **values: str | None) -> None:
+        args = ["annotate", "--overwrite", self.resource, self.name, "-n", self.namespace]
+        for key, value in values.items():
+            annotation = ANNOTATION_PREFIX + key.replace("_", "-")
+            args.append(f"{annotation}-" if value is None else f"{annotation}={value}")
+        kubectl(*args)
+
+
+def discover() -> list[Target]:
+    targets: list[Target] = []
+    for resource, path in KINDS:
+        result = kubectl("get", resource, "-A", "-o", "json", check=False)
+        if result.returncode != 0:
+            if "doesn't have a resource type" in result.stderr or "the server could not find" in result.stderr:
+                print(f"{resource}: CRD not installed, skipping")
+                continue
+            sys.exit(f"kubectl get {resource} failed: {result.stderr.strip()}")
+        for item in json.loads(result.stdout).get("items", []):
+            targets.append(Target(resource, path, item))
+    return targets
+
+
+def report(targets: list[Target]) -> bool:
+    enabled_any = False
+    if not targets:
+        print("no Datadog operator resources found")
+    for t in targets:
+        holders = ",".join(t.holders) or "-"
+        print(f"{t.ref}: gpu.enabled={t.enabled} was-enabled={t.annotations.get(WAS_ENABLED, '-')} holders={holders}")
+        enabled_any |= t.enabled
+    return enabled_any
+
+
+def github_output(**values: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    enabled = report(discover())
+    if args.github_output:
+        github_output(enabled=str(enabled).lower())
+
+
+def cmd_disable(args: argparse.Namespace) -> None:
+    targets = discover()
+    report(targets)
+    touched = False
+    for t in targets:
+        holders = t.holders
+        if t.enabled:
+            print(f"disabling GPU monitoring on {t.ref}")
+            t.annotate(datadog_gpu_was_enabled="true")
+            t.set_enabled(False)
+        elif not holders:
+            # Off before we got here and not because of another run: leave it
+            # alone and do not claim it, so restore will not turn it on.
+            print(f"{t.ref}: already off, not held by an e2e run; leaving as is")
+            continue
+        if args.holder not in holders:
+            holders.append(args.holder)
+            t.annotate(datadog_gpu_holders=",".join(holders))
+        touched = True
+    github_output(disabled=str(touched).lower())
+
+
+def cmd_restore(args: argparse.Namespace) -> None:
+    targets = discover()
+    report(targets)
+    for t in targets:
+        holders = t.holders
+        if args.holder not in holders:
+            continue
+        holders.remove(args.holder)
+        if holders:
+            print(f"{t.ref}: still held by {','.join(holders)}; leaving GPU monitoring off")
+            t.annotate(datadog_gpu_holders=",".join(holders))
+            continue
+        if t.annotations.get(WAS_ENABLED) == "true":
+            print(f"re-enabling GPU monitoring on {t.ref}")
+            t.set_enabled(True)
+        t.annotate(datadog_gpu_holders=None, datadog_gpu_was_enabled=None)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+    status = sub.add_parser("status", help="print the current state")
+    status.add_argument("--github-output", action="store_true", help="write enabled=true|false to $GITHUB_OUTPUT")
+    status.set_defaults(func=cmd_status)
+    for name, func in (("disable", cmd_disable), ("restore", cmd_restore)):
+        p = sub.add_parser(name)
+        p.add_argument("--holder", required=True, help="identifier of this workflow run")
+        p.set_defaults(func=func)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/resolve-snapshot-image-tag.py
+++ b/hack/resolve-snapshot-image-tag.py
@@ -7,12 +7,23 @@ The e2e run must test the commit it checked out, so the tag is derived from
 HEAD (v0.0.0-g<sha8>) and merely verified to be published for both the
 operator and agent packages. If push-artifacts has not published HEAD yet,
 the run fails instead of silently testing something else.
+
+Pull requests are the exception: push-artifacts publishes only main and
+release branches, so a PR head usually has no images. With --fallback-main the
+resolver first tries the head's own tags (plain, then the branch-slugged form a
+manual push-artifacts dispatch produces), and otherwise falls back to the
+newest plain v0.0.0-g<sha8> tag published for both packages. Plain tags are
+only ever produced from main/release, so the fallback cannot pick up another
+feature branch's build; it is announced loudly because the Snapshot under test
+is then main's, not the PR's.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.parse
@@ -20,11 +31,15 @@ import urllib.request
 
 
 GITHUB_API_VERSION = "2022-11-28"
-MAX_PAGES = 5
+PAGE_SIZE = 100
 ORG = "ai-dynamo"
+PACKAGES = ("snapshot/operator", "snapshot/agent")
+PLAIN_DEV_TAG = re.compile(r"^v0\.0\.0-g[0-9a-f]{8}$")
 
 
 def head_sha() -> str:
+    # On a push (including copy-pr-bot mirror pushes) GITHUB_SHA is the branch
+    # head, which is the commit a branch build would have tagged.
     sha = os.environ.get("GITHUB_SHA")
     if sha:
         return sha
@@ -37,31 +52,79 @@ def head_sha() -> str:
     return result.stdout.strip()
 
 
+def head_ref() -> str:
+    return os.environ.get("GITHUB_HEAD_REF") or os.environ.get("GITHUB_REF_NAME") or ""
+
+
 def dev_tag(sha: str) -> str:
     return f"v0.0.0-g{sha[:8]}"
 
 
-def package_has_tag(package: str, tag: str, headers: dict[str, str]) -> bool:
-    encoded = urllib.parse.quote(package, safe="")
+def branch_dev_tag(ref: str, sha: str) -> str:
+    # Mirrors push-artifacts.yaml: lowercase alphanumerics and single hyphens,
+    # capped at 30 characters, no leading/trailing hyphen.
+    slug = re.sub(r"[^a-z0-9]+", "-", ref.lower()).lstrip("-")[:30].rstrip("-") or "branch"
+    return f"v0.0.0-{slug}-g{sha[:8]}"
 
-    for page in range(1, MAX_PAGES + 1):
+
+_VERSIONS_CACHE: dict[str, list[dict]] = {}
+
+
+def package_versions(package: str, headers: dict[str, str]) -> list[dict]:
+    # One listing per package per run: every tag check below reads from it, so
+    # the fallback path costs the same handful of requests as the strict one.
+    if package in _VERSIONS_CACHE:
+        return _VERSIONS_CACHE[package]
+    encoded = urllib.parse.quote(package, safe="")
+    versions: list[dict] = []
+    # Page until exhausted: dev tags accumulate one per main commit and are not
+    # pruned, so a fixed page budget would eventually hide a published tag.
+    page = 0
+    while True:
+        page += 1
         url = (
             f"https://api.github.com/orgs/{ORG}/packages/container/"
-            f"{encoded}/versions?per_page=100&page={page}"
+            f"{encoded}/versions?per_page={PAGE_SIZE}&page={page}"
         )
         request = urllib.request.Request(url, headers=headers)
         with urllib.request.urlopen(request, timeout=30) as response:
-            versions = json.load(response)
-
-        if not versions:
+            page_versions = json.load(response)
+        if not page_versions:
             break
+        versions.extend(page_versions)
+        if len(page_versions) < PAGE_SIZE:
+            break
+    _VERSIONS_CACHE[package] = versions
+    return versions
 
-        for version in versions:
-            version_tags = version.get("metadata", {}).get("container", {}).get("tags", [])
-            if tag in version_tags:
-                return True
 
-    return False
+def version_tags(version: dict) -> list[str]:
+    return version.get("metadata", {}).get("container", {}).get("tags", [])
+
+
+def package_has_tag(package: str, tag: str, headers: dict[str, str]) -> bool:
+    return any(tag in version_tags(v) for v in package_versions(package, headers))
+
+
+def published_for_all(tag: str, headers: dict[str, str]) -> bool:
+    return all(package_has_tag(package, tag, headers) for package in PACKAGES)
+
+
+def newest_plain_tag(headers: dict[str, str]) -> str | None:
+    """Newest plain dev tag published for every package.
+
+    GHCR lists versions newest first, so the first operator tag also present
+    on the agent package is the newest common one.
+    """
+    per_package = [
+        [tag for v in package_versions(p, headers) for tag in version_tags(v) if PLAIN_DEV_TAG.match(tag)]
+        for p in PACKAGES
+    ]
+    common = set.intersection(*(set(tags) for tags in per_package[1:])) if len(per_package) > 1 else set(per_package[0])
+    for tag in per_package[0]:
+        if tag in common:
+            return tag
+    return None
 
 
 def write_github_env(tag: str) -> None:
@@ -74,6 +137,17 @@ def write_github_env(tag: str) -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--fallback-main",
+        action="store_true",
+        help=(
+            "if the head commit has no published tag (plain or branch-slugged), "
+            "use the newest plain v0.0.0-g<sha8> tag instead of failing"
+        ),
+    )
+    args = parser.parse_args()
+
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": GITHUB_API_VERSION,
@@ -85,12 +159,13 @@ def main() -> int:
     sha = head_sha()
     tag = dev_tag(sha)
 
-    missing = [
-        package
-        for package in ("snapshot/operator", "snapshot/agent")
-        if not package_has_tag(package, tag, headers)
-    ]
-    if missing:
+    if published_for_all(tag, headers):
+        write_github_env(tag)
+        print(f"Resolved Snapshot image tag: {tag} (commit {sha})")
+        return 0
+
+    if not args.fallback_main:
+        missing = [package for package in PACKAGES if not package_has_tag(package, tag, headers)]
         print(
             f"Tag {tag} for commit {sha} is not published for: "
             f"{', '.join(missing)}. Wait for push-artifacts to publish this "
@@ -100,8 +175,40 @@ def main() -> int:
         )
         return 1
 
-    write_github_env(tag)
-    print(f"Resolved Snapshot image tag: {tag} (commit {sha})")
+    ref = head_ref()
+    if ref:
+        branch_tag = branch_dev_tag(ref, sha)
+        if published_for_all(branch_tag, headers):
+            write_github_env(branch_tag)
+            print(f"Resolved Snapshot image tag: {branch_tag} (branch build of commit {sha})")
+            return 0
+
+    fallback = newest_plain_tag(headers)
+    if fallback is None:
+        print(
+            f"Commit {sha} has no published Snapshot images and no plain dev tag "
+            "exists to fall back to.",
+            file=sys.stderr,
+        )
+        return 1
+
+    write_github_env(fallback)
+    # ::warning:: surfaces in the job summary and annotations: anyone reading
+    # a green run must be able to see it did not test this commit's Snapshot.
+    print(
+        f"::warning title=Snapshot images not built for this commit::"
+        f"Commit {sha} has no published operator/agent images; testing against "
+        f"{fallback} (newest main build). Dispatch push-artifacts on this branch "
+        "and re-run to test the commit's own Snapshot."
+    )
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(
+                f"> **Snapshot images not built for this commit.** Tested against `{fallback}` "
+                f"(newest main build); commit `{sha[:8]}` has no published operator/agent images.\n"
+            )
+    print(f"Resolved Snapshot image tag: {fallback} (fallback; commit {sha} unpublished)")
     return 0
 
 


### PR DESCRIPTION
### Summary

Fixes #240

Wires the framework checkpoint/restore tests from #175 into CI: a per-framework GPU matrix on copy-pr-bot mirror branches, nightly, and dispatch; a cluster-free job on every PR; and the helper scripts the GPU job needs. This PR holds only `.github/` and `hack/`.

### Changes

- **`.github/workflows/e2e-frameworks.yaml`**: matrix `vllm | sglang | tensorrt-llm`, `runs-on: prod-deploy-tester-v1`, one vCluster per framework, `SNAPSHOT_E2E_PVC_SIZE=64Gi`. Triggers: `push` to `pull-request/[0-9]+` filtered to `e2e/**`, `docs/guides/**`, `hack/**`, and the workflow itself (the GPU runners reject `pull_request` events); nightly; `workflow_dispatch` with `framework`, `snapshot_tag`, and `datadog_gpu_monitoring`. Steps mirror `e2e.yaml` plus the shared model cache variables, the test, and on failure a diagnostics artifact (cluster YAML, describes, events, agent/operator/workload logs, agent `dmesg`). Job timeout is derived from the test budgets documented next to `SOURCE_READY_TIMEOUT_SECONDS`; concurrency cancels superseded runs per ref.
- **`.github/copy-pr-bot.yaml`** (`enabled: true`). Cannot be verified from a branch since the bot reads its config from the default branch; the first PR after merge must produce a `pull-request/<n>` branch and a run.
- **`.github/workflows/ci.yml`**: `e2e-static` job running the cluster-free framework manifest and workload script checks on every PR.
- **`hack/resolve-snapshot-image-tag.py --fallback-main`**: on any ref other than `main`/`release/*`, resolve head tag → branch-slugged tag → newest plain `v0.0.0-g<sha8>` common to operator and agent, with a `::warning::` and a step-summary note. Listings are paged to exhaustion so accumulated tags cannot push a valid one out of the window. Strict default unchanged.
- **`hack/datadog-gpu-monitoring.py`**: turns the host cluster's Datadog GPU monitoring off for the run and back on afterwards if it was on. Dispatch input `datadog_gpu_monitoring=leave` skips it.
- **Shared model cache**: workflow points at the CI cluster's NFS export via `SNAPSHOT_E2E_MODEL_CACHE_SERVER/PATH`; repository variables take precedence over the defaults, and a step reports which is in use. Defaults stay as literals until repository variables can be created (`admin: false`).

### GPU results

Latest, on the tree at the top of this stack: [34030830624](https://github.com/ai-dynamo/snapshot/actions/runs/34030830624), all three frameworks green (vLLM 7 min, SGLang 7 min, TensorRT-LLM 9 min).

History while the guide fixes in #175 were landing, all `workflow_dispatch` with fallback to `main`'s Snapshot images:

| Run | vLLM | SGLang | TensorRT-LLM |
|---|---|---|---|
| [33619417391](https://github.com/ai-dynamo/snapshot/actions/runs/33619417391) (pre-cache) | ✗ DNS/timeout | ✗ DNS | ✗ DNS |
| [33621269608](https://github.com/ai-dynamo/snapshot/actions/runs/33621269608) (cache) | ✗ CRIU segfault on restore | ✗ pause not idle | ✅ |
| [33622441930](https://github.com/ai-dynamo/snapshot/actions/runs/33622441930) (vLLM only) | ✅ | – | – |
| [33623640483](https://github.com/ai-dynamo/snapshot/actions/runs/33623640483) (`retract`) | ✗ CRIU segfault | ✗ hang after restore | ✅ |
| [33626331376](https://github.com/ai-dynamo/snapshot/actions/runs/33626331376) (error sentinel) | ✅ | ✗ hang after restore | ✅ |
| [33629204404](https://github.com/ai-dynamo/snapshot/actions/runs/33629204404) (progress markers) | ✗ CRIU segfault | ✅ | ✅ |
| [34030830624](https://github.com/ai-dynamo/snapshot/actions/runs/34030830624) (current tree) | ✅ | ✅ | ✅ |

The intermittent vLLM CRIU segfault is an agent-side defect and is documented in #175's known issues; the gate is intentionally kept red when it occurs.

### Verification

- Workflow YAML parses; resolver paths exercised against a fake GHCR listing.
- Run 34030830624 above, dispatched on this branch.

### Review follow-ups

- **PR path filter**: `agent/**`, `operator/**`, `api/**`, `charts/**` removed. A mirror-branch run tests `main`'s Snapshot images and cannot validate those changes; they are covered nightly. Follow-up, not here: build operator/agent images for mirror branches, then drop the fallback.
- **Timeouts**: job timeout recomputed after the image-resolution wait was removed; the relationship to the test budgets is documented in `frameworks.py`.
- **Cache defaults**: kept as a fallback because neither author nor reviewer can create repository variables; remove the literals once the variables exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end checkpoint and restore coverage for vLLM, SGLang, and TensorRT-LLM workloads.
  - Added framework workload configurations, model caching support, restore validation, and inference checks.
  - Added automated diagnostics collection and GPU monitoring management for test runs.
  - Added flexible snapshot image resolution with branch and fallback tag support.

- **Documentation**
  - Documented framework test selection, image configuration, model caches, and image resolution behavior.

- **Tests**
  - Added cluster-free manifest validation and expanded continuous integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


