### PR TITLE
📝 RUN-42620: align the usage guides on one namespace, image flow, and restore placeholder (backport #191)

### DIFF
--- a/docs/guides/checkpoint.md
+++ b/docs/guides/checkpoint.md
@@ -32,6 +32,13 @@ each framework — see the `deployment.yaml` referenced from the [vLLM](vllm.md)
 as the reference: a `PodSnapshot` targets a pod deployed this way, and a
 `SnapshotJob`'s `podTemplate` must carry the same fields.
 
+Set the namespace where the replica runs — the same one used to deploy it:
+
+```bash
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
+```
+
 ## Option 1 — `PodSnapshot` (checkpoint a running replica)
 
 Point at a replica that is already up and serving. Create a `PodSnapshot` naming its
@@ -42,7 +49,6 @@ apiVersion: nvidia.com/v1alpha1
 kind: PodSnapshot
 metadata:
   name: vllm-snapshot
-  namespace: my-inference
 spec:
   source:
     podRef:
@@ -52,9 +58,14 @@ spec:
 ```
 
 ```bash
-kubectl apply -f vllm-snapshot.yaml
-kubectl wait --for=condition=Ready podsnapshot/vllm-snapshot \
-  -n my-inference --timeout=30m
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename vllm-snapshot.yaml
+
+kubectl wait \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --for=condition=Ready podsnapshot/vllm-snapshot \
+  --timeout=30m
 ```
 
 The operator binds a cluster-scoped `PodSnapshotContent` and records the artifact.
@@ -73,7 +84,6 @@ apiVersion: nvidia.com/v1alpha1
 kind: SnapshotJob
 metadata:
   name: vllm-snapshot-job
-  namespace: my-inference
 spec:
   podSnapshotTemplate:
     targetContainers:
@@ -89,13 +99,19 @@ spec:
 ```
 
 ```bash
-kubectl apply -f vllm-snapshot-job.yaml
-kubectl wait --for=condition=Completed snapshotjob/vllm-snapshot-job \
-  -n my-inference --timeout=30m
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename vllm-snapshot-job.yaml
+
+kubectl wait \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --for=condition=Completed snapshotjob/vllm-snapshot-job \
+  --timeout=30m
 
 # the resulting PodSnapshot to restore from:
-kubectl get snapshotjob vllm-snapshot-job -n my-inference \
-  -o jsonpath='{.status.podSnapshotName}'
+kubectl get snapshotjob vllm-snapshot-job \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --output jsonpath='{.status.podSnapshotName}'
 ```
 
 Because the source replica is deleted, every serving replica — including the

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -15,22 +15,44 @@ the container during pod startup.
 
 Each build-and-deploy guide ships a ready-to-apply `restore-deployment.yaml` next
 to its `deployment.yaml`: the same manifest with the
-`nvidia.com/snapshot-is-checkpoint-source` label removed and an
-`nvidia.com/restore-from` annotation added, naming the `PodSnapshot` to restore
-from. Download the one for the framework in use:
+`nvidia.com/snapshot-is-checkpoint-source` label removed, an
+`nvidia.com/restore-from` annotation added naming the `PodSnapshot` to restore
+from, and the container command replaced with an inert `sleep infinity`.
+Download the one for the framework in use:
 
 - [vLLM `restore-deployment.yaml`](vllm/restore-deployment.yaml)
 - [SGLang `restore-deployment.yaml`](sglang/restore-deployment.yaml)
 - [TensorRT-LLM `restore-deployment.yaml`](tensorrt-llm/restore-deployment.yaml)
+
+Set the namespace where the restored replica will run — the same one holding the
+`PodSnapshot`:
+
+```bash
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
+```
 
 In the manifest, set the container `image` to the one built for the source and set
 the `restore-from` annotation to the `PodSnapshot` name, then apply it and watch the
 rollout (the Deployment is named `<framework>-restored`):
 
 ```bash
-kubectl apply -f restore-deployment.yaml
-kubectl rollout status deployment/<framework>-restored -n my-inference --timeout=30m
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename restore-deployment.yaml
+
+kubectl rollout status \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  deployment/<framework>-restored \
+  --timeout=30m
 ```
+
+The container starts as an inert `sleep infinity` placeholder, as the
+[restore Pod contract](../reference/restore-pod-contract.md) requires: the agent
+restores the checkpointed process into it as a sibling, so running the
+application there would only load a second copy of the model. Readiness
+therefore waits on the framework's post-restore sentinel — `vllm-restore-ready`
+and its equivalents — not the `ready-for-snapshot` file the source pod writes.
 
 The node agent adds a `nvidia.com/Restored` condition to the pod once the restore
 completes — watch it, along with pod readiness, to confirm. If the restored

--- a/docs/guides/sglang.md
+++ b/docs/guides/sglang.md
@@ -1,9 +1,9 @@
 # Build and deploy an SGLang replica
 
 Snapshot restores a replica by injecting its checkpointed state into a
-snapshot-ready image: an SGLang runtime image prepared with the application and container
-layout Snapshot expects. The Snapshot agent injects the restore tooling at
-runtime.
+snapshot-ready image: an SGLang runtime image prepared with the application and
+container layout Snapshot expects. The Snapshot agent injects the restore
+tooling at runtime.
 
 ## Build
 
@@ -58,9 +58,11 @@ send a `POST` request to `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
 The Dockerfile starts from the tested SGLang image, creates
-`/snapshot-control`, and adds `app.py`. The source and restore pods must use the
-same immutable image, mount the Snapshot control volume at
-`/snapshot-control`, and mount the same model cache at `/hf-cache`.
+`/snapshot-control`, and adds `app.py`.
+
+The source and restore pods must use the same immutable image, mount the
+Snapshot control volume at `/snapshot-control`, and mount the same model cache
+at `/hf-cache`.
 
 ### 2. Build the image
 
@@ -100,18 +102,27 @@ failure prints an error and returns a non-zero exit status.
 Set the namespace where the SGLang pod will run:
 
 ```bash
-export SGLANG_NAMESPACE=<namespace>
-kubectl get namespace "$SGLANG_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set the model through the `SNAPSHOT_MODEL` environment variable in both the
-init container and the main container in
-[`deployment.yaml`](sglang/deployment.yaml):
+In [`deployment.yaml`](sglang/deployment.yaml), replace the example `image` with
+the one pushed in step 2 and select the model through `SNAPSHOT_MODEL`. Both the
+init container and the main container carry each value:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+initContainers:
+  - name: model-cache
+    image: <registry>/sglang-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/sglang-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 The example configures a context length of 10240 tokens for a 24 GiB NVIDIA A10
@@ -129,36 +140,27 @@ Create the persistent model cache:
 
 ```bash
 kubectl apply \
-  --namespace "$SGLANG_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --filename model-cache-pvc.yaml
 ```
 
-Use [`deployment.yaml`](sglang/deployment.yaml) to deploy the image built in
-step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  model-cache="$SGLANG_SNAPSHOT_IMAGE" \
-  main="$SGLANG_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$SGLANG_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
 
-The command replaces both example image values in `deployment.yaml` with
-`$SGLANG_SNAPSHOT_IMAGE` before creating the Deployment. It does not modify the
-local file. The init container downloads the model when its cache marker does
-not exist. The main container then starts SGLang from the offline cache.
+The init container downloads the model when its cache marker does not exist. The
+main container then starts SGLang from the offline cache.
 
 Wait until the SGLang replica finishes initialization and becomes safe to
 checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$SGLANG_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/sglang-source \
   --timeout=30m
 ```
@@ -167,7 +169,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$SGLANG_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=sglang-source
 ```
 

--- a/docs/guides/sglang/restore-deployment.yaml
+++ b/docs/guides/sglang/restore-deployment.yaml
@@ -58,9 +58,12 @@ spec:
         - name: main
           image: sglang-snapshot:replace-me
           imagePullPolicy: Always
-          args:
-            - --mode
-            - snapshot
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
@@ -96,7 +99,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/sglang-restore-ready
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -1,9 +1,9 @@
 # Build and deploy a TensorRT-LLM replica
 
 Snapshot restores a replica by injecting its checkpointed state into a
-snapshot-ready image: a TensorRT-LLM runtime image prepared with the application and container
-layout Snapshot expects. The Snapshot agent injects the restore tooling at
-runtime.
+snapshot-ready image: a TensorRT-LLM runtime image prepared with the application
+and container layout Snapshot expects. The Snapshot agent injects the restore
+tooling at runtime.
 
 > [!NOTE]
 > TensorRT-LLM support is experimental and currently limited to a single GPU.
@@ -97,18 +97,21 @@ present. Any failure prints an error and returns a non-zero exit status.
 Set the namespace where the TensorRT-LLM pod will run:
 
 ```bash
-export TENSORRT_LLM_NAMESPACE=<namespace>
-kubectl get namespace "$TENSORRT_LLM_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set a model supported by the selected TensorRT-LLM image through the
-`SNAPSHOT_MODEL` environment variable in
-[`deployment.yaml`](tensorrt-llm/deployment.yaml):
+In [`deployment.yaml`](tensorrt-llm/deployment.yaml), replace the example `image`
+with the one pushed in step 2 and select a model supported by the chosen
+TensorRT-LLM image through `SNAPSHOT_MODEL`:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/tensorrt-llm-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 The example uses one GPU, the PyTorch backend, and a maximum sequence length of
@@ -122,30 +125,20 @@ TensorRT-LLM image, GPU count, backend, or engine settings.
 > [`LLM` API](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html) in
 > `app.py`.
 
-Use [`deployment.yaml`](tensorrt-llm/deployment.yaml) to deploy the image built
-in step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  main="$TENSORRT_LLM_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$TENSORRT_LLM_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
-
-The command replaces the example image value in `deployment.yaml` with
-`$TENSORRT_LLM_SNAPSHOT_IMAGE` before creating the Deployment. It does not
-modify the local file.
 
 Wait until the TensorRT-LLM replica finishes initialization and becomes safe to
 checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$TENSORRT_LLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/tensorrt-llm-source \
   --timeout=30m
 ```
@@ -154,7 +147,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$TENSORRT_LLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=tensorrt-llm-source
 ```
 

--- a/docs/guides/tensorrt-llm/restore-deployment.yaml
+++ b/docs/guides/tensorrt-llm/restore-deployment.yaml
@@ -34,6 +34,12 @@ spec:
         - name: main
           image: tensorrt-llm-snapshot:replace-me
           imagePullPolicy: Always
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
@@ -55,7 +61,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/trtllm-restore-ready
             periodSeconds: 1
             failureThreshold: 1800
           volumeMounts:

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -41,11 +41,10 @@ curl --fail --location \
 The program loads the model selected in `deployment.yaml`, runs one
 generation to initialize vLLM, and then calls `pause_generation()` and
 `sleep()`. It writes
-`ready-for-snapshot` only when the process is safe to checkpoint. In a restore
-container, it waits in standby until Snapshot injects the checkpointed process.
-That process calls `wake_up()` and `resume_generation()`, runs another
-generation, starts an API, and writes `vllm-restore-ready` when the API is
-listening. To validate the restored replica, send a `POST` request to
+`ready-for-snapshot` only when the process is safe to checkpoint. After restore,
+the checkpointed process calls `wake_up()` and `resume_generation()`, runs
+another generation, starts an API, and writes `vllm-restore-ready` when the API
+is listening. To validate the restored replica, send a `POST` request to
 `/generate` with a JSON body such as
 `{"prompt":"What is the capital of Italy?"}`.
 
@@ -55,8 +54,8 @@ Ubuntu 24.04 glibc required by the current Snapshot restore bundle. It creates
 `HF_HUB_DISABLE_XET=1` prevents the model downloader from leaving an open cache
 log that CRIU cannot reopen after restore.
 
-The source and restore pods must mount the Snapshot control volume at
-`/snapshot-control`.
+The source and restore pods must use the same immutable image and mount the
+Snapshot control volume at `/snapshot-control`.
 
 ### 2. Build the image
 
@@ -95,17 +94,20 @@ Any failure prints an error and returns a non-zero exit status.
 Set the namespace where the vLLM pod will run:
 
 ```bash
-export VLLM_NAMESPACE=<namespace>
-kubectl get namespace "$VLLM_NAMESPACE"
+export SNAPSHOT_NAMESPACE=<namespace>
+kubectl get namespace "$SNAPSHOT_NAMESPACE"
 ```
 
-Set the model through the `SNAPSHOT_MODEL` environment variable in
-[`deployment.yaml`](vllm/deployment.yaml):
+In [`deployment.yaml`](vllm/deployment.yaml), replace the example `image` with the
+one pushed in step 2 and select the model through `SNAPSHOT_MODEL`:
 
 ```yaml
-env:
-  - name: SNAPSHOT_MODEL
-    value: Qwen/Qwen3-0.6B
+containers:
+  - name: main
+    image: <registry>/vllm-snapshot:<tag>
+    env:
+      - name: SNAPSHOT_MODEL
+        value: Qwen/Qwen3-0.6B
 ```
 
 Other values include `TinyLlama/TinyLlama-1.1B-Chat-v1.0` or a mounted model
@@ -119,30 +121,20 @@ source and restored containers.
 > vLLM's [environment variables](https://docs.vllm.ai/en/v0.27.1/configuration/env_vars/)
 > set in the Deployment's Pod template.
 
-Use [`deployment.yaml`](vllm/deployment.yaml) to deploy the image built in
-step 2:
+Deploy the edited manifest:
 
 ```bash
-kubectl set image \
-  --local \
-  --filename deployment.yaml \
-  main="$VLLM_SNAPSHOT_IMAGE" \
-  --output yaml |
-  kubectl apply \
-    --namespace "$VLLM_NAMESPACE" \
-    --filename -
+kubectl apply \
+  --namespace "$SNAPSHOT_NAMESPACE" \
+  --filename deployment.yaml
 ```
-
-The command replaces the example image value in `deployment.yaml` with
-`$VLLM_SNAPSHOT_IMAGE` before creating the Deployment. It does not modify the
-local file.
 
 Wait until the vLLM replica finishes initialization and becomes safe to
 checkpoint:
 
 ```bash
 kubectl rollout status \
-  --namespace "$VLLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   deployment/vllm-source \
   --timeout=30m
 ```
@@ -151,7 +143,7 @@ List the generated Pod:
 
 ```bash
 kubectl get pods \
-  --namespace "$VLLM_NAMESPACE" \
+  --namespace "$SNAPSHOT_NAMESPACE" \
   --selector app=vllm-source
 ```
 

--- a/docs/guides/vllm/restore-deployment.yaml
+++ b/docs/guides/vllm/restore-deployment.yaml
@@ -31,6 +31,12 @@ spec:
         - name: main
           image: vllm-snapshot:replace-me
           imagePullPolicy: Always
+          # Inert placeholder: the agent restores the checkpointed process into
+          # this container, so app.py must not run here.
+          command:
+            - /bin/sh
+            - -c
+            - exec sleep infinity
           env:
             - name: SNAPSHOT_MODEL
               value: Qwen/Qwen3-0.6B
@@ -46,7 +52,7 @@ spec:
             exec:
               command:
                 - cat
-                - /snapshot-control/ready-for-snapshot
+                - /snapshot-control/vllm-restore-ready
             periodSeconds: 1
             failureThreshold: 1200
           volumeMounts:


### PR DESCRIPTION
Backport of #191 to `release/0.1`.

#191 aligned the five usage guides on a single `SNAPSHOT_NAMESPACE`, moved the source image from a `kubectl set image --local` pipeline to a called-out `deployment.yaml` edit, and gave the restore placeholder an inert `sleep infinity` with readiness repointed at each framework's post-restore sentinel.

## Cherry-pick was clean

For the eight affected files, `release/0.1` and `main` differed *only* by #191, so the pick applied with no conflicts. After the commit, `git diff origin/main -- docs/guides docs/reference` is empty — the guides on this branch are byte-identical to `main`.

## Why the restore changes matter on the release branch

As shipped in `release/0.1`, the restore examples set no `command`, so the placeholder ran the image entrypoint and `app.py` fell through to its normal path, loading a model into a container whose only job is to sit idle until the agent restores into it. Readiness also probed `ready-for-snapshot`, which nothing writes in a restore pod, so the rollout the guide tells readers to watch could never succeed.

## Validation

The original PR was validated end to end on a live single-GPU cluster — source deploy, checkpoint, restore, and an API check against the restored pod. This backport changes documentation and example manifests only; no service code is touched.

Cherry-picked from #191 (commit 8062806).
