### PR TITLE
docs(guides): backport #170 (SNAPSHOT_RESTORE_STANDBY) to release/0.1

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -340,9 +340,9 @@ ENTRYPOINT ["/usr/local/bin/snapshot-agent"]
 # path as it runs from — CRIU restores file-backed mappings by path, not via
 # PATH search — and so must this placeholder image (same BASE_IMAGE).
 #
-# Backend entrypoints run a restore standby path when the operator
-# injects DYN_SNAPSHOT_RESTORE_STANDBY=1, then sleep while the
-# snapshot-agent restores into the container.
+# Standby-aware workload entrypoints stay inert when the restore Pod sets
+# SNAPSHOT_RESTORE_STANDBY=1, then sleep while the snapshot-agent restores
+# into the container.
 # =============================================================================
 FROM ${BASE_IMAGE} AS placeholder
 

--- a/api/podcontract/protocol.go
+++ b/api/podcontract/protocol.go
@@ -59,14 +59,17 @@ const (
 	CUDAJobFilePath = SnapshotControlMountPath + "/" + CUDAJobFileName
 
 	// RestoreStandbyModeEnv asks standby-aware workload entrypoints to remain
-	// inert until Snapshot replaces them with restored processes. Snapshot does
-	// not inject this workload-specific setting.
+	// inert until Snapshot replaces them with restored processes. Snapshot
+	// publishes the name so producers and workloads agree on it, but does not
+	// inject this workload-specific setting.
 	RestoreStandbyModeEnv = "SNAPSHOT_RESTORE_STANDBY"
 
-	// LegacyRestoreStandbyModeEnv is the deprecated Dynamo restore standby
-	// environment variable. Snapshot publishes the name but does not inject it.
+	// LegacyRestoreStandbyModeEnv is the previous name of RestoreStandbyModeEnv,
+	// kept for existing workload integrations that still read it. Snapshot
+	// publishes the name but does not inject it.
 	//
-	// Deprecated: use RestoreStandbyModeEnv for new workload integrations.
+	// Deprecated: use RestoreStandbyModeEnv. This alias is removed in the next
+	// release.
 	LegacyRestoreStandbyModeEnv = "DYN_SNAPSHOT_RESTORE_STANDBY"
 
 	// RestoreCompleteFile is written by the Snapshot agent when restore has

--- a/docs/guides/sglang/app.py
+++ b/docs/guides/sglang/app.py
@@ -111,7 +111,7 @@ def serve_api(engine: Any, restored_text: str) -> None:
 
 
 def main() -> None:
-    if os.environ.get("DYN_SNAPSHOT_RESTORE_STANDBY") == "1":
+    if os.environ.get("SNAPSHOT_RESTORE_STANDBY") == "1":
         while True:
             time.sleep(3600)
 

--- a/docs/guides/tensorrt-llm/app.py
+++ b/docs/guides/tensorrt-llm/app.py
@@ -69,7 +69,7 @@ def serve_api(llm: LLM, restored_text: str) -> None:
 
 
 def main() -> None:
-    if os.environ.get("DYN_SNAPSHOT_RESTORE_STANDBY") == "1":
+    if os.environ.get("SNAPSHOT_RESTORE_STANDBY") == "1":
         while True:
             time.sleep(3600)
 

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -77,7 +77,7 @@ async def serve_api(engine: AsyncLLM, restored_text: str) -> None:
 
 
 async def main() -> None:
-    if os.environ.get("DYN_SNAPSHOT_RESTORE_STANDBY") == "1":
+    if os.environ.get("SNAPSHOT_RESTORE_STANDBY") == "1":
         await asyncio.Event().wait()
 
     CONTROL_DIR.joinpath("ready-for-snapshot").unlink(missing_ok=True)

--- a/docs/reference/restore-pod-contract.md
+++ b/docs/reference/restore-pod-contract.md
@@ -144,9 +144,13 @@ the restriction elsewhere. A destination container must not override a
 requested profile with a conflicting profile.
 
 Snapshot does not modify container commands and does not inject
-`SNAPSHOT_RESTORE_STANDBY`, its deprecated
-`DYN_SNAPSHOT_RESTORE_STANDBY` alias, or any other workload-specific standby
-setting. Both names are exported by `api/podcontract` so application owners can
-set the convention they support. The producer must ensure each destination
+`SNAPSHOT_RESTORE_STANDBY`, its deprecated `DYN_SNAPSHOT_RESTORE_STANDBY`
+alias, or any other workload-specific standby setting. The canonical name is
+exported by `api/podcontract` (`RestoreStandbyModeEnv`) so producers and
+standby-aware workload entrypoints agree on it: a producer sets
+`SNAPSHOT_RESTORE_STANDBY=1` on destination containers, and the workload
+entrypoint blocks without initializing when it sees that value. The alias
+(`LegacyRestoreStandbyModeEnv`) remains exported for existing integrations and
+is removed in the next release. The producer must ensure each destination
 process remains alive and inert until the agent replaces it with the restored
 process.

--- a/e2e/snapshot_e2e/workloads.py
+++ b/e2e/snapshot_e2e/workloads.py
@@ -144,9 +144,8 @@ def restore_pod(
         }
     }
     spec["containers"][0]["env"] = [
-        {"name": "DYN_SNAPSHOT_RESTORE_STANDBY", "value": "1"},
+        {"name": "SNAPSHOT_RESTORE_STANDBY", "value": "1"},
         {"name": "SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
-        {"name": "DYN_SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
         {"name": RESTORE_TOKEN_ENV, "value": run.restore_token},
     ]
     spec["containers"][0]["startupProbe"] = {
@@ -205,9 +204,8 @@ def multi_restore_pod(
                 }
             ],
             "env": [
-                {"name": "DYN_SNAPSHOT_RESTORE_STANDBY", "value": "1"},
+                {"name": "SNAPSHOT_RESTORE_STANDBY", "value": "1"},
                 {"name": "SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
-                {"name": "DYN_SNAPSHOT_CONTROL_DIR", "value": CONTROL_DIR},
                 {"name": RESTORE_TOKEN_ENV, "value": restore_tokens[destination]},
             ],
             "startupProbe": {

--- a/e2e/tests/test_workload_scripts.py
+++ b/e2e/tests/test_workload_scripts.py
@@ -138,6 +138,11 @@ def test_restore_manifests_use_canonical_control_mount_and_startup_gate(
         "cat",
         workloads.RESTORE_DONE,
     ]
+    # The standby flag is what keeps the placeholder from loading a model
+    # itself; it must be injected under its single canonical name.
+    standby_env = {"name": "SNAPSHOT_RESTORE_STANDBY", "value": "1"}
+    assert standby_env in single_container["env"]
+    assert all(not e["name"].startswith("DYN_") for e in single_container["env"])
 
     multi, _ = workloads.multi_restore_pod(
         config=config,
@@ -150,3 +155,5 @@ def test_restore_manifests_use_canonical_control_mount_and_startup_gate(
             "cat",
             workloads.RESTORE_DONE,
         ]
+        assert standby_env in container["env"]
+        assert all(not e["name"].startswith("DYN_") for e in container["env"])


### PR DESCRIPTION
### Summary

Backports #170 to `release/0.1`.

Cherry-pick of the squash-merge commit `eb6d0a0` from `main`. Standardizes on `SNAPSHOT_RESTORE_STANDBY` as the canonical restore-standby environment variable across `api/podcontract`, the guide programs, docs, and e2e; keeps `LegacyRestoreStandbyModeEnv` (`DYN_SNAPSHOT_RESTORE_STANDBY`) exported for one more release per #170's review follow-ups. Also fixes a real bug: the e2e restore pod builders previously set the deprecated alias instead of the canonical name.

### Verification

- Cherry-pick applied cleanly against `release/0.1` (no conflicts).
- `go vet ./... && go test ./...` in `api/podcontract` — ok.
- Manually diffed the result against `release/0.1` to confirm no leftover references to the removed `DYN_SNAPSHOT_CONTROL_DIR` env or stale doc text.
