### PR TITLE
docs: document Datadog GPU monitoring limitation (backport #168)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -9,5 +9,9 @@ roadmap.
 - x86_64 nodes only.
 - vGPU is not supported.
 - Runs only on NVIDIA GPUs supported by the required CUDA driver.
+- The checkpointed workload must not have tools that intercept `libcuda.so`
+  calls (e.g. Datadog GPU monitoring) — CUDA calls may fail or hang after
+  restore, with undefined results. Disable such interception for workloads
+  that will be snapshotted.
 
 Multi-GPU and Arm support are on the roadmap.


### PR DESCRIPTION
Backport of #168. This stacked PR depends on the #132 backport, which introduces the affected documentation files. Cherry-picked from 501b576fd9a6ecfbced6e78f87bb94eedac201a9.