### PR TITLE
docs: pin install instructions to latest chart (backport #169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Snapshot can be installed:
 
 ### From a release
 
-Find the latest version on the [releases page](https://github.com/ai-dynamo/snapshot/releases),
-then install the published chart, replacing `<VERSION>`:
+Install the published chart (see the [releases page](https://github.com/ai-dynamo/snapshot/releases)
+for other versions):
 
 ```bash
 helm install snapshot oci://ghcr.io/ai-dynamo/snapshot/snapshot \
-  --version <VERSION> \
+  --version 0.1.0-rc.1 \
   --namespace snapshot --create-namespace
 ```
 

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -8,13 +8,12 @@ Review the [prerequisites](../../README.md#prerequisites) before installing.
 
 ## Install from a release
 
-Find the latest version on the
-[releases page](https://github.com/ai-dynamo/snapshot/releases), then install the
-published chart, replacing `<VERSION>`:
+Install the published chart (see the
+[releases page](https://github.com/ai-dynamo/snapshot/releases) for other versions):
 
 ```bash
 helm install snapshot oci://ghcr.io/ai-dynamo/snapshot/snapshot \
-  --version <VERSION> \
+  --version 0.1.0-rc.1 \
   --namespace snapshot --create-namespace
 ```
 


### PR DESCRIPTION
Backport of #169. This stacked PR depends on the #132 backport, which introduces the affected documentation files. Cherry-picked from 0868e994860ed476aa830d07d6ae508194c3ef60.