### PR TITLE
feat/framework e2e model cache

### DIFF
--- a/.github/workflows/e2e-frameworks.yaml
+++ b/.github/workflows/e2e-frameworks.yaml
@@ -81,6 +81,12 @@ jobs:
       SNAPSHOT_E2E_READY_TIMEOUT_SECONDS: "480"
       SNAPSHOT_E2E_RESULT_FILE: ${{ github.workspace }}/.snapshot-e2e-setup-result.json
       SNAPSHOT_E2E_FRAMEWORK: ${{ matrix.framework }}
+      # Shared CI model cache (Hugging Face cache layout on an NFS export):
+      # pods in this cluster cannot resolve huggingface.co, and downloading
+      # weights per run would cost minutes anyway. Repository variables take
+      # precedence; the defaults are the CI cluster's export.
+      SNAPSHOT_E2E_MODEL_CACHE_SERVER: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_SERVER || 'dynamoinfracimodelcache.file.core.windows.net' }}
+      SNAPSHOT_E2E_MODEL_CACHE_PATH: ${{ vars.SNAPSHOT_E2E_MODEL_CACHE_PATH || '/dynamoinfracimodelcache/models' }}
       PYTHONUNBUFFERED: "1"
       UV_LINK_MODE: copy
     steps:

--- a/.github/workflows/e2e-frameworks.yaml
+++ b/.github/workflows/e2e-frameworks.yaml
@@ -311,6 +311,12 @@ jobs:
             kubectl logs -n "${TEST_NAMESPACE}" "${pod}" --all-containers --tail=-1 \
               > "${out}/${pod#pod/}.log"
           done
+          # Kernel trap lines are the only trace a crashed CRIU leaves; the
+          # agent is privileged with hostPID, so its dmesg is the node's.
+          for pod in $(kubectl get pods -n "${TEST_NAMESPACE}" -l app.kubernetes.io/component=snapshot-agent -o name); do
+            kubectl exec -n "${TEST_NAMESPACE}" "${pod}" -c agent -- \
+              sh -c 'dmesg -T 2>/dev/null | tail -300' > "${out}/dmesg-${pod#pod/}.txt" 2>&1 || true
+          done
           echo "DIAGNOSTICS_DIR=${out}" >> "$GITHUB_ENV"
 
       - name: Upload diagnostics

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -61,10 +61,12 @@ def generate_text(engine: Any, prompt: str) -> str:
 def pause_generation(engine: Any) -> None:
     from sglang.srt.managers.io_struct import PauseGenerationReqInput
 
+    # Default pause mode. The generation that ran before this call has already
+    # completed, so there is nothing to abort; "abort" mode does not leave the
+    # scheduler in the idle state release_memory_occupation() requires on
+    # SGLang 0.5.17 and fails with "should be called only when server is idle".
     engine.loop.run_until_complete(
-        engine.tokenizer_manager.pause_generation(
-            PauseGenerationReqInput(mode="abort")
-        )
+        engine.tokenizer_manager.pause_generation(PauseGenerationReqInput())
     )
 
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -154,10 +154,24 @@ SNAPSHOT_E2E_FRAMEWORK=vllm SNAPSHOT_E2E_FRAMEWORK_IMAGE=<registry>/vllm-snapsho
   uv run --project e2e pytest e2e/tests/test_frameworks.py -vv -s
 ```
 
-The SGLang guide uses a persistent model-cache PVC; the test creates it from
-the guide manifest if missing (with `SNAPSHOT_E2E_STORAGE_CLASS` when set) and
-leaves it in place so later runs skip the download. `tests/test_framework_manifests.py`
-pins the guide manifests to the restore-pod contract without a cluster.
+Model weights come from one of two places:
+
+- **Shared model cache** (CI): set `SNAPSHOT_E2E_MODEL_CACHE_SERVER` and
+  `SNAPSHOT_E2E_MODEL_CACHE_PATH` to an NFS export holding a Hugging Face cache
+  in `HF_HOME` layout (`hub/models--<org>--<model>/...`). The test creates a
+  static `PersistentVolume`/`PersistentVolumeClaim` (`SNAPSHOT_E2E_MODEL_CACHE_PVC`,
+  default `model-cache`), mounts it at `/models` on every framework container,
+  sets `HF_HOME=/models` and `HF_HUB_OFFLINE=1`, and drops the guide's download
+  init container. In vCluster mode the setup enables `sync.toHost.persistentVolumes`
+  so the NFS mount options reach the node. The model must already be in the cache.
+- **Guide download** (default without the variables): the guide's own plumbing
+  runs unchanged. SGLang's init container downloads into its PVC, which the test
+  creates from the guide manifest if missing (with `SNAPSHOT_E2E_STORAGE_CLASS`
+  when set) and leaves in place; vLLM and TensorRT-LLM download in-process.
+  This needs working DNS and egress from the pods.
+
+`tests/test_framework_manifests.py` pins the guide manifests, and the cache
+rewrite, to the restore-pod contract without a cluster.
 
 ## Framework Images
 

--- a/e2e/snapshot_e2e/framework_workloads.py
+++ b/e2e/snapshot_e2e/framework_workloads.py
@@ -22,13 +22,32 @@ from typing import Any
 import yaml
 
 from snapshot_e2e import k8s
+from snapshot_e2e.frameworks import MODEL_CACHE_MOUNT
+from snapshot_e2e.frameworks import MODEL_CACHE_VOLUME
 from snapshot_e2e.frameworks import FrameworkSpec
+from snapshot_e2e.frameworks import SharedModelCache
 from snapshot_e2e.frameworks import framework_image
 from snapshot_e2e.workloads import TestRun
 from snapshot_e2e.workloads import same_node_affinity
 from snapshot_e2e.workloads import workload_scheduling
 
 RESTORE_FROM_ANNOTATION = "nvidia.com/restore-from"
+# The guides' own cache plumbing, replaced when a shared cache is configured:
+# the init container downloads into the guide PVC, which the shared export
+# makes both unnecessary and impossible offline.
+GUIDE_CACHE_INIT_CONTAINER = "model-cache"
+# Sized and mounted like a typical CI model share: read-mostly, many readers,
+# large sequential reads of safetensors. Capacity is nominal for an NFS PV.
+SHARED_CACHE_CAPACITY = "1024Gi"
+SHARED_CACHE_MOUNT_OPTIONS = [
+    "vers=4",
+    "minorversion=1",
+    "sec=sys",
+    "nconnect=4",
+    "rsize=1048576",
+    "wsize=1048576",
+    "hard",
+]
 
 
 def load_manifest(path: Path) -> dict[str, Any]:
@@ -42,6 +61,7 @@ def source_pod(
     run: TestRun,
     spec: FrameworkSpec,
     image: str | None = None,
+    model_cache: SharedModelCache | None = None,
 ) -> dict[str, Any]:
     deployment = load_manifest(spec.deployment_manifest)
     pod = pod_from_deployment(
@@ -50,6 +70,7 @@ def source_pod(
         namespace=config.namespace,
         labels=run.labels,
         image=image or framework_image(spec),
+        model_cache=model_cache,
     )
     # The direct PodSnapshot flow: the test creates the PodSnapshot itself, so
     # the source must carry no restore/snapshot annotations of its own.
@@ -64,6 +85,7 @@ def restore_pod(
     spec: FrameworkSpec,
     source_node: str,
     image: str | None = None,
+    model_cache: SharedModelCache | None = None,
 ) -> dict[str, Any]:
     deployment = load_manifest(spec.restore_deployment_manifest)
     pod = pod_from_deployment(
@@ -72,6 +94,7 @@ def restore_pod(
         namespace=config.namespace,
         labels=run.labels,
         image=image or framework_image(spec),
+        model_cache=model_cache,
     )
     # The guide's placeholder annotation names its own PodSnapshot; this run's
     # PodSnapshot is what must be restored. Restore is node-pinned: the agent
@@ -97,6 +120,43 @@ def model_cache_pvc(
     return pvc
 
 
+def shared_model_cache_volume(
+    *,
+    config: k8s.E2EConfig,
+    cache: SharedModelCache,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """PersistentVolume and PersistentVolumeClaim for the shared NFS cache.
+
+    Static binding (empty storageClassName + volumeName) so no provisioner is
+    involved; Retain so deleting the claim can never touch the export.
+    """
+    pv = {
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": cache.pvc_name},
+        "spec": {
+            "capacity": {"storage": SHARED_CACHE_CAPACITY},
+            "accessModes": ["ReadWriteMany"],
+            "persistentVolumeReclaimPolicy": "Retain",
+            "storageClassName": "",
+            "mountOptions": list(SHARED_CACHE_MOUNT_OPTIONS),
+            "nfs": {"server": cache.server, "path": cache.path},
+        },
+    }
+    pvc = {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": cache.pvc_name, "namespace": config.namespace},
+        "spec": {
+            "accessModes": ["ReadWriteMany"],
+            "storageClassName": "",
+            "volumeName": cache.pvc_name,
+            "resources": {"requests": {"storage": SHARED_CACHE_CAPACITY}},
+        },
+    }
+    return pv, pvc
+
+
 def pod_from_deployment(
     deployment: dict[str, Any],
     *,
@@ -104,6 +164,7 @@ def pod_from_deployment(
     namespace: str,
     labels: dict[str, str],
     image: str,
+    model_cache: SharedModelCache | None = None,
 ) -> dict[str, Any]:
     template = copy.deepcopy(deployment["spec"]["template"])
     metadata = template.get("metadata", {})
@@ -114,6 +175,9 @@ def pod_from_deployment(
     # 30s grace period between tests.
     pod_spec["restartPolicy"] = "Never"
     pod_spec["terminationGracePeriodSeconds"] = 1
+
+    if model_cache is not None:
+        use_shared_model_cache(pod_spec, model_cache)
 
     for container in pod_spec.get("initContainers", []) + pod_spec["containers"]:
         container["image"] = image
@@ -136,6 +200,43 @@ def pod_from_deployment(
         },
         "spec": pod_spec,
     }
+
+
+def use_shared_model_cache(pod_spec: dict[str, Any], cache: SharedModelCache) -> None:
+    """Point the Pod at the shared cache instead of downloading.
+
+    Drops the guide's download init container, rebinds (or adds) the
+    model-cache volume to the shared claim, mounts it at MODEL_CACHE_MOUNT on
+    every remaining container, and sets HF_HOME there with HF_HUB_OFFLINE=1 so
+    a missing model fails immediately instead of hanging on the network.
+    """
+    pod_spec["initContainers"] = [
+        c for c in pod_spec.get("initContainers", []) if c["name"] != GUIDE_CACHE_INIT_CONTAINER
+    ]
+    if not pod_spec["initContainers"]:
+        del pod_spec["initContainers"]
+
+    volume = {
+        "name": MODEL_CACHE_VOLUME,
+        "persistentVolumeClaim": {"claimName": cache.pvc_name},
+    }
+    volumes = [v for v in pod_spec.get("volumes", []) if v["name"] != MODEL_CACHE_VOLUME]
+    pod_spec["volumes"] = volumes + [volume]
+
+    for container in pod_spec["containers"]:
+        mounts = [
+            m for m in container.get("volumeMounts", []) if m["name"] != MODEL_CACHE_VOLUME
+        ]
+        mounts.append({"name": MODEL_CACHE_VOLUME, "mountPath": MODEL_CACHE_MOUNT})
+        container["volumeMounts"] = mounts
+        set_env(container, "HF_HOME", MODEL_CACHE_MOUNT)
+        set_env(container, "HF_HUB_OFFLINE", "1")
+
+
+def set_env(container: dict[str, Any], name: str, value: str) -> None:
+    env = [item for item in container.get("env", []) if item.get("name") != name]
+    env.append({"name": name, "value": value})
+    container["env"] = env
 
 
 def main_container(pod: dict[str, Any]) -> dict[str, Any]:

--- a/e2e/snapshot_e2e/frameworks.py
+++ b/e2e/snapshot_e2e/frameworks.py
@@ -31,11 +31,16 @@ API_PORT = 8000
 PROMPT = "Reply with one short sentence confirming this restored worker can serve."
 REQUEST_TIMEOUT_SECONDS = 120
 
-# Phase budgets. The source budget covers image pull, model download, engine
-# load, and the warm-up generation; the checkpoint budget covers the dump and
-# artifact upload; the restore budget covers the agent restore plus the
-# program's own resume and the first post-restore generation.
-SOURCE_READY_TIMEOUT_SECONDS = 300
+# Phase budgets. The source budget covers image pull, model download or cache
+# load, engine load, compilation/CUDA-graph capture, and the warm-up
+# generation; the checkpoint budget covers the dump and artifact upload; the
+# restore budget covers the agent restore plus the program's own resume and
+# the first post-restore generation.
+#
+# The first run on a node pulls a 10-20 GB runtime image (observed: ~4 min on
+# the CI cluster) before the engine even starts, and vLLM then compiles and
+# captures CUDA graphs; 300s was exceeded with the engine still initializing.
+SOURCE_READY_TIMEOUT_SECONDS = 900
 CHECKPOINT_TIMEOUT_SECONDS = 300
 RESTORE_TIMEOUT_SECONDS = 300
 POD_DELETE_TIMEOUT_SECONDS = 180
@@ -94,6 +99,43 @@ FRAMEWORKS: dict[str, FrameworkSpec] = {
         restore_ready_file="/snapshot-control/trtllm-restore-ready",
     ),
 }
+
+
+@dataclass(frozen=True)
+class SharedModelCache:
+    """An NFS export holding a Hugging Face cache in HF_HOME layout.
+
+    CI clusters commonly block or throttle model downloads from the pods, and
+    even where they work, pulling weights on every run is wasted minutes. With
+    a shared cache the framework pods mount the export at MODEL_CACHE_MOUNT,
+    point HF_HOME at it, and run offline; the guide's own per-deployment cache
+    (SGLang's download init container and PVC) is replaced, not duplicated.
+    """
+
+    server: str
+    path: str
+    pvc_name: str
+
+    @classmethod
+    def from_env(cls) -> "SharedModelCache | None":
+        server = os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_SERVER", "").strip()
+        path = os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_PATH", "").strip()
+        if not server and not path:
+            return None
+        if not (server and path):
+            raise RuntimeError(
+                "SNAPSHOT_E2E_MODEL_CACHE_SERVER and SNAPSHOT_E2E_MODEL_CACHE_PATH "
+                "must be set together"
+            )
+        return cls(
+            server=server,
+            path=path,
+            pvc_name=os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_PVC", "model-cache"),
+        )
+
+
+MODEL_CACHE_MOUNT = "/models"
+MODEL_CACHE_VOLUME = "model-cache"
 
 
 def selected_frameworks() -> list[str]:

--- a/e2e/snapshot_e2e/infra/setup.py
+++ b/e2e/snapshot_e2e/infra/setup.py
@@ -504,7 +504,7 @@ def create_vcluster(namespace: str, name: str, k8s_version: str) -> None:
     if node_selector:
         synced_nodes["selector"]["labels"] = node_selector
 
-    values = {
+    values: dict[str, Any] = {
         "controlPlane": {
             "hostPathMapper": {
                 "enabled": True,
@@ -522,6 +522,12 @@ def create_vcluster(namespace: str, name: str, k8s_version: str) -> None:
             },
         },
     }
+    if os.environ.get("SNAPSHOT_E2E_MODEL_CACHE_SERVER"):
+        # The framework tests create a static NFS PersistentVolume for the
+        # shared model cache. Sync it to the host so its mount options are
+        # honored by the node; without this vCluster rewrites the claim to a
+        # host-provisioned volume and the NFS spec is lost.
+        values["sync"]["toHost"] = {"persistentVolumes": {"enabled": True}}
     values_file = write_temp_yaml("snapshot-vcluster-values-", values)
     try:
         run(

--- a/e2e/snapshot_e2e/lifecycle.py
+++ b/e2e/snapshot_e2e/lifecycle.py
@@ -828,6 +828,18 @@ def ensure_pvc(body: dict[str, Any]) -> None:
         print(f"PVC {namespace}/{name} already exists")
 
 
+def ensure_pv(body: dict[str, Any]) -> None:
+    """Creates the cluster-scoped PersistentVolume if it does not exist."""
+    name = body["metadata"]["name"]
+    try:
+        client.CoreV1Api().create_persistent_volume(body)
+        print(f"created PV {name}")
+    except ApiException as exc:
+        if exc.status != 409:
+            raise
+        print(f"PV {name} already exists")
+
+
 def debug_dump_framework(
     config: k8s.E2EConfig,
     run: TestRun,

--- a/e2e/snapshot_e2e/lifecycle.py
+++ b/e2e/snapshot_e2e/lifecycle.py
@@ -882,6 +882,33 @@ def debug_dump_framework(
             print(k8s.pod_logs(config.namespace, agent, tail_lines=200))
             print(f"--- nvidia-smi on {source_node} ---")
             print(k8s.exec_command(config.namespace, agent, "nvidia-smi 2>&1 || true"))
+            # A CRIU crash ("criu swrk failed: signal: segmentation fault") leaves
+            # no restore.log behind; the kernel's trap line is then the only
+            # record of where it died. The agent is privileged with hostPID, so
+            # its dmesg is the node's.
+            print(f"--- kernel log (criu/segfault) on {source_node} ---")
+            print(
+                k8s.exec_command(
+                    config.namespace,
+                    agent,
+                    "dmesg -T 2>/dev/null | grep -iE 'criu|segfault|traps|nsrestore|cuda' | tail -30 "
+                    "|| echo '<dmesg unavailable>'",
+                )
+            )
+            content_uid = bound_content_uid(config, run.snapshot_name)
+            if content_uid:
+                root = checkpoint_artifact_root(content_uid)
+                print(f"--- checkpoint artifact {content_uid} on {source_node} ---")
+                print(
+                    k8s.exec_command(
+                        config.namespace,
+                        agent,
+                        f"ls -la {root}/containers/* 2>&1; "
+                        f"for f in {root}/containers/*/restore.log {root}/containers/*/dump.log; do "
+                        "  if [ -f \"$f\" ]; then echo \"== $f (tail 60)\"; tail -60 \"$f\"; fi; "
+                        "done",
+                    )
+                )
         except Exception as exc:  # noqa: BLE001 - debug helper must never mask the real failure
             print(f"agent diagnostics unavailable: {type(exc).__name__}: {exc}")
     events = core.list_namespaced_event(config.namespace).items
@@ -890,6 +917,22 @@ def debug_dump_framework(
         if involved and involved.name in {run.source_pod, run.restore_pod, run.snapshot_name}:
             print(f"event {involved.kind}/{involved.name} {event.reason}: {event.message}")
     print("--- end debug ---\n")
+
+
+def bound_content_uid(config: k8s.E2EConfig, snapshot_name: str) -> str | None:
+    """UID of the PodSnapshotContent bound to the run's PodSnapshot, if any."""
+    api = client.CustomObjectsApi()
+    try:
+        snap = api.get_namespaced_custom_object(
+            GROUP, VERSION, config.namespace, PODSNAPSHOTS, snapshot_name
+        )
+        content_name = snap.get("status", {}).get("boundSnapshotContentName")
+        if not content_name:
+            return None
+        content = api.get_cluster_custom_object(GROUP, VERSION, PODSNAPSHOTCONTENTS, content_name)
+        return content["metadata"]["uid"]
+    except ApiException:
+        return None
 
 
 def snapshot_control_listing(namespace: str, pod: str) -> str:

--- a/e2e/tests/test_framework_manifests.py
+++ b/e2e/tests/test_framework_manifests.py
@@ -160,6 +160,76 @@ def test_model_cache_pvc_uses_configured_storage_class(monkeypatch: pytest.Monke
     assert fw.model_cache_pvc(config=CONFIG, spec=frameworks.FRAMEWORKS["vllm"]) is None
 
 
+CACHE = frameworks.SharedModelCache(
+    server="nfs.example.internal", path="/exports/models", pvc_name="model-cache"
+)
+
+
+@pytest.mark.workload
+def test_shared_model_cache_replaces_guide_download(spec: frameworks.FrameworkSpec) -> None:
+    run = workloads.TestRun.new("cache")
+    source = fw.source_pod(config=CONFIG, run=run, spec=spec, image=IMAGE, model_cache=CACHE)
+    restore = fw.restore_pod(
+        config=CONFIG, run=run, spec=spec, source_node="n0", image=IMAGE, model_cache=CACHE
+    )
+    for pod in (source, restore):
+        pod_spec = pod["spec"]
+        # No download init container: the export is mounted read-mostly and the
+        # pod runs offline, so a downloader would fail or race the readers.
+        assert not any(
+            c["name"] == fw.GUIDE_CACHE_INIT_CONTAINER for c in pod_spec.get("initContainers", [])
+        )
+        volumes = {v["name"]: v for v in pod_spec["volumes"]}
+        assert volumes[frameworks.MODEL_CACHE_VOLUME]["persistentVolumeClaim"] == {
+            "claimName": CACHE.pvc_name
+        }
+        # The guide's own claim (SGLang's sglang-model-cache) must not linger.
+        assert sum(1 for v in pod_spec["volumes"] if v["name"] == frameworks.MODEL_CACHE_VOLUME) == 1
+        main = fw.main_container(pod)
+        assert {
+            "name": frameworks.MODEL_CACHE_VOLUME,
+            "mountPath": frameworks.MODEL_CACHE_MOUNT,
+        } in main["volumeMounts"]
+        assert fw.env_value(main, "HF_HOME") == frameworks.MODEL_CACHE_MOUNT
+        assert fw.env_value(main, "HF_HUB_OFFLINE") == "1"
+        # Exactly one HF_HOME even when the guide already set one (SGLang).
+        assert sum(1 for e in main["env"] if e["name"] == "HF_HOME") == 1
+        # Contract pieces are untouched by the cache rewrite.
+        assert fw.env_value(main, "SNAPSHOT_CONTROL_DIR") == workloads.CONTROL_DIR
+        assert any(m["mountPath"] == "/dev/net/tun" for m in main["volumeMounts"])
+
+
+@pytest.mark.workload
+def test_shared_model_cache_volume_is_static_nfs() -> None:
+    pv, pvc = fw.shared_model_cache_volume(config=CONFIG, cache=CACHE)
+    assert pv["metadata"]["name"] == CACHE.pvc_name
+    assert pv["spec"]["nfs"] == {"server": CACHE.server, "path": CACHE.path}
+    assert pv["spec"]["persistentVolumeReclaimPolicy"] == "Retain"
+    assert pv["spec"]["storageClassName"] == ""
+    assert "hard" in pv["spec"]["mountOptions"]
+    assert pvc["metadata"] == {"name": CACHE.pvc_name, "namespace": CONFIG.namespace}
+    assert pvc["spec"]["volumeName"] == CACHE.pvc_name
+    assert pvc["spec"]["storageClassName"] == ""
+    assert pvc["spec"]["accessModes"] == ["ReadWriteMany"]
+
+
+@pytest.mark.workload
+def test_shared_model_cache_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("SNAPSHOT_E2E_MODEL_CACHE_SERVER", "SNAPSHOT_E2E_MODEL_CACHE_PATH", "SNAPSHOT_E2E_MODEL_CACHE_PVC"):
+        monkeypatch.delenv(name, raising=False)
+    assert frameworks.SharedModelCache.from_env() is None
+    monkeypatch.setenv("SNAPSHOT_E2E_MODEL_CACHE_SERVER", "nfs.example.internal")
+    with pytest.raises(RuntimeError):
+        frameworks.SharedModelCache.from_env()
+    monkeypatch.setenv("SNAPSHOT_E2E_MODEL_CACHE_PATH", "/exports/models")
+    cache = frameworks.SharedModelCache.from_env()
+    assert cache == frameworks.SharedModelCache(
+        server="nfs.example.internal", path="/exports/models", pvc_name="model-cache"
+    )
+    monkeypatch.setenv("SNAPSHOT_E2E_MODEL_CACHE_PVC", "shared-models")
+    assert frameworks.SharedModelCache.from_env().pvc_name == "shared-models"
+
+
 @pytest.mark.workload
 def test_framework_selection_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SNAPSHOT_E2E_FRAMEWORK", raising=False)

--- a/e2e/tests/test_frameworks.py
+++ b/e2e/tests/test_frameworks.py
@@ -53,12 +53,22 @@ def test_framework_checkpoint_restore_serves_inference(
 ) -> None:
     source_node: str | None = None
     try:
-        pvc = fw.model_cache_pvc(config=config, spec=framework)
-        if pvc is not None:
+        # Shared NFS cache when configured (offline, no download); otherwise the
+        # guide's own cache plumbing, which downloads from Hugging Face.
+        model_cache = frameworks.SharedModelCache.from_env()
+        if model_cache is not None:
+            pv, pvc = fw.shared_model_cache_volume(config=config, cache=model_cache)
+            snap.ensure_pv(pv)
             snap.ensure_pvc(pvc)
+        else:
+            guide_pvc = fw.model_cache_pvc(config=config, spec=framework)
+            if guide_pvc is not None:
+                snap.ensure_pvc(guide_pvc)
 
         # --- source: load, generate, pause, ready-for-snapshot -------------
-        k8s.create_pod(fw.source_pod(config=config, run=run, spec=framework))
+        k8s.create_pod(
+            fw.source_pod(config=config, run=run, spec=framework, model_cache=model_cache)
+        )
         source = snap.wait_for_pod_ready(
             config.namespace,
             run.source_pod,
@@ -91,7 +101,13 @@ def test_framework_checkpoint_restore_serves_inference(
 
         # --- restore --------------------------------------------------------
         k8s.create_pod(
-            fw.restore_pod(config=config, run=run, spec=framework, source_node=source_node)
+            fw.restore_pod(
+                config=config,
+                run=run,
+                spec=framework,
+                source_node=source_node,
+                model_cache=model_cache,
+            )
         )
         snap.wait_for_restored_condition(
             config.namespace,


### PR DESCRIPTION
> Stacked on #176 → #175 → #173 → #171 → #170 (stack #172). Review only the last two commits until the lower PRs merge.

### Summary

Fixes from the first GPU run of the framework tests (`workflow_dispatch` run [33619417391](https://github.com/ai-dynamo/snapshot/actions/runs/33619417391)), which got all three frameworks through vCluster setup, image resolution, environment validation, and into the test, then failed in three different ways.

### What the run showed

| Framework | Observation | Cause |
|---|---|---|
| TensorRT-LLM | source pod exited 1: `Temporary failure in name resolution` for `huggingface.co` ~25s after start | DNS in a freshly created vCluster is not immediately usable; the other two pods resolved HF a minute later |
| vLLM | source pod still initializing when the 300s budget expired | ~4 min image pull (10–20 GB) + model download + engine init + `torch.compile`/CUDA-graph capture |
| SGLang | `AssertionError: release_memory_occupation should be called only when server is idle` | the guide pauses with `mode="abort"`; SGLang 0.5.17 does not leave the scheduler idle in that mode |

### Changes

- **Shared model cache** (`frameworks.SharedModelCache`, `framework_workloads.use_shared_model_cache`, `shared_model_cache_volume`, `lifecycle.ensure_pv`): with `SNAPSHOT_E2E_MODEL_CACHE_SERVER/PATH` set, the test creates a static NFS PV/PVC (Retain, `storageClassName: ""`, NFS 4.1 mount options), mounts it at `/models` on every framework container with `HF_HOME=/models` and `HF_HUB_OFFLINE=1`, and drops the guide's download init container / cache volume. The vCluster setup enables `sync.toHost.persistentVolumes` so the mount options reach the node. Without the variables the guides' download path is unchanged.
  - The workflow points at the CI cluster's shared export; repository variables `SNAPSHOT_E2E_MODEL_CACHE_SERVER/PATH` take precedence over the defaults (an admin can set them and drop the literals).
- **Source readiness budget** 300s → 900s (`frameworks.SOURCE_READY_TIMEOUT_SECONDS`), with the observed numbers in the comment.
- **SGLang guide**: `PauseGenerationReqInput()` (default mode) instead of `mode="abort"` before `release_memory_occupation()`. The preceding generation has completed, so there is nothing to abort. This changes the SGLang image digest, so `E2E Framework Images` rebuilds it on this PR.
- Cluster-free tests for the cache rewrite (init container dropped, single `model-cache` volume, mount + env, contract pieces untouched), the PV/PVC shape, and env parsing. README documents both weight sources.

### Verification

- `pytest e2e/tests/test_framework_manifests.py e2e/tests/test_workload_scripts.py` — 30 passed.
- Workflow YAML parses; `setup.py` compiles.
- GPU run pending: needs the rebuilt SGLang image from this PR's `E2E Framework Images` run, then a `workflow_dispatch` on this branch.
