### PR TITLE
📝 RUN-42620: align the usage guides on one namespace, image flow, and restore placeholder

### DIFF
--- a/docs/guides/checkpoint.md
+++ b/docs/guides/checkpoint.md
@@ -32,6 +32,13 @@ each framework — see the `deployment.yaml` referenced from the [vLLM](vllm.md)
 as the reference: a `PodSnapshot` targets a pod deployed this way, and a
 `SnapshotJob`'s `podTemplate` must carry the same fields.
 
+Set the namespace where the replica runs — the same one used to deploy it:
+
+```bash
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
+```
+
 ## Option 1 — `PodSnapshot` (checkpoint a running replica)
 
 Point at a replica that is already up and serving. Create a `PodSnapshot` naming its
@@ -42,7 +49,6 @@ apiVersion: nvidia.com/v1alpha1
 kind: PodSnapshot
 metadata:
   name: vllm-snapshot
-  namespace: my-inference
 spec:
   source:
     podRef:
@@ -52,9 +58,14 @@ spec:
 ```
 
 ```bash
-kubectl apply -f vllm-snapshot.yaml
-kubectl wait --for=condition=Ready podsnapshot/vllm-snapshot \
-  -n my-inference --timeout=30m
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename vllm-snapshot.yaml
+
+kubectl wait \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --for=condition=Ready podsnapshot/vllm-snapshot \
+  --timeout=30m
 ```
 
 The operator binds a cluster-scoped `PodSnapshotContent` and records the artifact.
@@ -73,7 +84,6 @@ apiVersion: nvidia.com/v1alpha1
 kind: SnapshotJob
 metadata:
   name: vllm-snapshot-job
-  namespace: my-inference
 spec:
   podSnapshotTemplate:
     targetContainers:
@@ -89,13 +99,19 @@ spec:
 ```
 
 ```bash
-kubectl apply -f vllm-snapshot-job.yaml
-kubectl wait --for=condition=Completed snapshotjob/vllm-snapshot-job \
-  -n my-inference --timeout=30m
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename vllm-snapshot-job.yaml
+
+kubectl wait \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --for=condition=Completed snapshotjob/vllm-snapshot-job \
+  --timeout=30m
 
 # the resulting PodSnapshot to restore from:
-kubectl get snapshotjob vllm-snapshot-job -n my-inference \
-  -o jsonpath='{.status.podSnapshotName}'
+kubectl get snapshotjob vllm-snapshot-job \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --output jsonpath='{.status.podSnapshotName}'
 ```
 
 Because the source replica is deleted, every serving replica — including the

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -50,9 +50,7 @@ kubectl rollout status \
 The container starts as an inert `sleep infinity` placeholder, as the
 [restore Pod contract](../reference/restore-pod-contract.md) requires: the agent
 restores the checkpointed process into it as a sibling, so running the
-application there would only load a second copy of the model. Readiness
-therefore waits on the framework's post-restore sentinel — `vllm-restore-ready`
-and its equivalents — not the `ready-for-snapshot` file the source pod writes.
+application there would only load a second copy of the model.
 
 The node agent adds a `nvidia.com/Restored` condition to the pod once the restore
 completes — watch it, along with pod readiness, to confirm. If the restored

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -15,9 +15,10 @@ the container during pod startup.
 
 Each build-and-deploy guide ships a ready-to-apply `restore-deployment.yaml` next
 to its `deployment.yaml`: the same manifest with the
-`nvidia.com/snapshot-is-checkpoint-source` label removed and an
-`nvidia.com/restore-from` annotation added, naming the `PodSnapshot` to restore
-from. Download the one for the framework in use:
+`nvidia.com/snapshot-is-checkpoint-source` label removed, an
+`nvidia.com/restore-from` annotation added naming the `PodSnapshot` to restore
+from, and the container command replaced with an inert `sleep infinity`.
+Download the one for the framework in use:
 
 - [vLLM `restore-deployment.yaml`](vllm/restore-deployment.yaml)
 - [SGLang `restore-deployment.yaml`](sglang/restore-deployment.yaml)
@@ -45,6 +46,13 @@ kubectl rollout status \
   deployment/<framework>-restored \
   --timeout=30m
 ```
+
+The container starts as an inert `sleep infinity` placeholder, as the
+[restore Pod contract](../reference/restore-pod-contract.md) requires: the agent
+restores the checkpointed process into it as a sibling, so running the
+application there would only load a second copy of the model. Readiness
+therefore waits on the framework's post-restore sentinel — `vllm-restore-ready`
+and its equivalents — not the `ready-for-snapshot` file the source pod writes.
 
 The node agent adds a `nvidia.com/Restored` condition to the pod once the restore
 completes — watch it, along with pod readiness, to confirm. If the restored

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -50,7 +50,9 @@ kubectl rollout status \
 The container starts as an inert `sleep infinity` placeholder, as the
 [restore Pod contract](../reference/restore-pod-contract.md) requires: the agent
 restores the checkpointed process into it as a sibling, so running the
-application there would only load a second copy of the model.
+application there would only load a second copy of the model. Readiness
+therefore waits on the framework's post-restore sentinel — `vllm-restore-ready`
+and its equivalents — not the `ready-for-snapshot` file the source pod writes.
 
 The node agent adds a `nvidia.com/Restored` condition to the pod once the restore
 completes — watch it, along with pod readiness, to confirm. If the restored

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -23,13 +23,27 @@ from. Download the one for the framework in use:
 - [SGLang `restore-deployment.yaml`](sglang/restore-deployment.yaml)
 - [TensorRT-LLM `restore-deployment.yaml`](tensorrt-llm/restore-deployment.yaml)
 
+Set the namespace where the restored replica will run — the same one holding the
+`PodSnapshot`:
+
+```bash
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
+```
+
 In the manifest, set the container `image` to the one built for the source and set
 the `restore-from` annotation to the `PodSnapshot` name, then apply it and watch the
 rollout (the Deployment is named `<framework>-restored`):
 
 ```bash
-kubectl apply -f restore-deployment.yaml
-kubectl rollout status deployment/<framework>-restored -n my-inference --timeout=30m
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename restore-deployment.yaml
+
+kubectl rollout status \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  deployment/<framework>-restored \
+  --timeout=30m
 ```
 
 The node agent adds a `nvidia.com/Restored` condition to the pod once the restore

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -1,9 +1,9 @@
 # Build and deploy an SGLang replica
 
 Snapshot restores a replica by injecting its checkpointed state into a
-snapshot-ready image: an SGLang runtime image prepared with the application and container
-layout Snapshot expects. The Snapshot agent injects the restore tooling at
-runtime.
+snapshot-ready image: an SGLang runtime image prepared with the application and
+container layout Snapshot expects. The Snapshot agent injects the restore
+tooling at runtime.
 
 ## Build
 
@@ -58,9 +58,11 @@ send a `POST` request to `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
 The Dockerfile starts from the tested SGLang image, creates
-`/snapshot-control`, and adds `app.py`. The source and restore pods must use the
-same immutable image, mount the Snapshot control volume at
-`/snapshot-control`, and mount the same model cache at `/hf-cache`.
+`/snapshot-control`, and adds `app.py`.
+
+The source and restore pods must use the same immutable image, mount the
+Snapshot control volume at `/snapshot-control`, and mount the same model cache
+at `/hf-cache`.
 
 ### 2. Build the image
 

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -100,8 +100,8 @@ failure prints an error and returns a non-zero exit status.
 Set the namespace where the SGLang pod will run:
 
 ```bash
-export SGLANG_NAMESPACE=<namespace>
-kubectl get namespace "$SGLANG_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
 Set the model through the `SNAPSHOT_MODEL` environment variable in both the
@@ -129,7 +129,7 @@ Create the persistent model cache:
 
 ```bash
 kubectl apply \
-  --namespace "$SGLANG_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --filename model-cache-pvc.yaml
 ```
 
@@ -144,7 +144,7 @@ kubectl set image \
   main="$SGLANG_SNAPSHOT_IMAGE" \
   --output yaml |
   kubectl apply \
-    --namespace "$SGLANG_NAMESPACE" \
+    --namespace "$SNAPSHOT_NAMESPACE" \
     --filename -
 ```
 
@@ -158,7 +158,7 @@ checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$SGLANG_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/sglang-source \
   --timeout=30m
 ```
@@ -167,7 +167,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$SGLANG_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=sglang-source
 ```
 

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -104,14 +104,23 @@ export SNAPSHOT_NAMESPACE=<namespace>
 kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set the model through the `SNAPSHOT_MODEL` environment variable in both the
-init container and the main container in
-[`deployment.yaml`](sglang/deployment.yaml):
+In [`deployment.yaml`](sglang/deployment.yaml), replace the example `image` with
+the one pushed in step 2 and select the model through `SNAPSHOT_MODEL`. Both the
+init container and the main container carry each value:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+initContainers:
+  - name: model-cache
+    image: <registry>/sglang-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/sglang-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 The example configures a context length of 10240 tokens for a 24 GiB NVIDIA A10
@@ -133,25 +142,16 @@ kubectl apply \
   --filename model-cache-pvc.yaml
 ```
 
-Use [`deployment.yaml`](sglang/deployment.yaml) to deploy the image built in
-step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  model-cache="$SGLANG_SNAPSHOT_IMAGE" \
-  main="$SGLANG_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$SNAPSHOT_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
 
-The command replaces both example image values in `deployment.yaml` with
-`$SGLANG_SNAPSHOT_IMAGE` before creating the Deployment. It does not modify the
-local file. The init container downloads the model when its cache marker does
-not exist. The main container then starts SGLang from the offline cache.
+The init container downloads the model when its cache marker does not exist. The
+main container then starts SGLang from the offline cache.
 
 Wait until the SGLang replica finishes initialization and becomes safe to
 checkpoint:

--- a/docs/guides/sglang/restore-deployment.yaml
+++ b/docs/guides/sglang/restore-deployment.yaml
@@ -99,7 +99,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/sglang-restore-ready
+                - /snapshot-control/ready-for-snapshot
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/sglang/restore-deployment.yaml
+++ b/docs/guides/sglang/restore-deployment.yaml
@@ -99,7 +99,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/sglang-restore-ready
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/sglang/restore-deployment.yaml
+++ b/docs/guides/sglang/restore-deployment.yaml
@@ -58,9 +58,12 @@ spec:
         - name: main
           image: sglang-snapshot:replace-me
           imagePullPolicy: Always
-          args:
-            - --mode
-            - snapshot
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
@@ -96,7 +99,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/sglang-restore-ready
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -97,8 +97,8 @@ present. Any failure prints an error and returns a non-zero exit status.
 Set the namespace where the TensorRT-LLM pod will run:
 
 ```bash
-export TENSORRT_LLM_NAMESPACE=<namespace>
-kubectl get namespace "$TENSORRT_LLM_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
 Set a model supported by the selected TensorRT-LLM image through the
@@ -132,7 +132,7 @@ kubectl set image \
   main="$TENSORRT_LLM_SNAPSHOT_IMAGE" \
   --output yaml |
   kubectl apply \
-    --namespace "$TENSORRT_LLM_NAMESPACE" \
+    --namespace "$SNAPSHOT_NAMESPACE" \
     --filename -
 ```
 
@@ -145,7 +145,7 @@ checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$TENSORRT_LLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/tensorrt-llm-source \
   --timeout=30m
 ```
@@ -154,7 +154,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$TENSORRT_LLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=tensorrt-llm-source
 ```
 

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -101,14 +101,17 @@ export SNAPSHOT_NAMESPACE=<namespace>
 kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set a model supported by the selected TensorRT-LLM image through the
-`SNAPSHOT_MODEL` environment variable in
-[`deployment.yaml`](tensorrt-llm/deployment.yaml):
+In [`deployment.yaml`](tensorrt-llm/deployment.yaml), replace the example `image`
+with the one pushed in step 2 and select a model supported by the chosen
+TensorRT-LLM image through `SNAPSHOT_MODEL`:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/tensorrt-llm-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 The example uses one GPU, the PyTorch backend, and a maximum sequence length of
@@ -122,23 +125,13 @@ TensorRT-LLM image, GPU count, backend, or engine settings.
 > [`LLM` API](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html) in
 > `app.py`.
 
-Use [`deployment.yaml`](tensorrt-llm/deployment.yaml) to deploy the image built
-in step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  main="$TENSORRT_LLM_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$SNAPSHOT_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
-
-The command replaces the example image value in `deployment.yaml` with
-`$TENSORRT_LLM_SNAPSHOT_IMAGE` before creating the Deployment. It does not
-modify the local file.
 
 Wait until the TensorRT-LLM replica finishes initialization and becomes safe to
 checkpoint:

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -1,9 +1,9 @@
 # Build and deploy a TensorRT-LLM replica
 
 Snapshot restores a replica by injecting its checkpointed state into a
-snapshot-ready image: a TensorRT-LLM runtime image prepared with the application and container
-layout Snapshot expects. The Snapshot agent injects the restore tooling at
-runtime.
+snapshot-ready image: a TensorRT-LLM runtime image prepared with the application
+and container layout Snapshot expects. The Snapshot agent injects the restore
+tooling at runtime.
 
 > [!NOTE]
 > TensorRT-LLM support is experimental and currently limited to a single GPU.

--- a/docs/guides/tensorrt-llm/restore-deployment.yaml
+++ b/docs/guides/tensorrt-llm/restore-deployment.yaml
@@ -34,6 +34,12 @@ spec:
         - name: main
           image: tensorrt-llm-snapshot:replace-me
           imagePullPolicy: Always
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
@@ -55,7 +61,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/trtllm-restore-ready
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/tensorrt-llm/restore-deployment.yaml
+++ b/docs/guides/tensorrt-llm/restore-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/trtllm-restore-ready
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/tensorrt-llm/restore-deployment.yaml
+++ b/docs/guides/tensorrt-llm/restore-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/trtllm-restore-ready
+                - /snapshot-control/ready-for-snapshot
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -54,8 +54,8 @@ Ubuntu 24.04 glibc required by the current Snapshot restore bundle. It creates
 `HF_HUB_DISABLE_XET=1` prevents the model downloader from leaving an open cache
 log that CRIU cannot reopen after restore.
 
-The source and restore pods must mount the Snapshot control volume at
-`/snapshot-control`.
+The source and restore pods must use the same immutable image and mount the
+Snapshot control volume at `/snapshot-control`.
 
 ### 2. Build the image
 

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -41,11 +41,10 @@ curl --fail --location \
 The program loads the model selected in `deployment.yaml`, runs one
 generation to initialize vLLM, and then calls `pause_generation()` and
 `sleep()`. It writes
-`ready-for-snapshot` only when the process is safe to checkpoint. In a restore
-container, it waits in standby until Snapshot injects the checkpointed process.
-That process calls `wake_up()` and `resume_generation()`, runs another
-generation, starts an API, and writes `vllm-restore-ready` when the API is
-listening. To validate the restored replica, send a `POST` request to
+`ready-for-snapshot` only when the process is safe to checkpoint. After restore,
+the checkpointed process calls `wake_up()` and `resume_generation()`, runs
+another generation, starts an API, and writes `vllm-restore-ready` when the API
+is listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -95,8 +95,8 @@ Any failure prints an error and returns a non-zero exit status.
 Set the namespace where the vLLM pod will run:
 
 ```bash
-export VLLM_NAMESPACE=<namespace>
-kubectl get namespace "$VLLM_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
 Set the model through the `SNAPSHOT_MODEL` environment variable in
@@ -129,7 +129,7 @@ kubectl set image \
   main="$VLLM_SNAPSHOT_IMAGE" \
   --output yaml |
   kubectl apply \
-    --namespace "$VLLM_NAMESPACE" \
+    --namespace "$SNAPSHOT_NAMESPACE" \
     --filename -
 ```
 
@@ -142,7 +142,7 @@ checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$VLLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/vllm-source \
   --timeout=30m
 ```
@@ -151,7 +151,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$VLLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=vllm-source
 ```
 

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -99,13 +99,16 @@ export SNAPSHOT_NAMESPACE=<namespace>
 kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set the model through the `SNAPSHOT_MODEL` environment variable in
-[`deployment.yaml`](vllm/deployment.yaml):
+In [`deployment.yaml`](vllm/deployment.yaml), replace the example `image` with the
+one pushed in step 2 and select the model through `SNAPSHOT_MODEL`:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/vllm-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 Other values include `TinyLlama/TinyLlama-1.1B-Chat-v1.0` or a mounted model
@@ -119,23 +122,13 @@ source and restored containers.
 > vLLM's [environment variables](https://docs.vllm.ai/en/v0.27.1/configuration/env_vars/)
 > set in the Deployment's Pod template.
 
-Use [`deployment.yaml`](vllm/deployment.yaml) to deploy the image built in
-step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  main="$VLLM_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$SNAPSHOT_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
-
-The command replaces the example image value in `deployment.yaml` with
-`$VLLM_SNAPSHOT_IMAGE` before creating the Deployment. It does not modify the
-local file.
 
 Wait until the vLLM replica finishes initialization and becomes safe to
 checkpoint:

--- a/docs/guides/vllm/restore-deployment.yaml
+++ b/docs/guides/vllm/restore-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/vllm-restore-ready
+                - /snapshot-control/ready-for-snapshot
             periodSeconds: 1
             failureThreshold: 1200
           volumeMounts:

--- a/docs/guides/vllm/restore-deployment.yaml
+++ b/docs/guides/vllm/restore-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/vllm-restore-ready
             periodSeconds: 1
             failureThreshold: 1200
           volumeMounts:

--- a/docs/guides/vllm/restore-deployment.yaml
+++ b/docs/guides/vllm/restore-deployment.yaml
@@ -31,6 +31,12 @@ spec:
         - name: main
           image: vllm-snapshot:replace-me
           imagePullPolicy: Always
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
@@ -46,7 +52,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/vllm-restore-ready
             periodSeconds: 1
             failureThreshold: 1200
           volumeMounts:


### PR DESCRIPTION
## Summary

The three stages of the usage flow had drifted apart, and the restore stage had two real defects.

- **One namespace variable.** Each build-and-deploy guide exported its own (`VLLM_NAMESPACE`, `SGLANG_NAMESPACE`, `TENSORRT_LLM_NAMESPACE`) while checkpoint and restore hardcoded `my-inference`. They now share `SNAPSHOT_NAMESPACE`, exported once and verified the same way, matching the existing `SNAPSHOT_MODEL` / `SNAPSHOT_CONTROL_DIR` naming. The restore guide previously applied the Deployment with **no namespace at all** and then waited for the rollout in `my-inference`, so the Deployment landed in whatever namespace the caller's context pointed at while the watch looked somewhere else.
- **One way to set an image.** The source guides substituted the image at apply time via `kubectl set image --local | kubectl apply`; the restore guide asked for a plain manifest edit. The source guides now use the same manifest edit, called out next to the `SNAPSHOT_MODEL` edit it sits beside and shown in its real position in the pod spec.
- **An inert restore placeholder.** The restore manifests set no `command`, so the placeholder ran the image entrypoint. `app.py` only stays inert when `DYN_SNAPSHOT_RESTORE_STANDBY` is set, and these manifests never set it — so as shipped, the placeholder fell through to the normal path and loaded a model in a container whose only job is to sit idle until the agent restores into it. They now use `sleep infinity`, which is what [`docs/reference/restore-pod-contract.md`](https://github.com/ai-dynamo/snapshot/blob/main/docs/reference/restore-pod-contract.md) already prescribes and what this guide links to.

### Why readiness moves with it

`sleep infinity` means `app.py` no longer runs in the restore container, and `ready-for-snapshot` is a file only `app.py` writes. The control volume is a fresh `emptyDir`, so nothing creates that file in a restore pod and the probe can never succeed.

That matters because this guide tells readers to run `kubectl rollout status` and watch pod readiness. Left on `ready-for-snapshot` the Deployment never becomes available, and since vLLM and SGLang inherit the 600s `progressDeadlineSeconds` default, the rollout fails well inside the 30 minutes the guide suggests. On `main` that command worked only because `app.py` ran in the restore container and loaded a second copy of the model — exactly what this PR removes.

The probe therefore watches each framework's post-restore sentinel (`<framework>-restore-ready`), which the restored process writes once its API is listening. RUN-42620 does not mention readiness; this rides along because the `sleep infinity` change it *does* ask for would otherwise regress the guide's own verification step. ccf2210 and 7357682 are that call being made in the open rather than silently.

SGLang also loses its `--mode snapshot` args in the restore manifest — those are `app.py` flags, and `app.py` no longer runs there.

### Note for #170 and #171

An inert `sleep infinity` placeholder makes `SNAPSHOT_RESTORE_STANDBY` unnecessary in these three restore examples. [#171](https://github.com/ai-dynamo/snapshot/pull/171) is currently adding that env var to the same manifests to solve the same problem the other way. I have deliberately not touched those lines or `app.py` — @oleg-kushniriov, worth deciding which approach the examples should keep.

## Jira

[RUN-42620](https://runai.atlassian.net/browse/RUN-42620)

## Test plan

- [ ] Documentation only; no unit or E2E coverage applies. No code or test consumes the guide manifests — the E2E suite builds its own pod specs in `e2e/snapshot_e2e/workloads.py`, where the restore placeholder already ends in `sleep infinity`.
- [ ] All three edited `restore-deployment.yaml` files parse, with `command` and the repointed `readinessProbe` resolving as intended.
- [ ] Relative links in the edited guides resolve.

## Review ownership

- **@shmuel-runai @shayasoolin @danbar2 @Ronkahn21 @oleg-kushniriov @yoedgin @dfeigin-nv @galletas1712 @julienmancuso @Hutm @hhzhang16** (global `*` rule in `.github/CODEOWNERS`; the repository defines no per-path teams):
  - `docs/guides/checkpoint.md`
  - `docs/guides/restore.md`
  - `docs/guides/vllm.md`
  - `docs/guides/sglang.md`
  - `docs/guides/tensorrt-llm.md`
  - `docs/guides/vllm/restore-deployment.yaml`
  - `docs/guides/sglang/restore-deployment.yaml`
  - `docs/guides/tensorrt-llm/restore-deployment.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated checkpoint and restore guides with configurable namespaces, explicit Kubernetes commands, rollout timeouts, and clearer readiness verification.
  - Revised SGLang, TensorRT-LLM, and vLLM deployment instructions for consistent image, model, cache, and snapshot volume configuration.
  - Clarified restore workflows, including the required vLLM version and use of consistent source and restore images.
  - Documented inert restore containers that remain idle until checkpoint restoration completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

