### PR TITLE
feat: cuinterpose delivery, agent orchestration, and packaging

### DIFF
--- a/agent/.dockerignore
+++ b/agent/.dockerignore
@@ -1,0 +1,1 @@
+cmd/cuinterpose/build/

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -113,14 +113,30 @@ RUN mkdir -p /go-src && go mod vendor -o /go-src/vendor
 # =============================================================================
 FROM ${AGENT_BASE_IMAGE} AS cuda-helper-builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# cuinterpose is built against CUDA 13.1 headers (the base image ships 13.0):
+# 13.1 added the device-explicit multicast bind entry points the shim wraps.
+# Headers only; the shim links nothing from libcuda. libgtest-dev runs the
+# shim's unit tests during the build, so a broken shim fails the image.
+# The base image carries no NVIDIA apt repository; the pinned cuda-keyring
+# package adds it.
+ARG CUINTERPOSE_CUDA_HEADERS=13-1
+ADD --checksum=sha256:d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba \
+    https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
+    /tmp/cuda-keyring.deb
+RUN dpkg -i /tmp/cuda-keyring.deb && rm /tmp/cuda-keyring.deb \
+    && apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    libgtest-dev \
+    cuda-driver-dev-${CUINTERPOSE_CUDA_HEADERS} \
+    cuda-cudart-dev-${CUINTERPOSE_CUDA_HEADERS} \
+    cuda-crt-${CUINTERPOSE_CUDA_HEADERS} \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
 COPY cmd/cuda-checkpoint-helper/main.c ./cmd/cuda-checkpoint-helper/main.c
 COPY cmd/ns-bind-mount/main.c ./cmd/ns-bind-mount/main.c
+COPY cmd/cuinterpose/ ./cmd/cuinterpose/
 
 RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
     ./cmd/cuda-checkpoint-helper/main.c \
@@ -131,6 +147,13 @@ RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
 # ns-bind-mount bind-mounts the snapshot binaries into a target container's mount
 # namespace. It needs no CUDA headers, only mount_setattr (Linux 5.12+).
 RUN gcc -O2 -Wall -Wextra -o /ns-bind-mount ./cmd/ns-bind-mount/main.c
+
+# cuinterpose: LD_PRELOAD shim and static coordinator (see cmd/cuinterpose/README.md).
+# `test` builds a sanitizer-instrumented copy of the shim plus fake CUDA
+# libraries and runs the GoogleTest suites; the production artifacts in
+# /cuinterpose-build are the uninstrumented ones.
+RUN make -C ./cmd/cuinterpose BUILD_DIR=/cuinterpose-build \
+    CUDA_HOME=/usr/local/cuda-$(echo ${CUINTERPOSE_CUDA_HEADERS} | tr - .) all test
 
 # =============================================================================
 # Stage: CRIU Builder - Build CRIU with CUDA plugin
@@ -251,8 +274,11 @@ COPY --from=cuda-helper-builder /cuda-checkpoint-helper /usr/local/bin/cuda-chec
 # nsmount resolves this helper at /usr/local/sbin/ns-bind-mount (see
 # agent/internal/nsmount/mount.go defaultBinaryPath).
 COPY --from=cuda-helper-builder /ns-bind-mount /usr/local/sbin/ns-bind-mount
+COPY --from=cuda-helper-builder /cuinterpose-build/libcuinterpose.so /usr/local/lib/snapshot/libcuinterpose.so
+COPY --from=cuda-helper-builder /cuinterpose-build/cuinterpose-coordinator /usr/local/bin/cuinterpose-coordinator
 RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-helper \
-    /usr/local/sbin/ns-bind-mount
+    /usr/local/sbin/ns-bind-mount /usr/local/bin/cuinterpose-coordinator \
+    && chmod 0644 /usr/local/lib/snapshot/libcuinterpose.so
 
 # Copy the built binaries
 COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
@@ -266,12 +292,20 @@ RUN output=$(/usr/local/bin/pagebroker 2>&1); status=$?; \
 # The placeholder ships none of this. nsrestore redirects all three lookup
 # mechanisms into the mount: criu's libdir -> criu-plugins/ (criu.overrideLibDir),
 # LD_LIBRARY_PATH -> lib/, and PATH -> the bundle root.
-RUN mkdir -p /snapshot-binaries/lib /snapshot-binaries/criu-plugins
+RUN mkdir -p /snapshot-binaries/lib /snapshot-binaries/criu-plugins /snapshot-binaries/cuinterpose
 COPY --from=builder /nsrestore /snapshot-binaries/nsrestore
 COPY --from=criu-builder /criu-install/usr/local/sbin/criu /snapshot-binaries/criu
 COPY --from=criu-builder /criu-install/usr/local/lib/snapshot/criu-plugins/ /snapshot-binaries/criu-plugins/
 COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /snapshot-binaries/cuda-checkpoint
 COPY --from=cuda-helper-builder /cuda-checkpoint-helper /snapshot-binaries/cuda-checkpoint-helper
+# cuinterpose restore bundle: the shim and the cuda-checkpoint that wrapped the
+# source workload are bind-mounted at the same path the source used, because
+# CRIU restores file-backed mappings by path.
+COPY --from=cuda-helper-builder /cuinterpose-build/libcuinterpose.so /snapshot-binaries/cuinterpose/libcuinterpose.so
+COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /snapshot-binaries/cuinterpose/cuda-checkpoint
+RUN chmod 0644 /snapshot-binaries/cuinterpose/libcuinterpose.so \
+    && chmod +x /snapshot-binaries/cuinterpose/cuda-checkpoint
+COPY --from=cuda-helper-builder /cuinterpose-build/cuinterpose-coordinator /snapshot-binaries/cuinterpose-coordinator
 
 # Network binaries needed during restore:
 #   ip  — address/route restore (criu/net.c)
@@ -285,6 +319,7 @@ RUN set -eu; \
     cp -L "$(command -v ip)" "$(command -v tar)" /snapshot-binaries/; \
     chmod +x /snapshot-binaries/criu /snapshot-binaries/nsrestore \
              /snapshot-binaries/cuda-checkpoint /snapshot-binaries/cuda-checkpoint-helper \
+             /snapshot-binaries/cuinterpose-coordinator \
              /snapshot-binaries/ip /snapshot-binaries/tar
 
 # Shared-library closure of the bundled binaries and plugins.

--- a/agent/cmd/cuinterpose/.gitignore
+++ b/agent/cmd/cuinterpose/.gitignore
@@ -1,0 +1,4 @@
+build/
+tests/gpu/.venv/
+__pycache__/
+.pytest_cache/

--- a/agent/cmd/cuinterpose/Makefile
+++ b/agent/cmd/cuinterpose/Makefile
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds libcuinterpose.so (the LD_PRELOAD shim) and cuinterpose-coordinator
+# (a static helper the snapshot agent runs), and runs the unit tests against a
+# fake libcuda/libcudart so no GPU is needed.
+#
+#   make                 build both artifacts into $(BUILD_DIR)
+#   make test            build the fakes and GoogleTest binaries, run them
+#   make CUDA_HOME=...   point at a CUDA toolkit (headers only are used)
+#
+# The shim is delivered in layers. Every C file in this directory is part of
+# the shim except coordinator.c; tests are found by name (see "Tests" below).
+# Adding a layer means adding files, not editing this Makefile.
+
+BUILD_DIR ?= build
+CUDA_HOME ?= /usr/local/cuda
+CC ?= cc
+CXX ?= c++
+
+INTERPOSER := $(BUILD_DIR)/libcuinterpose.so
+COORDINATOR := $(BUILD_DIR)/cuinterpose-coordinator
+
+# The shim must load into any workload image from Ubuntu 22.04 (glibc 2.35)
+# onward. It resolves glibc's dlsym through dlvsym(..., "GLIBC_2.34"), and the
+# build rejects any symbol version newer than this.
+MIN_GLIBC := GLIBC_2.34
+# CUDA 13.1 added the device-explicit multicast bind entry points. The shipped
+# shim is built against 13.1 or newer headers so those wrappers exist; the
+# shim has no runtime dependency on the header version because every driver
+# symbol is looked up at run time. Set ALLOW_OLD_CUDA_HEADERS=1 for local
+# builds against older headers.
+MIN_CUDA_VERSION := 13010
+CUDA_VERSION := $(shell sed -n 's/^\#define CUDA_VERSION \([0-9]*\).*/\1/p' $(CUDA_HOME)/include/cuda.h 2>/dev/null)
+
+COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror
+INTERPOSER_CPPFLAGS := -DCUINTERPOSE_DLSYM_VERSION=\"$(MIN_GLIBC)\" -I$(CUDA_HOME)/include
+INTERPOSER_CFLAGS := $(COMMON_FLAGS) -fPIC -fvisibility=hidden -Wno-deprecated-declarations
+# -z defs: every reference must resolve at link time, so an accidental direct
+# call into libcuda (which the shim must never link) fails the build instead of
+# failing inside a workload. -Bsymbolic-functions: the shim's own internal calls
+# bind locally and cannot be interposed by the application.
+INTERPOSER_LDFLAGS := -shared -Wl,-Bsymbolic-functions -Wl,-z,defs -ldl -pthread
+INTERPOSER_SOURCES := $(filter-out coordinator.c,$(wildcard *.c))
+INTERPOSER_HEADERS := $(wildcard *.h)
+COORDINATOR_SOURCES := coordinator.c util.c
+COORDINATOR_HEADERS := protocol.h util.h
+# Everything the shim is allowed to export. Anything else is a bug: an
+# LD_PRELOAD library sits first in the process's symbol search order.
+EXPORT_ALLOWLIST := '^(cu[A-Z][A-Za-z0-9_]*|cuda[A-Z][A-Za-z0-9_]*|dlsym|cuinterpose_[a-z_]+)$$'
+
+.PHONY: all clean test check-cuda-headers
+
+all: $(INTERPOSER) $(COORDINATOR)
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+check-cuda-headers:
+	@test -n "$(CUDA_VERSION)" || { echo "cuda.h not found under $(CUDA_HOME)/include" >&2; exit 1; }
+	@if [ "$(CUDA_VERSION)" -lt "$(MIN_CUDA_VERSION)" ] && [ -z "$(ALLOW_OLD_CUDA_HEADERS)" ]; then \
+	  echo "CUDA headers are $(CUDA_VERSION); the shim is built against >= $(MIN_CUDA_VERSION) (set ALLOW_OLD_CUDA_HEADERS=1 to override)" >&2; exit 1; fi
+
+$(INTERPOSER): $(INTERPOSER_SOURCES) $(INTERPOSER_HEADERS) | $(BUILD_DIR) check-cuda-headers
+	$(CC) $(INTERPOSER_CFLAGS) $(INTERPOSER_CPPFLAGS) -o $@.tmp $(INTERPOSER_SOURCES) $(INTERPOSER_LDFLAGS)
+	@# No link-time dependency on the CUDA libraries.
+	! readelf -d $@.tmp | grep -Eq 'NEEDED.*(libcuda|libcudart)'
+	@# No glibc symbol newer than MIN_GLIBC.
+	max=$$(readelf -V $@.tmp | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1); \
+	  [ "$$(printf '%s\n%s\n' "$$max" "$(MIN_GLIBC)" | sort -uV | tail -1)" = "$(MIN_GLIBC)" ]
+	@# The real dlsym is fetched through the pinned dlvsym (once the shim resolves symbols at all).
+	@if [ -f symbols.c ]; then readelf --dyn-syms -W $@.tmp | grep -q 'dlvsym@$(MIN_GLIBC)'; fi
+	@# Only the intended symbols are exported.
+	@bad=$$(nm -D --defined-only $@.tmp | awk '$$2 ~ /^[TWDRBV]$$/ {print $$3}' | grep -Ev $(EXPORT_ALLOWLIST) || true); \
+	  if [ -n "$$bad" ]; then echo "unexpected exported symbols:" $$bad >&2; exit 1; fi
+	mv $@.tmp $@
+
+$(COORDINATOR): $(COORDINATOR_SOURCES) $(COORDINATOR_HEADERS) | $(BUILD_DIR)
+	$(CC) $(COMMON_FLAGS) -static -pthread -o $@.tmp $(COORDINATOR_SOURCES)
+	! readelf -d $@.tmp 2>/dev/null | grep -q NEEDED
+	mv $@.tmp $@
+
+# ---------------------------------------------------------------------------
+# Tests. The shim under test is a separate build with AddressSanitizer and
+# UndefinedBehaviorSanitizer; the production .so above is never instrumented.
+# Fake libcuda.so.1 / libcudart.so.13 record what they were called with.
+#
+# Three kinds of test, told apart by file name:
+#   tests/<name>_unit_test.cc     links the shim's CUDA-free objects (util,
+#                                 posix, tables, export cache) and runs alone
+#   tests/<name>_preload_test.cc  runs with the sanitized shim LD_PRELOADed
+#                                 over the fake libcuda/libcudart
+#   tests/coordinator_test.cc     runs the sanitized coordinator binary
+#                                 against fake participants
+# ---------------------------------------------------------------------------
+TEST_DIR := $(BUILD_DIR)/test
+SANITIZE ?= address,undefined
+SANITIZE_FLAGS := $(if $(SANITIZE),-fsanitize=$(SANITIZE) -fno-omit-frame-pointer,)
+GTEST_CFLAGS ?= $(shell pkg-config --cflags gtest 2>/dev/null)
+GTEST_LIBS ?= $(shell pkg-config --libs gtest_main gtest 2>/dev/null || echo -lgtest_main -lgtest)
+TEST_CXXFLAGS := -std=c++17 -O1 -g -Wall -Wextra -Werror -Wno-deprecated-declarations -I. -I$(CUDA_HOME)/include $(GTEST_CFLAGS)
+TEST_INTERPOSER := $(TEST_DIR)/libcuinterpose.so
+FAKE_CUDA := $(TEST_DIR)/libcuda.so.1
+FAKE_CUDART := $(TEST_DIR)/libcudart.so.13
+TEST_COORDINATOR := $(TEST_DIR)/cuinterpose-coordinator
+TEST_HEADERS := $(wildcard tests/*.h)
+UNIT_TESTS := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/*_unit_test.cc))
+PRELOAD_TESTS := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/*_preload_test.cc))
+COORDINATOR_TEST := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/coordinator_test.cc))
+# Shim sources that need no CUDA driver at run time. symbols.c and context.c
+# resolve driver symbols and are exercised through the preload tests.
+UNIT_SOURCES := $(filter-out coordinator.c interpose.c multicast.c symbols.c context.c,$(wildcard *.c))
+UNIT_OBJECTS := $(patsubst %.c,$(TEST_DIR)/%.o,$(UNIT_SOURCES))
+# When the shim under test is ASan-instrumented, the ASan runtime must be the
+# first library in the process, ahead of the shim itself.
+ASAN_PRELOAD := $(if $(findstring address,$(SANITIZE)),$(shell $(CC) -print-file-name=libasan.so):,)
+TEST_ENV := SNAPSHOT_CONTROL_DIR=$(abspath $(TEST_DIR)/control) CUINTERPOSE_COORDINATOR=$(abspath $(TEST_COORDINATOR))
+
+$(TEST_DIR):
+	mkdir -p $@
+
+$(TEST_DIR)/%.o: %.c $(INTERPOSER_HEADERS) | $(TEST_DIR)
+	$(CC) $(COMMON_FLAGS) $(SANITIZE_FLAGS) -g -c -o $@ $<
+
+# symbols.c is compiled without instrumentation: it defines dlsym, which the
+# sanitizer runtime itself calls while it is still initializing, before
+# instrumented code may run.
+SYMBOLS_OBJECT := $(if $(wildcard symbols.c),$(TEST_DIR)/symbols.plain.o,)
+SANITIZED_SOURCES := $(filter-out symbols.c,$(INTERPOSER_SOURCES))
+$(TEST_DIR)/symbols.plain.o: symbols.c $(INTERPOSER_HEADERS) | $(TEST_DIR) check-cuda-headers
+	$(CC) $(INTERPOSER_CFLAGS) $(INTERPOSER_CPPFLAGS) -g -c -o $@ symbols.c
+
+$(TEST_INTERPOSER): $(INTERPOSER_SOURCES) $(INTERPOSER_HEADERS) $(SYMBOLS_OBJECT) | $(TEST_DIR) check-cuda-headers
+	$(CC) $(INTERPOSER_CFLAGS) $(INTERPOSER_CPPFLAGS) $(SANITIZE_FLAGS) -g -o $@ $(SANITIZED_SOURCES) $(SYMBOLS_OBJECT) $(INTERPOSER_LDFLAGS)
+
+$(FAKE_CUDA): tests/fake_cuda.c tests/fake_cuda.h | $(TEST_DIR)
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
+	  -Wl,-soname,libcuda.so.1 -o $@ tests/fake_cuda.c -pthread
+	ln -sf libcuda.so.1 $(TEST_DIR)/libcuda.so
+
+$(FAKE_CUDART): tests/fake_cudart.c tests/fake_cuda.h | $(TEST_DIR) $(FAKE_CUDA)
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
+	  -Wl,-soname,libcudart.so.13 -L$(TEST_DIR) -o $@ tests/fake_cudart.c -lcuda
+	ln -sf libcudart.so.13 $(TEST_DIR)/libcudart.so
+
+$(TEST_DIR)/%_unit_test: tests/%_unit_test.cc $(UNIT_OBJECTS) $(INTERPOSER_HEADERS) $(TEST_HEADERS) | $(TEST_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(SANITIZE_FLAGS) -o $@ $< $(UNIT_OBJECTS) $(GTEST_LIBS) -pthread
+
+$(TEST_DIR)/%_preload_test: tests/%_preload_test.cc $(INTERPOSER_HEADERS) $(TEST_HEADERS) $(FAKE_CUDA) $(FAKE_CUDART) | $(TEST_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(SANITIZE_FLAGS) -L$(TEST_DIR) -Wl,-rpath,'$$ORIGIN' -o $@ $< -lcuda -lcudart -ldl $(GTEST_LIBS) -pthread
+
+# A dynamically linked, sanitizer-instrumented coordinator for the tests; the
+# production one above is static and uninstrumented.
+$(TEST_COORDINATOR): $(COORDINATOR_SOURCES) $(COORDINATOR_HEADERS) | $(TEST_DIR)
+	$(CC) $(COMMON_FLAGS) $(SANITIZE_FLAGS) -g -pthread -o $@ $(COORDINATOR_SOURCES)
+
+$(TEST_DIR)/coordinator_test: tests/coordinator_test.cc $(TEST_DIR)/util.o protocol.h util.h $(TEST_HEADERS) $(TEST_COORDINATOR) | $(TEST_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(SANITIZE_FLAGS) -o $@ $< $(TEST_DIR)/util.o $(GTEST_LIBS) -pthread
+
+test: $(INTERPOSER) $(COORDINATOR) $(UNIT_TESTS) $(COORDINATOR_TEST) $(if $(PRELOAD_TESTS),$(TEST_INTERPOSER) $(TEST_COORDINATOR)) $(PRELOAD_TESTS)
+	@mkdir -p $(TEST_DIR)/control
+	$(foreach t,$(UNIT_TESTS),$(t) &&) true
+	$(foreach t,$(COORDINATOR_TEST),CUINTERPOSE_COORDINATOR=$(abspath $(TEST_COORDINATOR)) $(t) &&) true
+	$(foreach t,$(PRELOAD_TESTS),$(TEST_ENV) LD_PRELOAD=$(ASAN_PRELOAD)$(abspath $(TEST_INTERPOSER)) $(t) &&) true
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/agent/cmd/cuinterpose/README.md
+++ b/agent/cmd/cuinterpose/README.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# cuinterpose
+
+cuinterpose is the CUDA interposer: a library that a workload loads through
+`LD_PRELOAD` so Snapshot can checkpoint and restore CUDA memory that is shared
+between processes on one node, plus a small coordinator the snapshot agent runs
+at checkpoint and restore time.
+
+## Using it
+
+1. Install Snapshot with the chart; the operator learns the agent image from
+   `image.agent` and, for private registries, the pull secrets from
+   `cuinterpose.imagePullSecrets`.
+2. Opt a source Pod in with the annotation `nvidia.com/cuinterpose: enabled`
+   and give its container an explicit `command`. A `SnapshotJob` shapes the Pod
+   itself; for a `PodSnapshot` of a Deployment you manage, shape the template
+   with `podcontract.ShapeCuinterposeCapture` (init container copying the shim
+   out of the agent image, `LD_PRELOAD`, the `cuda-checkpoint --launch-job`
+   wrapper).
+3. Keep the workload's allocators on POSIX file-descriptor handles; fabric
+   handles pass through untracked (see `docs/limitations.md`).
+4. Checkpoint and restore as usual. The agent's log carries one line per
+   coordinator phase, for example:
+
+```
+cuinterpose-coordinator phase=save_host_carrier status=ok elapsed_ms=339.7 participants=4 carrier_count=382 carrier_bytes=2076180480 gb_per_s=6.10 copy_gb_per_s=82.54
+```
+
+Knobs, read by the shim and the coordinator: `SNAPSHOT_CONTROL_DIR` (default
+`/snapshot-control`), `SNAPSHOT_PARTICIPANT_ID` (tests only),
+`SNAPSHOT_CONTROL_TIMEOUT_SECONDS` (default 10) for ordinary exchanges, and
+`SNAPSHOT_CARRIER_TIMEOUT_SECONDS` (default 3600) for the two phases that copy
+allocation contents.
+
+The design, the flows as sequence diagrams, the invariants, the pitfalls that
+shaped it, and what is explicitly unsupported are in
+[`docs/reference/cuinterpose.md`](../../../docs/reference/cuinterpose.md).
+
+## Build
+
+```bash
+make -C agent/cmd/cuinterpose CUDA_HOME=/usr/local/cuda-13.1
+```
+
+Only headers are used from `CUDA_HOME`; the shim never links libcuda. Every C
+file in the directory is part of the shim except `coordinator.c`, which is the
+coordinator. The build asserts, on the produced `libcuinterpose.so`:
+
+- no `NEEDED` entry for libcuda or libcudart;
+- no glibc symbol newer than `GLIBC_2.34` (the shim must load into Ubuntu
+  22.04 images);
+- the real `dlsym` is obtained through `dlvsym(..., "GLIBC_2.34")`;
+- the exported symbol set is exactly the CUDA entry points it replaces,
+  `dlsym`, and `cuinterpose_*` (everything else is hidden, because an
+  `LD_PRELOAD` library is first in the symbol search order of the whole
+  process);
+- the CUDA headers are 13.1 or newer (`ALLOW_OLD_CUDA_HEADERS=1` overrides).
+
+`cuinterpose_build_info` records the CUDA header version the loaded shim was
+compiled against; `nm -D libcuinterpose.so` shows it.
+
+The coordinator is statically linked so it can run inside the restored
+container's mount namespace regardless of that image's C library.
+
+## Tests
+
+```bash
+make -C agent/cmd/cuinterpose CUDA_HOME=/usr/local/cuda-13.1 test
+```
+
+GoogleTest suites, no GPU needed, found by file name under `tests/`:
+`<name>_unit_test.cc` links the shim's CUDA-free objects and runs on its own;
+`<name>_preload_test.cc` runs with a sanitizer-instrumented build of the shim
+`LD_PRELOAD`ed over a fake `libcuda.so.1` / `libcudart.so.13` that record what
+they were called with; `coordinator_test.cc` runs the sanitizer-instrumented
+coordinator against fake participants. All are built with AddressSanitizer and
+UndefinedBehaviorSanitizer (`SANITIZE=` disables). The agent image build runs
+them; a failing test fails the image. GPU tests live under `tests/gpu`.

--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Placeholder coordinator. The snapshot agent runs the coordinator only when a
+ * checkpointed CUDA process shows a cuinterpose control socket, and this
+ * build's shim opens none, so this program is never reached in practice. If it
+ * is, it refuses to do anything and says so. The real coordinator replaces it
+ * in a following change; the agent's argument contract is already final and
+ * covered by the Go tests against a fake binary.
+ */
+
+#include <stdio.h>
+
+#include "protocol.h"
+
+int
+main(int argc, char** argv)
+{
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "cuinterpose-coordinator (protocol %u): this build carries no coordinator; nothing was prepared or restored\n",
+          (unsigned)CUINTERPOSE_VERSION);
+  return 1;
+}

--- a/agent/cmd/cuinterpose/export.h
+++ b/agent/cmd/cuinterpose/export.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_EXPORT_H
+#define CUINTERPOSE_EXPORT_H
+
+#include <stdint.h>
+
+/*
+ * The shim is built with -fvisibility=hidden, so nothing leaks into the
+ * workload's global symbol table unless it is marked with CUINTERPOSE_API. Only the
+ * CUDA entry points the shim replaces, dlsym, and cuinterpose_build_info carry
+ * it; the Makefile asserts that no other symbol is exported. An LD_PRELOAD
+ * library sits first in symbol lookup for the whole process, so an accidental
+ * export named like a common helper would silently hijack another library's
+ * call.
+ */
+#define CUINTERPOSE_API __attribute__((visibility("default")))
+
+/*
+ * cuinterpose_build_info lets an operator or a test confirm which CUDA headers
+ * the loaded shim was compiled against, for example with
+ * `nm -D libcuinterpose.so` or by dlsym()ing the symbol.
+ */
+struct cuinterpose_build_info {
+  uint32_t cuda_version; /* CUDA_VERSION from cuda.h at build time */
+  uint32_t protocol_version; /* CUINTERPOSE_VERSION from protocol.h */
+};
+
+extern CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info;
+
+/*
+ * Live counters for tests and operators: how much the shim is tracking in this
+ * process right now. Reading them takes the shim's lock briefly.
+ */
+struct cuinterpose_debug_stats {
+  uint64_t allocations; /* tracked allocation records */
+  uint64_t handles; /* logical handles handed to the application */
+  uint64_t mappings; /* tracked mappings */
+  uint64_t multicasts; /* tracked multicast objects */
+  uint64_t cached_exports; /* descriptors held in the export cache */
+  uint64_t live_raw_imports; /* untracked imports not yet released */
+  uint64_t passthrough_creations; /* allocations created with non-POSIX handle types */
+  uint32_t phase; /* enum cuinterpose_phase */
+};
+
+CUINTERPOSE_API void cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats);
+
+#endif

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Placeholder shim. It builds and is packaged as libcuinterpose.so so that the
+ * delivery path (init container, LD_PRELOAD, restore mount) is final before
+ * the interposer exists, and it intercepts nothing. The following changes
+ * replace it: symbol resolution and forwarding, allocation tracking, the
+ * checkpoint lifecycle, multicast objects.
+ */
+
+#include <cuda.h>
+#include <string.h>
+
+#include "export.h"
+#include "protocol.h"
+
+CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info = {CUDA_VERSION, CUINTERPOSE_VERSION};
+
+CUINTERPOSE_API void
+cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
+{
+  memset(stats, 0, sizeof(*stats));
+}

--- a/agent/cmd/cuinterpose/protocol.h
+++ b/agent/cmd/cuinterpose/protocol.h
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_PROTOCOL_H
+#define CUINTERPOSE_PROTOCOL_H
+
+#include <stdint.h>
+
+/* The headers are shared with C++ tests. */
+#ifdef __cplusplus
+#define CUINTERPOSE_STATIC_ASSERT static_assert
+#else
+#define CUINTERPOSE_STATIC_ASSERT _Static_assert
+#endif
+
+/*
+ * Wire contract between the shim's control socket and the coordinator, and
+ * the fixed names the Go agent relies on. The Go side pins these strings with a
+ * test (agent/internal/cuda), so renaming one here breaks that test rather
+ * than silently disabling interposition.
+ */
+
+/* Directory (inside the workload container) holding per-process control sockets. */
+#define CUINTERPOSE_CONTROL_DIR "/snapshot-control"
+/* Environment variable overriding CUINTERPOSE_CONTROL_DIR; must be absolute. */
+#define CUINTERPOSE_CONTROL_DIR_ENV "SNAPSHOT_CONTROL_DIR"
+/* Socket name: <prefix><namespace-pid>.sock */
+#define CUINTERPOSE_SOCKET_PREFIX "cuinterpose-"
+/* Topology sidecar the coordinator writes into the checkpoint directory. */
+#define CUINTERPOSE_STATE_FILENAME "cuinterpose.state"
+/* Optional stable participant identity: 32 lowercase hex characters. */
+#define CUINTERPOSE_PARTICIPANT_ID_ENV "SNAPSHOT_PARTICIPANT_ID"
+/* Whole-second send/receive timeout for every control socket, both sides. */
+#define CUINTERPOSE_CONTROL_TIMEOUT_ENV "SNAPSHOT_CONTROL_TIMEOUT_SECONDS"
+#define CUINTERPOSE_CONTROL_TIMEOUT_SECONDS_DEFAULT 10U
+/* Longer timeout for the two operations that copy allocation contents between
+ * device and host; they scale with the amount of tracked memory. */
+#define CUINTERPOSE_CARRIER_TIMEOUT_ENV "SNAPSHOT_CARRIER_TIMEOUT_SECONDS"
+#define CUINTERPOSE_CARRIER_TIMEOUT_SECONDS_DEFAULT 3600U
+/* First line of the state file; bump when the record layout changes. */
+#define CUINTERPOSE_STATE_HEADER "cuinterpose-state-v2"
+
+#define CUINTERPOSE_MAGIC 0x44564d4dU
+#define CUINTERPOSE_VERSION 2U
+#define CUINTERPOSE_ID_SIZE 33U
+#define CUINTERPOSE_ALLOCATION_ID_SIZE 16U
+#define CUINTERPOSE_TOKEN_SIZE 16U
+/* Access descriptors kept per mapping. The shim merges access calls per
+ * location, so this bounds the number of distinct GPUs (plus host NUMA nodes)
+ * that may be granted access to one mapping. */
+#define CUINTERPOSE_MAX_ACCESS 32U
+#define CUINTERPOSE_MAX_RECORDS 4096U
+#define CUINTERPOSE_POSIX_HANDLE_TYPE 1U
+
+enum cuinterpose_operation {
+  CUINTERPOSE_IDENTIFY = 1,
+  CUINTERPOSE_INSPECT = 2,
+  CUINTERPOSE_PREPARE_MULTICAST = 3,
+  CUINTERPOSE_PREPARE = 4,
+  CUINTERPOSE_RESTORE_CREATORS = 5,
+  CUINTERPOSE_RESTORE_IMPORTERS = 6,
+  CUINTERPOSE_EXPORT = 7,
+  CUINTERPOSE_RESTORE_MULTICAST_CREATORS = 8,
+  CUINTERPOSE_RESTORE_MULTICAST_IMPORTERS = 9,
+  CUINTERPOSE_RESTORE_MULTICAST_DEVICES = 10,
+  CUINTERPOSE_RESTORE_MULTICAST = 11,
+  CUINTERPOSE_SAVE_HOST_CARRIER = 12,
+  CUINTERPOSE_RESTORE_HOST_CARRIER = 13,
+};
+
+enum cuinterpose_record_kind {
+  CUINTERPOSE_ALLOCATION = 1,
+  CUINTERPOSE_MAPPING = 2,
+  CUINTERPOSE_MULTICAST = 3,
+  CUINTERPOSE_MULTICAST_DEVICE = 4,
+  CUINTERPOSE_MULTICAST_BINDING = 5,
+  CUINTERPOSE_MULTICAST_MAPPING = 6,
+};
+
+enum cuinterpose_record_flags {
+  CUINTERPOSE_CREATOR = 1U << 0,
+  CUINTERPOSE_APPLICATION_HANDLE_LIVE = 1U << 1,
+  CUINTERPOSE_HOST_CARRIER = 1U << 2,
+  /* A creator allocation that was never exported. It is reported only so its
+   * contents can travel through the host carrier; no importer refers to it. */
+  CUINTERPOSE_CARRIER_ONLY = 1U << 3,
+};
+
+/* Where a participant is in the checkpoint/restore lifecycle; reported in
+ * IDENTIFY replies for diagnostics. */
+enum cuinterpose_phase {
+  CUINTERPOSE_PHASE_ACTIVE = 1,
+  CUINTERPOSE_PHASE_PREPARING = 2,
+  CUINTERPOSE_PHASE_PREPARED = 3,
+  CUINTERPOSE_PHASE_RESTORING = 4,
+  CUINTERPOSE_PHASE_FAILED = 5,
+};
+
+enum cuinterpose_resource_kind {
+  CUINTERPOSE_RESOURCE_UNICAST = 1,
+  CUINTERPOSE_RESOURCE_MULTICAST = 2,
+};
+
+enum cuinterpose_multicast_binding_kind {
+  CUINTERPOSE_MULTICAST_BIND_MEM = 1,
+  CUINTERPOSE_MULTICAST_BIND_ADDR = 2,
+};
+
+/*
+ * Every control exchange is one fixed-size header each way, optionally
+ * followed by `count` records (`payload_size` bytes) and optionally carrying
+ * one file descriptor as SCM_RIGHTS ancillary data.
+ */
+struct cuinterpose_header {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t operation;
+  int32_t status; /* 0 on success, -1 with `message` on failure */
+  uint32_t count;
+  uint64_t payload_size;
+  char participant_id[CUINTERPOSE_ID_SIZE];
+  char message[96];
+  uint8_t authorization[CUINTERPOSE_TOKEN_SIZE];
+  uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  uint32_t resource_kind;
+  /* Set by the shim in IDENTIFY and INSPECT replies. */
+  uint32_t live_raw_imports; /* untracked imports still held; prepare refuses if non-zero */
+  uint32_t passthrough_creations; /* allocations created with non-POSIX handle types, informational */
+  uint8_t phase; /* enum cuinterpose_phase, 0 when unknown */
+  uint8_t reserved_align[3];
+  uint32_t copy_us; /* carrier replies: how long the copies themselves took, in microseconds */
+  uint8_t reserved[48];
+};
+
+struct cuinterpose_access {
+  int32_t location_type;
+  int32_t location_id;
+  uint64_t flags;
+};
+
+struct cuinterpose_record {
+  uint32_t kind;
+  uint32_t flags;
+  uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  uint64_t address;
+  uint64_t size;
+  uint64_t offset;
+  uint64_t allocation_size;
+  int32_t allocation_type;
+  uint32_t requested_handle_types;
+  int32_t allocation_location_type;
+  int32_t allocation_location_id;
+  uint32_t access_count;
+  uint32_t application_handle_count;
+  struct cuinterpose_access access[CUINTERPOSE_MAX_ACCESS];
+  uint8_t member_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  char creator_participant[CUINTERPOSE_ID_SIZE];
+  uint8_t binding_kind;
+  uint8_t api_version;
+  uint8_t reserved[5];
+  uint64_t member_offset;
+  uint64_t operation_flags;
+  uint64_t handle_types;
+  uint64_t object_flags;
+  uint32_t num_devices;
+  int32_t device;
+};
+
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_header) == 256, "cuinterpose header layout changed");
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_access) == 16, "cuinterpose access layout changed");
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_record) == 688, "cuinterpose record layout changed");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_ALLOCATION < CUINTERPOSE_MULTICAST_BINDING, "unicast members must sort before multicast bindings");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_MULTICAST < CUINTERPOSE_MULTICAST_DEVICE, "multicast objects must sort before their devices");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_MULTICAST_DEVICE < CUINTERPOSE_MULTICAST_BINDING,
+    "multicast devices must sort before their bindings");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_MULTICAST < CUINTERPOSE_MULTICAST_MAPPING, "multicast objects must sort before their mappings");
+
+#endif

--- a/agent/cmd/cuinterpose/util.c
+++ b/agent/cmd/cuinterpose/util.c
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "util.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/random.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+int
+cuinterpose_write_all(int fd, const void* value, size_t size)
+{
+  const uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = write(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+cuinterpose_send_all(int fd, const void* value, size_t size)
+{
+  const uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = send(fd, current, size, MSG_NOSIGNAL);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+cuinterpose_read_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = read(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+cuinterpose_pread_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+  off_t offset = 0;
+
+  while (size != 0) {
+    ssize_t count = pread(fd, current, size, offset);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    offset += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+cuinterpose_random_bytes(void* output, size_t size)
+{
+  unsigned char* current = output;
+
+  while (size != 0) {
+    ssize_t count = getrandom(current, size, 0);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+cuinterpose_random_id(char output[CUINTERPOSE_ID_SIZE])
+{
+  uint8_t value[16];
+  size_t index;
+
+  if (cuinterpose_random_bytes(value, sizeof(value)) != 0)
+    return -1;
+  for (index = 0; index < sizeof(value); index++)
+    snprintf(output + index * 2, CUINTERPOSE_ID_SIZE - index * 2, "%02x", value[index]);
+  return 0;
+}
+
+bool
+cuinterpose_is_lower_hex_id(const char value[CUINTERPOSE_ID_SIZE])
+{
+  size_t index;
+
+  if (value == NULL)
+    return false;
+  for (index = 0; index < CUINTERPOSE_ID_SIZE - 1; index++) {
+    if (!((value[index] >= '0' && value[index] <= '9') || (value[index] >= 'a' && value[index] <= 'f')))
+      return false;
+  }
+  return value[CUINTERPOSE_ID_SIZE - 1] == '\0';
+}
+
+bool
+cuinterpose_header_strings_terminated(const struct cuinterpose_header* header)
+{
+  return memchr(header->participant_id, '\0', sizeof(header->participant_id)) != NULL &&
+         memchr(header->message, '\0', sizeof(header->message)) != NULL;
+}
+
+void
+cuinterpose_header_error(struct cuinterpose_header* header, const char* message)
+{
+  header->status = -1;
+  snprintf(header->message, sizeof(header->message), "%s", message);
+}
+
+int
+cuinterpose_set_socket_timeouts(int fd, unsigned seconds)
+{
+  struct timeval timeout = {.tv_sec = (time_t)seconds};
+
+  return setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) == 0 &&
+                 setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == 0
+             ? 0
+             : -1;
+}
+
+/*
+ * Hand-rolled rather than strtol: the shim is compiled with _GNU_SOURCE, which
+ * turns on _ISOC23_SOURCE and makes <stdlib.h> route the strtol family to
+ * __isoc23_strtol@GLIBC_2.38. That would raise the shim's glibc floor above the
+ * 2.34 the Makefile asserts. Trailing garbage is rejected rather than ignored
+ * so "3x" cannot silently arm a 3-second timeout.
+ */
+unsigned
+cuinterpose_bounded_seconds(const char* value, unsigned fallback)
+{
+  unsigned long parsed = 0;
+  const char* digits;
+
+  if (value == NULL)
+    return fallback;
+  while (*value == ' ' || *value == '\t' || *value == '\n' || *value == '\r')
+    value++;
+  for (digits = value; *value >= '0' && *value <= '9'; value++) {
+    parsed = parsed * 10 + (unsigned long)(*value - '0');
+    if (parsed > 86400)
+      return fallback;
+  }
+  if (value == digits || parsed == 0)
+    return fallback;
+  while (*value == ' ' || *value == '\t' || *value == '\n' || *value == '\r')
+    value++;
+  return *value == '\0' ? (unsigned)parsed : fallback;
+}
+
+unsigned
+cuinterpose_control_timeout_seconds(void)
+{
+  static unsigned cached;
+
+  if (cached == 0)
+    cached = cuinterpose_bounded_seconds(
+        getenv(CUINTERPOSE_CONTROL_TIMEOUT_ENV), CUINTERPOSE_CONTROL_TIMEOUT_SECONDS_DEFAULT);
+  return cached;
+}
+
+int
+cuinterpose_send_header(int fd, const struct cuinterpose_header* header, int passed_fd)
+{
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {.iov_base = (void*)header, .iov_len = sizeof(*header)};
+  struct msghdr message = {.msg_iov = &vector, .msg_iovlen = 1};
+  ssize_t count;
+
+  if (passed_fd >= 0) {
+    struct cmsghdr* item;
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(item), &passed_fd, sizeof(passed_fd));
+  }
+  do {
+    count = sendmsg(fd, &message, MSG_NOSIGNAL);
+  } while (count < 0 && errno == EINTR);
+  return count == (ssize_t)sizeof(*header) ? 0 : -1;
+}
+
+/*
+ * The kernel installs any SCM_RIGHTS descriptors into this process before
+ * recvmsg returns, even when the message is truncated or carries more than
+ * expected. Every failure path below therefore closes whatever arrived so a
+ * misbehaving peer cannot make the process leak descriptors.
+ */
+int
+cuinterpose_receive_header(int fd, struct cuinterpose_header* header, int* passed_fd)
+{
+  /* Room for two descriptors so a second one is detected instead of truncated. */
+  char control[CMSG_SPACE(sizeof(int) * 2)] = {0};
+  struct iovec vector = {.iov_base = header, .iov_len = sizeof(*header)};
+  struct msghdr message = {
+      .msg_iov = &vector,
+      .msg_iovlen = 1,
+      .msg_control = control,
+      .msg_controllen = sizeof(control),
+  };
+  struct cmsghdr* item;
+  ssize_t count;
+  int received[2] = {-1, -1};
+  size_t received_count = 0;
+  bool ok;
+
+  *passed_fd = -1;
+  do {
+    count = recvmsg(fd, &message, MSG_WAITALL | MSG_CMSG_CLOEXEC);
+  } while (count < 0 && errno == EINTR);
+  if (count < 0)
+    return -1;
+  for (item = CMSG_FIRSTHDR(&message); item != NULL; item = CMSG_NXTHDR(&message, item)) {
+    if (item->cmsg_level != SOL_SOCKET || item->cmsg_type != SCM_RIGHTS)
+      continue;
+    size_t bytes = item->cmsg_len - CMSG_LEN(0);
+    size_t index;
+    for (index = 0; index < bytes / sizeof(int); index++) {
+      int value;
+      memcpy(&value, CMSG_DATA(item) + index * sizeof(int), sizeof(value));
+      if (received_count < 2)
+        received[received_count] = value;
+      else
+        close(value);
+      received_count++;
+    }
+  }
+  ok = count == (ssize_t)sizeof(*header) && (message.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) == 0 &&
+       received_count <= 1;
+  if (!ok) {
+    if (received[0] >= 0)
+      close(received[0]);
+    if (received[1] >= 0)
+      close(received[1]);
+    return -1;
+  }
+  *passed_fd = received[0];
+  return 0;
+}

--- a/agent/cmd/cuinterpose/util.h
+++ b/agent/cmd/cuinterpose/util.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_UTIL_H
+#define CUINTERPOSE_UTIL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "protocol.h"
+
+/*
+ * Small I/O and identity helpers shared by the shim and the coordinator. All
+ * of these are internal: the shim is built with hidden visibility, and the
+ * coordinator is a static binary.
+ */
+
+/* Loops until every byte is written. For files and memfds; not for sockets. */
+int cuinterpose_write_all(int fd, const void* value, size_t size);
+/* Like cuinterpose_write_all for a socket: uses send(MSG_NOSIGNAL) so a peer
+ * that hung up produces EPIPE instead of killing the process with SIGPIPE. */
+int cuinterpose_send_all(int fd, const void* value, size_t size);
+int cuinterpose_read_all(int fd, void* value, size_t size);
+/* Reads `size` bytes from offset 0 without moving the file position. */
+int cuinterpose_pread_all(int fd, void* value, size_t size);
+int cuinterpose_random_bytes(void* output, size_t size);
+/* Writes 32 lowercase hex characters plus the terminator. */
+int cuinterpose_random_id(char output[CUINTERPOSE_ID_SIZE]);
+bool cuinterpose_is_lower_hex_id(const char value[CUINTERPOSE_ID_SIZE]);
+bool cuinterpose_header_strings_terminated(const struct cuinterpose_header* header);
+void cuinterpose_header_error(struct cuinterpose_header* header, const char* message);
+int cuinterpose_set_socket_timeouts(int fd, unsigned seconds);
+/* Parses a whole-second override; anything malformed yields `fallback`. */
+unsigned cuinterpose_bounded_seconds(const char* value, unsigned fallback);
+/* CUINTERPOSE_CONTROL_TIMEOUT_ENV or the default, read once. */
+unsigned cuinterpose_control_timeout_seconds(void);
+/* Sends one header and, when passed_fd >= 0, that descriptor as SCM_RIGHTS. */
+int cuinterpose_send_header(int fd, const struct cuinterpose_header* header, int passed_fd);
+/* Receives one header. On success *passed_fd is the received descriptor or -1.
+ * On failure no descriptor is left open, whatever the peer sent. */
+int cuinterpose_receive_header(int fd, struct cuinterpose_header* header, int* passed_fd);
+
+#endif

--- a/agent/cmd/ns-bind-mount/main.c
+++ b/agent/cmd/ns-bind-mount/main.c
@@ -2,15 +2,17 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
- * ns-bind-mount installs and removes the two mounts used by restore:
+ * ns-bind-mount installs and removes the fixed mounts used by restore:
  *
  *   mount-bundle-fd <namespace-fd>
+ *   mount-cuinterpose-fd <namespace-fd>
  *   mount-checkpoint-fd <namespace-fd> <checkpoint-path>
  *   unmount-bundle-fd <namespace-fd> [created]
+ *   unmount-cuinterpose-fd <namespace-fd> [created]
  *   unmount-checkpoint-fd <namespace-fd> [created]
  *
  * The caller pins the target mount namespace and passes its descriptor through
- * ExtraFiles. Bundle and checkpoint policy is deliberately fixed here: callers
+ * ExtraFiles. Bundle, cuinterpose, and checkpoint policy is deliberately fixed here: callers
  * cannot select arbitrary host sources, container destinations, or attributes.
  */
 
@@ -58,6 +60,13 @@ struct mount_attr {
 
 #define BUNDLE_SOURCE "/snapshot-binaries"
 #define BUNDLE_DESTINATION "/tmp/snapshot-binaries"
+/*
+ * cuinterpose: the CUDA interposer shim and the cuda-checkpoint that wrapped the
+ * source workload. The destination must equal podcontract.CuinterposeMountPath,
+ * because CRIU re-opens the shim's file-backed mappings by that path.
+ */
+#define CUINTERPOSE_SOURCE "/snapshot-binaries/cuinterpose"
+#define CUINTERPOSE_DESTINATION "/tmp/cuinterpose"
 #define CHECKPOINT_ROOT "/checkpoints"
 #define CHECKPOINT_DESTINATION "/tmp/checkpoint"
 #define PAGEBROKER_RESTORE_ROOT "/pagebroker/staging/restore"
@@ -235,6 +244,23 @@ mount_bundle(int argc, char* argv[])
 }
 
 static int
+mount_cuinterpose(int argc, char* argv[])
+{
+  if (argc != 3) {
+    fprintf(stderr, "usage: ns-bind-mount mount-cuinterpose-fd <namespace-fd>\n");
+    return 1;
+  }
+  int ns_fd = parse_fd(argv[2]);
+  if (ns_fd < 0)
+    return 1;
+  return install_mount(
+      ns_fd,
+      CUINTERPOSE_SOURCE,
+      CUINTERPOSE_DESTINATION,
+      MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV);
+}
+
+static int
 mount_checkpoint(int argc, char* argv[])
 {
   if (argc != 4) {
@@ -298,6 +324,8 @@ main(int argc, char* argv[])
   }
   if (strcmp(argv[1], "mount-bundle-fd") == 0)
     return mount_bundle(argc, argv);
+  if (strcmp(argv[1], "mount-cuinterpose-fd") == 0)
+    return mount_cuinterpose(argc, argv);
   if (strcmp(argv[1], "mount-checkpoint-fd") == 0)
     return mount_checkpoint(argc, argv);
   if (strcmp(argv[1], "mount-pagebroker-fd") == 0)
@@ -308,6 +336,12 @@ main(int argc, char* argv[])
         argv,
         BUNDLE_DESTINATION,
         "usage: ns-bind-mount unmount-bundle-fd <namespace-fd> [created]");
+  if (strcmp(argv[1], "unmount-cuinterpose-fd") == 0)
+    return unmount_role(
+        argc,
+        argv,
+        CUINTERPOSE_DESTINATION,
+        "usage: ns-bind-mount unmount-cuinterpose-fd <namespace-fd> [created]");
   if (strcmp(argv[1], "unmount-checkpoint-fd") == 0)
     return unmount_role(
         argc,

--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -89,6 +89,7 @@ type restoreArtifact struct {
 	SnapshotName        string
 	ContentUID          string
 	SourceContainerName string
+	Cuinterpose         bool
 	Path                string
 }
 
@@ -96,6 +97,7 @@ type restoreTarget struct {
 	SnapshotName        string
 	ContentUID          string
 	SourceContainerName string
+	Cuinterpose         bool
 }
 
 type restorePlan struct {
@@ -610,7 +612,19 @@ func validateRestoreTarget(pod *corev1.Pod, snapshot *snapshotv1alpha1.PodSnapsh
 	}); err != nil {
 		return nil, nil, err
 	}
-	return &restoreTarget{SnapshotName: snapshot.Name, ContentUID: string(content.UID), SourceContainerName: containerName}, mappings, nil
+	// The PodSnapshot records whether the source ran with the cuinterpose
+	// shim preloaded; restore must then mount the shim at its capture path so
+	// CRIU can re-open the file-backed mappings.
+	cuinterposeEnabled, err := podcontract.CuinterposeEnabled(snapshot.Annotations)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &restoreTarget{
+		SnapshotName:        snapshot.Name,
+		ContentUID:          string(content.UID),
+		SourceContainerName: containerName,
+		Cuinterpose:         cuinterposeEnabled,
+	}, mappings, nil
 }
 
 // resolveRestoreArtifact resolves the validated restore target to its physical
@@ -636,6 +650,7 @@ func (w *NodeController) resolveRestoreArtifact(podKey string, target *restoreTa
 		SnapshotName:        target.SnapshotName,
 		ContentUID:          target.ContentUID,
 		SourceContainerName: target.SourceContainerName,
+		Cuinterpose:         target.Cuinterpose,
 		Path:                path,
 	}, nil
 }
@@ -871,6 +886,7 @@ func (op *restoreOperation) executeRestore(ctx context.Context) (int, error) {
 		ArtifactContainerName:       op.artifact.SourceContainerName,
 		DestinationContainerName:    op.destination,
 		Clientset:                   w.clientset,
+		Cuinterpose:                 op.artifact.Cuinterpose,
 		PageBrokerRequested:         op.pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
 		PageBrokerEnabled:           w.config.PageBroker.Enabled,
 		PageBrokerControlSocketPath: w.config.PageBroker.ControlSocketPath,

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -87,6 +87,10 @@ func (noopInjector) MountBundle(_ context.Context, _ int) (nsmount.MountPoint, e
 	return noopMountPoint{}, nil
 }
 
+func (noopInjector) MountCuinterpose(_ context.Context, _ nsmount.MountPoint) (nsmount.MountPoint, error) {
+	return noopMountPoint{}, nil
+}
+
 func (noopInjector) MountArtifact(_ context.Context, _ nsmount.MountPoint, _ string) (nsmount.MountPoint, error) {
 	return noopMountPoint{}, nil
 }
@@ -1457,4 +1461,25 @@ func TestCheckpointLeaseNameUsesContentAndContainer(t *testing.T) {
 	b := checkpointLeaseName("content-uid", "worker")
 	assert.NotEqual(t, a, b)
 	assert.True(t, strings.HasPrefix(a, "snapshot-capture-"))
+}
+
+func TestValidateRestoreTargetRecordsCuinterpose(t *testing.T) {
+	pod := restorePod(map[string]string{podcontract.RestoreFromAnnotation: "snapshot-a"})
+	snapshot, content := readySnapshotObjects()
+
+	target, _, err := validateRestoreTarget(pod, snapshot, content)
+	require.NoError(t, err)
+	assert.False(t, target.Cuinterpose, "a PodSnapshot without the annotation restores without the shim")
+
+	if snapshot.Annotations == nil {
+		snapshot.Annotations = map[string]string{}
+	}
+	snapshot.Annotations[podcontract.CuinterposeAnnotation] = podcontract.CuinterposeAnnotationEnabled
+	target, _, err = validateRestoreTarget(pod, snapshot, content)
+	require.NoError(t, err)
+	assert.True(t, target.Cuinterpose, "the PodSnapshot annotation drives the restore-time shim mount")
+
+	snapshot.Annotations[podcontract.CuinterposeAnnotation] = "yes"
+	_, _, err = validateRestoreTarget(pod, snapshot, content)
+	require.Error(t, err, "an unrecognized annotation value must not be read as disabled")
 }

--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -584,17 +585,22 @@ func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *
 func (w *NodeController) executorCheckpoint(ctx context.Context, params CheckpointParams) error {
 	log := logr.FromContextOrDiscard(ctx)
 
+	cuinterposeRequested, err := podcontract.CuinterposeEnabled(params.Pod.Annotations)
+	if err != nil {
+		return fmt.Errorf("source pod %s/%s: %w", params.Pod.Namespace, params.Pod.Name, err)
+	}
 	req := executor.CheckpointRequest{
-		ContainerID:         params.ContainerID,
-		ContainerName:       params.ContainerName,
-		ContentUID:          params.ContentUID,
-		StartedAt:           params.StartedAt,
-		NodeName:            w.config.NodeName,
-		PodName:             params.Pod.Name,
-		PodNamespace:        params.Pod.Namespace,
-		PodIP:               params.Pod.Status.PodIP,
-		Clientset:           w.clientset,
-		PageBrokerRequested: params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
+		CuinterposeRequested: cuinterposeRequested,
+		ContainerID:          params.ContainerID,
+		ContainerName:        params.ContainerName,
+		ContentUID:           params.ContentUID,
+		StartedAt:            params.StartedAt,
+		NodeName:             w.config.NodeName,
+		PodName:              params.Pod.Name,
+		PodNamespace:         params.Pod.Namespace,
+		PodIP:                params.Pod.Status.PodIP,
+		Clientset:            w.clientset,
+		PageBrokerRequested:  params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
 	}
 	if err := executor.Checkpoint(ctx, w.runtime, log, req, w.config); err != nil {
 		if executor.CheckpointNeedsSourceKill(err) {

--- a/agent/internal/cuda/cuinterpose.go
+++ b/agent/internal/cuda/cuinterpose.go
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+)
+
+// cuinterpose is the CUDA interposer shim (agent/cmd/cuinterpose). Each CUDA
+// process running it listens on a Unix socket under the pod's snapshot control
+// directory. The agent never talks to those sockets itself; it runs the
+// cuinterpose-coordinator binary, which does, once before the native CUDA
+// checkpoint (prepare) and once after the native CUDA restore (restore).
+//
+// The string constants below mirror agent/cmd/cuinterpose/protocol.h; a test
+// checks they agree.
+const (
+	// CoordinatorBinaryName is the cuinterpose-coordinator executable name.
+	CoordinatorBinaryName = "cuinterpose-coordinator"
+	// DefaultCoordinatorBinaryPath is where the agent image installs the
+	// coordinator, used for prepare. Restore runs inside the restored
+	// container's mount namespace, which does not contain the agent bundle, so
+	// that call site passes a /proc/self/fd path opened before CRIU ran.
+	DefaultCoordinatorBinaryPath = "/usr/local/bin/" + CoordinatorBinaryName
+	// CuinterposeStateFile is the topology sidecar the coordinator writes into
+	// the checkpoint directory during prepare and reads during restore.
+	CuinterposeStateFile = "cuinterpose.state"
+
+	cuinterposeSocketPrefix = "cuinterpose-"
+	cuinterposeSocketSuffix = ".sock"
+	coordinatorReportPrefix = "cuinterpose-coordinator "
+)
+
+// cuinterposeEndpointPath is the shim's control socket for one CUDA process,
+// reached through the host's /proc mount: <procRoot>/<pid>/root is the
+// process's own root filesystem.
+func cuinterposeEndpointPath(procRoot string, observedPID, namespacePID int) string {
+	return filepath.Join(
+		procRoot,
+		strconv.Itoa(observedPID),
+		"root",
+		strings.TrimPrefix(podcontract.SnapshotControlMountPath, string(os.PathSeparator)),
+		cuinterposeSocketName(namespacePID),
+	)
+}
+
+func cuinterposeSocketName(namespacePID int) string {
+	return fmt.Sprintf("%s%d%s", cuinterposeSocketPrefix, namespacePID, cuinterposeSocketSuffix)
+}
+
+// DetectCuinterpose reports whether the live CUDA processes run the shim. The
+// signal is the shim's control socket, one per CUDA process, not the process
+// environment: Python's setproctitle (vLLM, SGLang) overwrites what /proc
+// shows as the environment while the sockets remain. No sockets at all means
+// the workload is not interposed and is checkpointed natively. Some but not
+// all sockets, or a non-socket file in a socket's place, is an error: a
+// half-interposed process tree cannot be checkpointed consistently.
+func DetectCuinterpose(procRoot string, observedPIDs, namespacePIDs []int) (bool, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return false, fmt.Errorf(
+			"cuinterpose PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return false, nil
+	}
+	valid := 0
+	seen := 0
+	for index, observedPID := range observedPIDs {
+		endpoint := cuinterposeEndpointPath(procRoot, observedPID, namespacePIDs[index])
+		info, err := os.Lstat(endpoint)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("stat cuinterpose endpoint %q: %w", endpoint, err)
+		}
+		seen++
+		if info.Mode()&os.ModeSocket != 0 {
+			valid++
+		}
+	}
+	if seen == 0 {
+		return false, nil
+	}
+	if valid != len(observedPIDs) {
+		return false, fmt.Errorf(
+			"cuinterpose endpoint missing or invalid for %d of %d CUDA processes",
+			len(observedPIDs)-valid,
+			len(observedPIDs),
+		)
+	}
+	return true, nil
+}
+
+// CheckCuinterposeEnablement is the rule for what the Pod asked for versus what
+// the CUDA processes are running. Both disagreements are refused:
+//
+//   - requested but no process exposes a socket: the shim never loaded (wrong
+//     path, glibc too old, LD_PRELOAD stripped). A native checkpoint would look
+//     fine and restore with stale sharing, so it must not be taken.
+//   - not requested but sockets are present: something other than Snapshot
+//     preloaded the shim; the restore side would not mount it.
+//
+// With no CUDA processes there is nothing to interpose and nothing to check.
+func CheckCuinterposeEnablement(requested, detected bool, cudaProcesses int) error {
+	if cudaProcesses == 0 {
+		return nil
+	}
+	if requested && !detected {
+		return fmt.Errorf(
+			"cuinterpose was requested (%s) but no CUDA process exposes a control socket; the shim did not load, refusing to checkpoint without it",
+			podcontract.CuinterposeAnnotation)
+	}
+	if !requested && detected {
+		return fmt.Errorf(
+			"CUDA processes run the cuinterpose shim but the source Pod did not request it (%s); restore would not mount the shim",
+			podcontract.CuinterposeAnnotation)
+	}
+	return nil
+}
+
+// HasCuinterposeState reports whether the checkpoint directory holds the
+// coordinator's state file.
+func HasCuinterposeState(checkpointDir string) (bool, error) {
+	_, err := os.Stat(filepath.Join(checkpointDir, CuinterposeStateFile))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// RemoveStaleCuinterposeSockets deletes leftover shim sockets from an earlier
+// incarnation of the pod. Each shim binds its socket by namespace PID, and
+// CRIU recreates the checkpointed process with the same namespace PID, so a
+// stale file at that path makes the restored bind() fail. Called inside the
+// container's mount namespace before CRIU runs. Returns how many were removed.
+func RemoveStaleCuinterposeSockets(controlDir string) (int, error) {
+	entries, err := os.ReadDir(controlDir)
+	if err != nil {
+		return 0, fmt.Errorf("list cuinterpose control directory %s: %w", controlDir, err)
+	}
+	removed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, cuinterposeSocketPrefix) || !strings.HasSuffix(name, cuinterposeSocketSuffix) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(controlDir, name)); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("remove stale cuinterpose socket %s: %w", name, err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// CoordinatorPhase is one progress line the coordinator printed:
+// "cuinterpose-coordinator phase=<name> status=ok key=value ...".
+type CoordinatorPhase struct {
+	Phase  string
+	Fields map[string]string
+}
+
+// PrepareCuinterpose runs the coordinator against the live CUDA processes,
+// through the host's /proc mount, before the native CUDA checkpoint. On
+// success the coordinator has written CuinterposeStateFile into checkpointDir.
+// There is no undo: once prepare has torn down shared mappings the source
+// workload can only continue by being restored, so a later checkpoint failure
+// is fail-stop for the source (the caller terminates it).
+func PrepareCuinterpose(
+	ctx context.Context,
+	checkpointDir string,
+	procRoot string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) ([]CoordinatorPhase, error) {
+	args, err := cuinterposeArgs("prepare", checkpointDir, procRoot, podcontract.SnapshotControlMountPath, observedPIDs, namespacePIDs)
+	if err != nil {
+		return nil, err
+	}
+	return runCoordinator(ctx, coordinatorBinaryPath, args, log)
+}
+
+// RestoreCuinterpose runs the coordinator inside the restored container's
+// mount namespace after the native CUDA restore, so procRoot is empty and the
+// control sockets are addressed directly under the control directory.
+func RestoreCuinterpose(
+	ctx context.Context,
+	checkpointDir string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) ([]CoordinatorPhase, error) {
+	args, err := cuinterposeArgs("restore", checkpointDir, "", podcontract.SnapshotControlMountPath, observedPIDs, namespacePIDs)
+	if err != nil {
+		return nil, err
+	}
+	return runCoordinator(ctx, coordinatorBinaryPath, args, log)
+}
+
+func runCoordinator(ctx context.Context, binary string, args []string, log logr.Logger) ([]CoordinatorPhase, error) {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	phases := parseCoordinatorReports(stdout.String())
+	for _, phase := range phases {
+		values := make([]any, 0, 2+2*len(phase.Fields))
+		values = append(values, "operation", args[0], "phase", phase.Phase)
+		for key, value := range phase.Fields {
+			values = append(values, key, value)
+		}
+		log.Info("cuinterpose coordinator phase", values...)
+	}
+	if runErr != nil {
+		completed := make([]string, 0, len(phases))
+		for _, phase := range phases {
+			completed = append(completed, phase.Phase)
+		}
+		return phases, fmt.Errorf(
+			"%s %s failed: %w (completed phases: %s; stderr: %s)",
+			binary, args[0], runErr,
+			strings.Join(completed, ","),
+			strings.TrimSpace(stderr.String()),
+		)
+	}
+	return phases, nil
+}
+
+// parseCoordinatorReports extracts progress lines from the coordinator's
+// stdout; anything else on stdout is ignored.
+func parseCoordinatorReports(output string) []CoordinatorPhase {
+	var phases []CoordinatorPhase
+	for _, line := range strings.Split(output, "\n") {
+		if phase, ok := parseCoordinatorReport(line); ok {
+			phases = append(phases, phase)
+		}
+	}
+	return phases
+}
+
+func parseCoordinatorReport(line string) (CoordinatorPhase, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, coordinatorReportPrefix) {
+		return CoordinatorPhase{}, false
+	}
+	phase := CoordinatorPhase{Fields: map[string]string{}}
+	for _, field := range strings.Fields(strings.TrimPrefix(line, coordinatorReportPrefix)) {
+		key, value, found := strings.Cut(field, "=")
+		if !found {
+			continue
+		}
+		if key == "phase" {
+			phase.Phase = value
+			continue
+		}
+		phase.Fields[key] = value
+	}
+	if phase.Phase == "" {
+		return CoordinatorPhase{}, false
+	}
+	return phase, true
+}
+
+func cuinterposeArgs(operation, checkpointDir, procRoot, controlDir string, observedPIDs, namespacePIDs []int) ([]string, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return nil, fmt.Errorf(
+			"cuinterpose PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return nil, errors.New("cuinterpose coordinator requires at least one CUDA process")
+	}
+	args := []string{
+		"--" + operation,
+		"--proc-root", procRoot,
+		"--checkpoint-dir", checkpointDir,
+		"--control-dir", controlDir,
+	}
+	for index, observedPID := range observedPIDs {
+		args = append(args, "--process", strconv.Itoa(observedPID), strconv.Itoa(namespacePIDs[index]))
+	}
+	return args, nil
+}

--- a/agent/internal/cuda/cuinterpose_test.go
+++ b/agent/internal/cuda/cuinterpose_test.go
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+)
+
+func TestDetectCuinterposeSkipsEmptyPIDList(t *testing.T) {
+	interposed, err := DetectCuinterpose(t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("DetectCuinterpose() error = %v", err)
+	}
+	if interposed {
+		t.Fatal("DetectCuinterpose() = true, want skip")
+	}
+}
+
+func TestDetectCuinterposePIDCountMismatch(t *testing.T) {
+	if _, err := DetectCuinterpose(t.TempDir(), []int{101}, nil); err == nil {
+		t.Fatal("expected PID mapping count mismatch")
+	}
+}
+
+func TestDetectCuinterposeSkipsWithoutSockets(t *testing.T) {
+	procRoot := shortTempDir(t)
+	mustControlDir(t, procRoot, 101, 1)
+	interposed, err := DetectCuinterpose(procRoot, []int{101, 102}, []int{1, 2})
+	if err != nil {
+		t.Fatalf("DetectCuinterpose() error = %v", err)
+	}
+	if interposed {
+		t.Fatal("DetectCuinterpose() = true, want skip")
+	}
+}
+
+func TestDetectCuinterposeIgnoresProcfsEnviron(t *testing.T) {
+	procRoot := shortTempDir(t)
+	mustControlDir(t, procRoot, 101, 1)
+	mustEnviron(t, procRoot, 101, "LD_PRELOAD="+podcontract.CuinterposeLibraryPath+"\x00")
+	interposed, err := DetectCuinterpose(procRoot, []int{101}, []int{1})
+	if err != nil {
+		t.Fatalf("DetectCuinterpose() error = %v", err)
+	}
+	if interposed {
+		t.Fatal("DetectCuinterpose() keyed off procfs environ; only sockets count")
+	}
+}
+
+func TestDetectCuinterposeRequiresEveryCUDAProcessSocket(t *testing.T) {
+	procRoot := shortTempDir(t)
+	listenUnix(t, cuinterposeEndpointPath(procRoot, 101, 1))
+
+	if _, err := DetectCuinterpose(procRoot, []int{101, 102}, []int{1, 2}); err == nil {
+		t.Fatal("expected a missing endpoint to fail closed")
+	}
+
+	listenUnix(t, cuinterposeEndpointPath(procRoot, 102, 2))
+	interposed, err := DetectCuinterpose(procRoot, []int{101, 102}, []int{1, 2})
+	if err != nil {
+		t.Fatalf("DetectCuinterpose() error = %v", err)
+	}
+	if !interposed {
+		t.Fatal("DetectCuinterpose() = false, want true")
+	}
+}
+
+func TestDetectCuinterposeRejectsNonSocketEndpoint(t *testing.T) {
+	procRoot := shortTempDir(t)
+	listenUnix(t, cuinterposeEndpointPath(procRoot, 101, 1))
+	path := cuinterposeEndpointPath(procRoot, 102, 2)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not a socket"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DetectCuinterpose(procRoot, []int{101, 102}, []int{1, 2}); err == nil {
+		t.Fatal("expected a non-socket endpoint to fail closed")
+	}
+}
+
+func TestHasCuinterposeState(t *testing.T) {
+	checkpointDir := t.TempDir()
+	present, err := HasCuinterposeState(checkpointDir)
+	if err != nil || present {
+		t.Fatalf("HasCuinterposeState() = %v, %v for a missing file", present, err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, CuinterposeStateFile), []byte("state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	present, err = HasCuinterposeState(checkpointDir)
+	if err != nil || !present {
+		t.Fatalf("HasCuinterposeState() = %v, %v, want true", present, err)
+	}
+}
+
+func TestRemoveStaleCuinterposeSockets(t *testing.T) {
+	control := shortTempDir(t)
+	listenUnix(t, filepath.Join(control, cuinterposeSocketName(7)))
+	listenUnix(t, filepath.Join(control, cuinterposeSocketName(8)))
+	for _, keep := range []string{"restore-complete", "cuda-checkpoint-job", "other-1.sock"} {
+		if err := os.WriteFile(filepath.Join(control, keep), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, err := RemoveStaleCuinterposeSockets(control)
+	if err != nil {
+		t.Fatalf("RemoveStaleCuinterposeSockets() error = %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed %d, want 2", removed)
+	}
+	entries, _ := os.ReadDir(control)
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if strings.Join(names, ",") != "cuda-checkpoint-job,other-1.sock,restore-complete" {
+		t.Fatalf("unexpected leftovers: %v", names)
+	}
+	if _, err := RemoveStaleCuinterposeSockets(filepath.Join(control, "missing")); err == nil {
+		t.Fatal("a missing control directory must be an error, not a silent no-op")
+	}
+}
+
+func TestParseCoordinatorReport(t *testing.T) {
+	phase, ok := parseCoordinatorReport("cuinterpose-coordinator phase=save_host_carrier status=ok elapsed_ms=12.5 participants=8 carrier_count=3 carrier_bytes=1610612736 gb_per_s=41.20")
+	if !ok || phase.Phase != "save_host_carrier" {
+		t.Fatalf("parse = %+v, %v", phase, ok)
+	}
+	if phase.Fields["carrier_bytes"] != "1610612736" || phase.Fields["gb_per_s"] != "41.20" || phase.Fields["status"] != "ok" {
+		t.Fatalf("fields = %v", phase.Fields)
+	}
+	for _, junk := range []string{"", "prepare failed: participant inspect", "cuinterpose-coordinator status=ok", "phase=inspect"} {
+		if _, ok := parseCoordinatorReport(junk); ok {
+			t.Fatalf("parsed %q as a report", junk)
+		}
+	}
+}
+
+// A shell script standing in for the coordinator: records its argv, prints
+// two progress lines, and exits as told.
+func fakeCoordinator(t *testing.T, exitCode int) (binary, argvFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	argvFile = filepath.Join(dir, "argv")
+	binary = filepath.Join(dir, "coordinator.sh")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > " + argvFile + "\n" +
+		"echo 'cuinterpose-coordinator phase=inspect status=ok elapsed_ms=1.0 participants=2 records=4'\n" +
+		"echo 'not a report line'\n" +
+		"echo 'cuinterpose-coordinator phase=validate status=ok elapsed_ms=0.2 participants=2'\n" +
+		"echo 'prepare failed: participant prepare' >&2\n" +
+		"exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(binary, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return binary, argvFile
+}
+
+func TestPrepareCuinterposeArgvContractAndReports(t *testing.T) {
+	binary, argvFile := fakeCoordinator(t, 0)
+	phases, err := PrepareCuinterpose(context.Background(), "/checkpoints/x", "/host/proc", []int{4242, 4243}, []int{7, 9}, binary, testr.New(t))
+	if err != nil {
+		t.Fatalf("PrepareCuinterpose() error = %v", err)
+	}
+	argv, _ := os.ReadFile(argvFile)
+	want := strings.Join([]string{
+		"--prepare", "--proc-root", "/host/proc", "--checkpoint-dir", "/checkpoints/x",
+		"--control-dir", podcontract.SnapshotControlMountPath,
+		"--process", "4242", "7", "--process", "4243", "9", "",
+	}, "\n")
+	if string(argv) != want {
+		t.Fatalf("argv:\n%s\nwant:\n%s", argv, want)
+	}
+	if len(phases) != 2 || phases[0].Phase != "inspect" || phases[1].Phase != "validate" || phases[0].Fields["records"] != "4" {
+		t.Fatalf("phases = %+v", phases)
+	}
+}
+
+func TestRestoreCuinterposeArgvUsesEmptyProcRoot(t *testing.T) {
+	binary, argvFile := fakeCoordinator(t, 0)
+	if _, err := RestoreCuinterpose(context.Background(), "/tmp/checkpoint", []int{100}, []int{1}, binary, logr.Discard()); err != nil {
+		t.Fatalf("RestoreCuinterpose() error = %v", err)
+	}
+	argv, _ := os.ReadFile(argvFile)
+	if !strings.HasPrefix(string(argv), "--restore\n--proc-root\n\n--checkpoint-dir\n/tmp/checkpoint\n--control-dir\n"+podcontract.SnapshotControlMountPath+"\n") {
+		t.Fatalf("argv:\n%s", argv)
+	}
+}
+
+func TestCoordinatorFailureReportsStderrAndCompletedPhases(t *testing.T) {
+	binary, _ := fakeCoordinator(t, 3)
+	phases, err := PrepareCuinterpose(context.Background(), "/c", "/p", []int{1}, []int{1}, binary, logr.Discard())
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if len(phases) != 2 {
+		t.Fatalf("phases before failure = %d, want 2", len(phases))
+	}
+	for _, want := range []string{"exit status 3", "completed phases: inspect,validate", "prepare failed: participant prepare"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q lacks %q", err, want)
+		}
+	}
+}
+
+func TestCuinterposeArgsRejectsEmptyOrMismatchedPIDs(t *testing.T) {
+	if _, err := cuinterposeArgs("prepare", "/c", "/p", "/snapshot-control", nil, nil); err == nil {
+		t.Fatal("no processes must be an error")
+	}
+	if _, err := cuinterposeArgs("prepare", "/c", "/p", "/snapshot-control", []int{1, 2}, []int{1}); err == nil {
+		t.Fatal("mismatched PID lists must be an error")
+	}
+}
+
+// The Go constants and the coordinator's command line mirror the C sources.
+// This test reads them so a rename on one side cannot silently turn
+// interposition off.
+func TestGoConstantsMatchTheCSources(t *testing.T) {
+	protocol, err := os.ReadFile(filepath.Join("..", "..", "cmd", "cuinterpose", "protocol.h"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator, err := os.ReadFile(filepath.Join("..", "..", "cmd", "cuinterpose", "coordinator.c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	define := func(name string) string {
+		match := regexp.MustCompile(`(?m)^#define ` + name + ` "([^"]*)"`).FindSubmatch(protocol)
+		if match == nil {
+			t.Fatalf("protocol.h lacks #define %s", name)
+		}
+		return string(match[1])
+	}
+	if got := define("CUINTERPOSE_SOCKET_PREFIX"); got != cuinterposeSocketPrefix {
+		t.Errorf("socket prefix: C %q, Go %q", got, cuinterposeSocketPrefix)
+	}
+	if got := define("CUINTERPOSE_STATE_FILENAME"); got != CuinterposeStateFile {
+		t.Errorf("state file: C %q, Go %q", got, CuinterposeStateFile)
+	}
+	if got := define("CUINTERPOSE_CONTROL_DIR"); got != podcontract.SnapshotControlMountPath {
+		t.Errorf("control dir: C %q, podcontract %q", got, podcontract.SnapshotControlMountPath)
+	}
+	if got := define("CUINTERPOSE_CONTROL_DIR_ENV"); got != podcontract.SnapshotControlDirEnv {
+		t.Errorf("control dir env: C %q, podcontract %q", got, podcontract.SnapshotControlDirEnv)
+	}
+	for _, flag := range []string{"--prepare", "--restore", "--proc-root", "--checkpoint-dir", "--control-dir", "--process"} {
+		if !strings.Contains(string(coordinator), `"`+flag+`"`) {
+			t.Errorf("coordinator.c does not parse %s", flag)
+		}
+	}
+	if !strings.Contains(string(coordinator), `"cuinterpose-coordinator phase=%s status=ok`) {
+		t.Error("coordinator.c progress line format changed; update parseCoordinatorReport")
+	}
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	// Unix socket paths are limited to 108 bytes; t.TempDir() paths are long.
+	dir, err := os.MkdirTemp("", "cui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func mustControlDir(t *testing.T, procRoot string, observedPID, namespacePID int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(cuinterposeEndpointPath(procRoot, observedPID, namespacePID)), 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustEnviron(t *testing.T, procRoot string, observedPID int, content string) {
+	t.Helper()
+	path := filepath.Join(procRoot, strconv.Itoa(observedPID), "environ")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listenUnix(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+}
+
+func TestCheckCuinterposeEnablement(t *testing.T) {
+	cases := []struct {
+		requested, detected bool
+		cuda                int
+		wantErr             bool
+	}{
+		{false, false, 0, false},
+		{true, false, 0, false}, // no CUDA processes: nothing to interpose
+		{false, false, 4, false},
+		{true, true, 4, false},
+		{true, false, 4, true}, // asked for, shim never loaded
+		{false, true, 4, true}, // shim present without the opt-in
+	}
+	for _, tc := range cases {
+		err := CheckCuinterposeEnablement(tc.requested, tc.detected, tc.cuda)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("CheckCuinterposeEnablement(%v, %v, %d) = %v, wantErr %v", tc.requested, tc.detected, tc.cuda, err, tc.wantErr)
+		}
+	}
+}

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -55,12 +55,16 @@ type CheckpointRequest struct {
 	PodIP               string
 	Clientset           kubernetes.Interface
 	PageBrokerRequested bool
+	// CuinterposeRequested is the source Pod's nvidia.com/cuinterpose opt-in,
+	// recorded in the manifest so restore mounts the shim.
+	CuinterposeRequested bool
 }
 
 type checkpointPhaseTimings struct {
-	CUDACheckpointDuration time.Duration
-	CRIUDumpDuration       time.Duration
-	OverlayCaptureDuration time.Duration
+	CuinterposePrepareDuration time.Duration
+	CUDACheckpointDuration     time.Duration
+	CRIUDumpDuration           time.Duration
+	OverlayCaptureDuration     time.Duration
 }
 
 // Checkpoint performs a CRIU dump of a container.
@@ -158,6 +162,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	wall := time.Since(checkpointStart)
 	unaccounted := remainingDuration(wall,
 		gpuDeviceMapDuration,
+		captureTimings.CuinterposePrepareDuration,
 		captureTimings.CUDACheckpointDuration,
 		captureTimings.CRIUDumpDuration,
 		captureTimings.OverlayCaptureDuration,
@@ -167,6 +172,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 		"duration": wall.String(),
 		"phases": map[string]string{
 			"gpu_device_map":                gpuDeviceMapDuration.String(),
+			"cuinterpose_prepare":           captureTimings.CuinterposePrepareDuration.String(),
 			"cuda_checkpoint":               captureTimings.CUDACheckpointDuration.String(),
 			"criu_dump":                     captureTimings.CRIUDumpDuration.String(),
 			"overlay_capture":               captureTimings.OverlayCaptureDuration.String(),
@@ -243,6 +249,13 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	if len(cudaHostPIDs) > 0 {
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
+	cuinterpose, err := cuda.DetectCuinterpose(snapshotruntime.HostProcPath, cudaHostPIDs, cudaNamespacePIDs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("detect cuinterpose: %w", err)
+	}
+	if err := cuda.CheckCuinterposeEnablement(req.CuinterposeRequested, cuinterpose, len(cudaHostPIDs)); err != nil {
+		return nil, 0, err
+	}
 	var gpuUUIDs []string
 	var gpuDeviceMapDuration time.Duration
 	if len(cudaHostPIDs) > 0 {
@@ -275,6 +288,7 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		CUDAHostPIDs:   cudaHostPIDs,
 		CUDANSPIDs:     cudaNamespacePIDs,
 		GPUUUIDs:       gpuUUIDs,
+		Cuinterpose:    cuinterpose,
 	}, gpuDeviceMapDuration, nil
 }
 
@@ -300,6 +314,7 @@ func configureCheckpoint(
 	if len(state.CUDANSPIDs) > 0 {
 		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs)
 	}
+	m.Cuinterpose.Requested = req.CuinterposeRequested
 
 	if err := types.WriteManifest(checkpointDir, m); err != nil {
 		return nil, nil, fmt.Errorf("failed to write checkpoint manifest: %w", err)
@@ -313,6 +328,30 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 
 	// CUDA lock+checkpoint must happen before CRIU dump
 	if len(state.CUDAHostPIDs) > 0 {
+		if state.Cuinterpose {
+			// Prepare runs on the live workload before the native CUDA lock: it
+			// tears down shared mappings so the native checkpoint sees plain
+			// memory. There is no rollback; if anything after this fails the
+			// caller terminates the source (checkpointNeedsSourceKill).
+			prepareStart := time.Now()
+			_, err := cuda.PrepareCuinterpose(
+				ctx,
+				checkpointDir,
+				snapshotruntime.HostProcPath,
+				state.CUDAHostPIDs,
+				state.CUDANSPIDs,
+				cuda.DefaultCoordinatorBinaryPath,
+				log,
+			)
+			timings.CuinterposePrepareDuration = time.Since(prepareStart)
+			if err != nil {
+				return nil, fmt.Errorf("prepare cuinterpose: %w", err)
+			}
+			data.Cuinterpose.Prepared = true
+			if err := types.WriteManifest(checkpointDir, data); err != nil {
+				return nil, fmt.Errorf("record cuinterpose prepare in checkpoint manifest: %w", err)
+			}
+		}
 		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -38,6 +38,9 @@ type RestoreInNamespaceResult struct {
 	CRIUPrepareDuration    time.Duration `json:"criuPrepareDuration"`
 	CRIURestoreDuration    time.Duration `json:"criuRestoreDuration"`
 	CUDARestoreDuration    time.Duration `json:"cudaRestoreDuration"`
+	// CuinterposeRestoreDuration is the coordinator's restore step, which runs
+	// after the native CUDA restore and rebuilds shared memory topology.
+	CuinterposeRestoreDuration time.Duration `json:"cuinterposeRestoreDuration"`
 }
 
 // CleanupError is the wire representation of a successful restore whose
@@ -94,11 +97,12 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	}
 
 	result := &RestoreInNamespaceResult{
-		RestoredPID:            restoredPID,
-		OverlayCaptureDuration: executeTimings.overlayCaptureDuration,
-		CRIUPrepareDuration:    executeTimings.criuPrepareDuration,
-		CRIURestoreDuration:    executeTimings.criuRestoreDuration,
-		CUDARestoreDuration:    executeTimings.cudaRestoreDuration,
+		RestoredPID:                restoredPID,
+		OverlayCaptureDuration:     executeTimings.overlayCaptureDuration,
+		CRIUPrepareDuration:        executeTimings.criuPrepareDuration,
+		CRIURestoreDuration:        executeTimings.criuRestoreDuration,
+		CUDARestoreDuration:        executeTimings.cudaRestoreDuration,
+		CuinterposeRestoreDuration: executeTimings.cuinterposeRestoreDuration,
 	}
 	if cleanupErr != nil {
 		result.CleanupError = &CleanupError{
@@ -110,10 +114,11 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 }
 
 type nsrestorePhaseTimings struct {
-	overlayCaptureDuration time.Duration
-	criuPrepareDuration    time.Duration
-	criuRestoreDuration    time.Duration
-	cudaRestoreDuration    time.Duration
+	overlayCaptureDuration     time.Duration
+	criuPrepareDuration        time.Duration
+	criuRestoreDuration        time.Duration
+	cudaRestoreDuration        time.Duration
+	cuinterposeRestoreDuration time.Duration
 }
 
 func executeRestore(
@@ -168,6 +173,7 @@ func executeRestore(
 	// opening the binary now and exec'ing via /proc/self/fd/N after CRIU returns,
 	// the fd remains valid even if the mount is gone.
 	var cudaHelperFdPath string
+	var coordinatorFdPath string
 	if !m.CUDA.IsEmpty() {
 		helperPath := filepath.Join(opts.BundleDir, cuda.HelperBinaryName)
 		f, err := os.Open(helperPath)
@@ -177,6 +183,17 @@ func executeRestore(
 		defer f.Close()
 		cudaHelperFdPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
 	}
+	if m.Cuinterpose.Prepared {
+		if err := requireCuinterposeState(m, opts.CheckpointPath); err != nil {
+			return nil, 0, nil, err
+		}
+		coordinator, err := os.Open(filepath.Join(opts.BundleDir, cuda.CoordinatorBinaryName))
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("failed to open %s before CRIU restore: %w", cuda.CoordinatorBinaryName, err)
+		}
+		defer coordinator.Close()
+		coordinatorFdPath = fmt.Sprintf("/proc/self/fd/%d", coordinator.Fd())
+	}
 
 	// The restore-complete sentinel lives on the pod emptyDir mounted at
 	// SnapshotControlMountPath. Clear it here, in that mount namespace, so a
@@ -185,6 +202,18 @@ func executeRestore(
 	// a missing mount is a hard error.
 	if err := snapshotruntime.RemoveControlSentinel(podcontract.SnapshotControlMountPath, podcontract.RestoreCompleteFile); err != nil {
 		return nil, 0, nil, fmt.Errorf("remove stale restore-complete sentinel: %w", err)
+	}
+	if m.Cuinterpose.Requested {
+		// The shim binds its control socket by namespace PID, which CRIU
+		// reproduces exactly; a socket file left by an earlier incarnation of
+		// this pod (agent restart, replaced container) would make that bind fail.
+		removed, err := cuda.RemoveStaleCuinterposeSockets(podcontract.SnapshotControlMountPath)
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("remove stale cuinterpose sockets: %w", err)
+		}
+		if removed > 0 {
+			log.Info("Removed stale cuinterpose control sockets before restore", "count", removed)
+		}
 	}
 
 	criuPID, cleanup, prepare, restore, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, opts.BundleDir, log)
@@ -253,7 +282,42 @@ func executeRestore(
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("CUDA restore failed: %w", err)
 		}
+		if m.Cuinterpose.Prepared {
+			// The driver is unlocked so the shims can issue CUDA calls, but the
+			// application itself is still parked in its restore-complete poll
+			// loop, so nothing else touches the shared memory while the
+			// coordinator rebuilds it.
+			cuinterposeStart := time.Now()
+			_, err := cuda.RestoreCuinterpose(ctx, opts.CheckpointPath, restorePIDs, m.CUDA.PIDs, coordinatorFdPath, log)
+			timings.cuinterposeRestoreDuration = time.Since(cuinterposeStart)
+			if err != nil {
+				return nil, 0, nil, fmt.Errorf("restore cuinterpose: %w", err)
+			}
+		}
 	}
 
 	return timings, restoredPID, nil, nil
+}
+
+// requireCuinterposeState checks that a checkpoint whose manifest records a
+// cuinterpose prepare also carries the coordinator's state file. Without it
+// the shims inside the restored processes would stay frozen mid-checkpoint
+// forever, so restoring such an artifact is refused up front.
+func requireCuinterposeState(m *types.CheckpointManifest, checkpointPath string) error {
+	if !m.Cuinterpose.Prepared {
+		return nil
+	}
+	if m.CUDA.IsEmpty() {
+		return fmt.Errorf("checkpoint manifest records a cuinterpose prepare but no CUDA processes")
+	}
+	hasState, err := cuda.HasCuinterposeState(checkpointPath)
+	if err != nil {
+		return fmt.Errorf("stat cuinterpose state: %w", err)
+	}
+	if !hasState {
+		return fmt.Errorf(
+			"checkpoint manifest records a cuinterpose prepare but %s is missing from %s; the artifact is incomplete",
+			cuda.CuinterposeStateFile, checkpointPath)
+	}
+	return nil
 }

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -32,6 +32,7 @@ import (
 // artifact inside a placeholder container's mount namespace.
 type RestoreMounter interface {
 	MountBundle(ctx context.Context, pid int) (nsmount.MountPoint, error)
+	MountCuinterpose(ctx context.Context, namespaceMount nsmount.MountPoint) (nsmount.MountPoint, error)
 	MountArtifact(ctx context.Context, namespaceMount nsmount.MountPoint, artifactPath string) (nsmount.MountPoint, error)
 	MountPageBroker(ctx context.Context, namespaceMount nsmount.MountPoint, stagingPath string) (nsmount.MountPoint, error)
 }
@@ -67,16 +68,19 @@ func cleanupRestoreMounts(ctx context.Context, mounts []restoreMount) error {
 
 // RestoreRequest holds the parameters for a restore operation.
 type RestoreRequest struct {
-	ContentUID                  string
-	BasePath                    string
-	ContainerID                 string
-	StartedAt                   time.Time
-	PodName                     string
-	PodNamespace                string
-	TargetPodIP                 string
-	ArtifactContainerName       string
-	DestinationContainerName    string
-	Clientset                   kubernetes.Interface
+	ContentUID               string
+	BasePath                 string
+	ContainerID              string
+	StartedAt                time.Time
+	PodName                  string
+	PodNamespace             string
+	TargetPodIP              string
+	ArtifactContainerName    string
+	DestinationContainerName string
+	Clientset                kubernetes.Interface
+	// Cuinterpose asks for the CUDA interposer shim and cuda-checkpoint to be
+	// mounted at their capture-time path before CRIU runs.
+	Cuinterpose                 bool
 	PageBrokerRequested         bool
 	PageBrokerEnabled           bool
 	PageBrokerControlSocketPath string
@@ -149,6 +153,14 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 	if err != nil {
 		return 0, err
 	}
+	// The manifest is the source of truth for whether the shim must be mounted;
+	// the PodSnapshot annotation is kept as a fallback for artifacts written
+	// before the manifest recorded it, and a disagreement is worth a log line.
+	if manifest.Cuinterpose.Requested != req.Cuinterpose {
+		log.Info("cuinterpose request in manifest and PodSnapshot disagree; following the manifest",
+			"manifest", manifest.Cuinterpose.Requested, "podsnapshot", req.Cuinterpose)
+	}
+	req.Cuinterpose = manifest.Cuinterpose.Requested || req.Cuinterpose
 
 	bundleMount, err := mounts.MountBundle(ctx, snap.PlaceholderPID)
 	if err != nil {
@@ -159,8 +171,8 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		point:  bundleMount,
 	})
 
-	containerCheckpointPath := nsmount.CheckpointDst
 	var pageBrokerStageDuration, pageBrokerMountDuration, pageBrokerCommitDuration time.Duration
+	stagedPath := ""
 	if brokered {
 		transactionID = uuid.NewString()
 		broker = pagebroker.Client{ControlSocketPath: req.PageBrokerControlSocketPath}
@@ -170,26 +182,16 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		if err != nil {
 			return 0, fmt.Errorf("stage PageBroker restore: %w", err)
 		}
-		mountStart := time.Now()
-		stagingMount, err := mounts.MountPageBroker(ctx, bundleMount, staged)
+		stagedPath = staged
+	}
+	mountStart := time.Now()
+	inputMounts, containerCheckpointPath, err := mountRestoreInputs(ctx, mounts, req, bundleMount, artifactPath, stagedPath)
+	activeMounts = append(activeMounts, inputMounts...)
+	if err != nil {
+		return 0, err
+	}
+	if brokered {
 		pageBrokerMountDuration = time.Since(mountStart)
-		if err != nil {
-			return 0, fmt.Errorf("mount PageBroker staging: %w", err)
-		}
-		activeMounts = append(activeMounts, restoreMount{
-			action: "unmount PageBroker staging from placeholder",
-			point:  stagingMount,
-		})
-		containerCheckpointPath = nsmount.PageBrokerDst
-	} else {
-		artifactMount, err := mounts.MountArtifact(ctx, bundleMount, artifactPath)
-		if err != nil {
-			return 0, fmt.Errorf("mount checkpoint artifact into placeholder: %w", err)
-		}
-		activeMounts = append(activeMounts, restoreMount{
-			action: "unmount checkpoint artifact from placeholder",
-			point:  artifactMount,
-		})
 	}
 
 	result, err := execNSRestore(ctx, log, req, snap, bundleMount, containerCheckpointPath)
@@ -228,19 +230,21 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		result.CRIUPrepareDuration,
 		result.CRIURestoreDuration,
 		result.CUDARestoreDuration,
+		result.CuinterposeRestoreDuration,
 	)
 	summary := map[string]any{
 		"duration": wall.String(),
 		"phases": map[string]string{
-			"pagebroker_stage":  pageBrokerStageDuration.String(),
-			"pagebroker_mount":  pageBrokerMountDuration.String(),
-			"pagebroker_commit": pageBrokerCommitDuration.String(),
-			"gpu_device_map":    gpuDeviceMapDuration.String(),
-			"overlay_capture":   result.OverlayCaptureDuration.String(),
-			"criu_prepare":      result.CRIUPrepareDuration.String(),
-			"criu_restore":      result.CRIURestoreDuration.String(),
-			"cuda_restore":      result.CUDARestoreDuration.String(),
-			"unaccounted":       unaccounted.String(),
+			"pagebroker_stage":    pageBrokerStageDuration.String(),
+			"pagebroker_mount":    pageBrokerMountDuration.String(),
+			"pagebroker_commit":   pageBrokerCommitDuration.String(),
+			"gpu_device_map":      gpuDeviceMapDuration.String(),
+			"overlay_capture":     result.OverlayCaptureDuration.String(),
+			"criu_prepare":        result.CRIUPrepareDuration.String(),
+			"criu_restore":        result.CRIURestoreDuration.String(),
+			"cuda_restore":        result.CUDARestoreDuration.String(),
+			"cuinterpose_restore": result.CuinterposeRestoreDuration.String(),
+			"unaccounted":         unaccounted.String(),
 		},
 	}
 	if !req.StartedAt.IsZero() {
@@ -448,4 +452,51 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	}
 
 	return &result, nil
+}
+
+// mountRestoreInputs installs, after the agent bundle, the mounts nsrestore
+// reads from inside the placeholder: the cuinterpose bundle when the artifact
+// was captured with the shim, then either the PageBroker staging directory
+// (stagedPath != "") or the checkpoint artifact itself. Order matters: the
+// brokered path unmounts the *last* returned mount early, so the staging mount
+// must come last. Mounts that succeeded before an error are returned so the
+// caller can unmount them.
+func mountRestoreInputs(
+	ctx context.Context,
+	mounts RestoreMounter,
+	req RestoreRequest,
+	bundleMount nsmount.MountPoint,
+	artifactPath string,
+	stagedPath string,
+) (mounted []restoreMount, containerCheckpointPath string, err error) {
+	if req.Cuinterpose {
+		cuinterposeMount, err := mounts.MountCuinterpose(ctx, bundleMount)
+		if err != nil {
+			return mounted, "", fmt.Errorf("mount cuinterpose into placeholder: %w", err)
+		}
+		mounted = append(mounted, restoreMount{
+			action: "unmount cuinterpose from placeholder",
+			point:  cuinterposeMount,
+		})
+	}
+	if stagedPath != "" {
+		stagingMount, err := mounts.MountPageBroker(ctx, bundleMount, stagedPath)
+		if err != nil {
+			return mounted, "", fmt.Errorf("mount PageBroker staging: %w", err)
+		}
+		mounted = append(mounted, restoreMount{
+			action: "unmount PageBroker staging from placeholder",
+			point:  stagingMount,
+		})
+		return mounted, nsmount.PageBrokerDst, nil
+	}
+	artifactMount, err := mounts.MountArtifact(ctx, bundleMount, artifactPath)
+	if err != nil {
+		return mounted, "", fmt.Errorf("mount checkpoint artifact into placeholder: %w", err)
+	}
+	mounted = append(mounted, restoreMount{
+		action: "unmount checkpoint artifact from placeholder",
+		point:  artifactMount,
+	})
+	return mounted, nsmount.CheckpointDst, nil
 }

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
@@ -191,5 +192,109 @@ func TestRemainingDuration(t *testing.T) {
 	}
 	if remainingDuration(5*time.Second, 4*time.Second, 3*time.Second) != 0 {
 		t.Fatal("remainingDuration should not go negative")
+	}
+}
+
+// recordingMounter records the order of role mounts for mountRestoreInputs.
+type recordingMounter struct {
+	calls   []string
+	failOn  string
+	failErr error
+}
+
+func (m *recordingMounter) record(role string) (nsmount.MountPoint, error) {
+	m.calls = append(m.calls, role)
+	if role == m.failOn {
+		return nil, m.failErr
+	}
+	return testMountPoint{}, nil
+}
+
+func (m *recordingMounter) MountBundle(context.Context, int) (nsmount.MountPoint, error) {
+	return m.record("bundle")
+}
+
+func (m *recordingMounter) MountCuinterpose(context.Context, nsmount.MountPoint) (nsmount.MountPoint, error) {
+	return m.record("cuinterpose")
+}
+
+func (m *recordingMounter) MountArtifact(context.Context, nsmount.MountPoint, string) (nsmount.MountPoint, error) {
+	return m.record("artifact")
+}
+
+func (m *recordingMounter) MountPageBroker(context.Context, nsmount.MountPoint, string) (nsmount.MountPoint, error) {
+	return m.record("pagebroker")
+}
+
+func TestMountRestoreInputsOrdersCuinterposeBeforeStaging(t *testing.T) {
+	cases := map[string]struct {
+		cuinterpose bool
+		staged      string
+		wantCalls   []string
+		wantPath    string
+	}{
+		"plain artifact":            {wantCalls: []string{"artifact"}, wantPath: nsmount.CheckpointDst},
+		"cuinterpose then artifact": {cuinterpose: true, wantCalls: []string{"cuinterpose", "artifact"}, wantPath: nsmount.CheckpointDst},
+		"brokered":                  {staged: "/pagebroker/staging/restore/tx", wantCalls: []string{"pagebroker"}, wantPath: nsmount.PageBrokerDst},
+		"cuinterpose then brokered": {cuinterpose: true, staged: "/pagebroker/staging/restore/tx", wantCalls: []string{"cuinterpose", "pagebroker"}, wantPath: nsmount.PageBrokerDst},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := &recordingMounter{}
+			mounted, path, err := mountRestoreInputs(context.Background(), m, RestoreRequest{Cuinterpose: tc.cuinterpose}, testMountPoint{}, "/checkpoints/x", tc.staged)
+			if err != nil {
+				t.Fatalf("mountRestoreInputs: %v", err)
+			}
+			if strings.Join(m.calls, ",") != strings.Join(tc.wantCalls, ",") {
+				t.Fatalf("mount order = %v, want %v", m.calls, tc.wantCalls)
+			}
+			if path != tc.wantPath {
+				t.Fatalf("checkpoint path = %q, want %q", path, tc.wantPath)
+			}
+			if len(mounted) != len(tc.wantCalls) {
+				t.Fatalf("mounted %d, want %d", len(mounted), len(tc.wantCalls))
+			}
+			// The brokered path unmounts the last active mount early; it must
+			// be the staging mount, never the cuinterpose mount.
+			if tc.staged != "" && mounted[len(mounted)-1].action != "unmount PageBroker staging from placeholder" {
+				t.Fatalf("last mount = %q, want the staging mount", mounted[len(mounted)-1].action)
+			}
+		})
+	}
+}
+
+func TestMountRestoreInputsReturnsEarlierMountsOnFailure(t *testing.T) {
+	m := &recordingMounter{failOn: "artifact", failErr: errors.New("boom")}
+	mounted, _, err := mountRestoreInputs(context.Background(), m, RestoreRequest{Cuinterpose: true}, testMountPoint{}, "/checkpoints/x", "")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected the artifact mount error, got %v", err)
+	}
+	if len(mounted) != 1 || mounted[0].action != "unmount cuinterpose from placeholder" {
+		t.Fatalf("earlier mounts must be returned for cleanup, got %+v", mounted)
+	}
+}
+
+func TestRequireCuinterposeState(t *testing.T) {
+	dir := t.TempDir()
+	plain := &types.CheckpointManifest{}
+	if err := requireCuinterposeState(plain, dir); err != nil {
+		t.Fatalf("a checkpoint without cuinterpose needs no state file: %v", err)
+	}
+	prepared := &types.CheckpointManifest{
+		CUDA:        types.NewCUDAManifest([]int{1}, nil),
+		Cuinterpose: types.CuinterposeManifest{Requested: true, Prepared: true},
+	}
+	if err := requireCuinterposeState(prepared, dir); err == nil {
+		t.Fatal("a prepared checkpoint without its state file must be refused")
+	}
+	if err := os.WriteFile(dir+"/"+cuda.CuinterposeStateFile, []byte("cuinterpose-state-v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireCuinterposeState(prepared, dir); err != nil {
+		t.Fatalf("state present: %v", err)
+	}
+	noCUDA := &types.CheckpointManifest{Cuinterpose: types.CuinterposeManifest{Prepared: true}}
+	if err := requireCuinterposeState(noCUDA, dir); err == nil {
+		t.Fatal("prepared without CUDA processes is inconsistent")
 	}
 }

--- a/agent/internal/nsmount/injector.go
+++ b/agent/internal/nsmount/injector.go
@@ -42,6 +42,24 @@ type MountPoint interface {
 	NsFd() *os.File
 }
 
+// MountCuinterpose exposes the cuinterpose shim and cuda-checkpoint at the
+// path the source workload used (podcontract.CuinterposeMountPath). Both the
+// source and destination are fixed inside the ns-bind-mount helper.
+func (nsm *NSMounter) MountCuinterpose(
+	ctx context.Context,
+	namespaceMount MountPoint,
+) (MountPoint, error) {
+	if namespaceMount == nil || namespaceMount.NsFd() == nil {
+		return nil, fmt.Errorf("mount cuinterpose: pinned mount namespace is required")
+	}
+	nsm.log.Info("mounting cuinterpose into placeholder namespace")
+	ref, err := nsm.mounter.MountCuinterpose(ctx, namespaceMount.NsFd())
+	if err != nil {
+		return nil, err
+	}
+	return &mountPoint{mount: ref}, nil
+}
+
 // NSMounter installs the binary bundle and a selected checkpoint artifact at
 // their fixed destinations in a placeholder container's mount namespace.
 type NSMounter struct {

--- a/agent/internal/nsmount/injector_test.go
+++ b/agent/internal/nsmount/injector_test.go
@@ -51,6 +51,15 @@ func (m *mockMounter) MountBundle(_ context.Context, pid int) (mountRef, error) 
 	return m.mount("bundle", pid, "")
 }
 
+func (m *mockMounter) MountCuinterpose(_ context.Context, nsFd *os.File) (mountRef, error) {
+	i := len(m.calls)
+	m.calls = append(m.calls, mountCall{role: "cuinterpose", nsFd: nsFd})
+	if i < len(m.results) && m.results[i] != nil {
+		return nil, m.results[i]
+	}
+	return &fakeMountRef{dst: "cuinterpose", unmountLog: &m.unmountLog}, nil
+}
+
 func (m *mockMounter) MountCheckpoint(_ context.Context, nsFd *os.File, src string) (mountRef, error) {
 	i := len(m.calls)
 	m.calls = append(m.calls, mountCall{role: "checkpoint", nsFd: nsFd, src: src})
@@ -96,10 +105,14 @@ func TestRoleMountsUseFixedPathsAndPolicies(t *testing.T) {
 	if _, err := nsm.MountArtifact(context.Background(), bundle, "/checkpoints/artifacts/content-uid/containers/main"); err != nil {
 		t.Fatalf("MountArtifact: %v", err)
 	}
+	if _, err := nsm.MountCuinterpose(context.Background(), bundle); err != nil {
+		t.Fatalf("MountCuinterpose: %v", err)
+	}
 
 	want := []mountCall{
 		{role: "bundle", pid: testPID},
 		{role: "checkpoint", src: "/checkpoints/artifacts/content-uid/containers/main"},
+		{role: "cuinterpose"},
 	}
 	if len(m.calls) != len(want) {
 		t.Fatalf("got %d calls, want %d", len(m.calls), len(want))
@@ -111,6 +124,9 @@ func TestRoleMountsUseFixedPathsAndPolicies(t *testing.T) {
 	}
 	if m.calls[1].nsFd != bundle.NsFd() {
 		t.Fatal("checkpoint mount did not reuse the bundle's pinned namespace fd")
+	}
+	if m.calls[2].nsFd != bundle.NsFd() {
+		t.Fatal("cuinterpose mount did not reuse the bundle's pinned namespace fd")
 	}
 }
 

--- a/agent/internal/nsmount/mount.go
+++ b/agent/internal/nsmount/mount.go
@@ -32,6 +32,7 @@ type mountRef interface {
 
 type mounter interface {
 	MountBundle(ctx context.Context, pid int) (mountRef, error)
+	MountCuinterpose(ctx context.Context, nsFd *os.File) (mountRef, error)
 	MountCheckpoint(ctx context.Context, nsFd *os.File, checkpointPath string) (mountRef, error)
 	MountPageBroker(ctx context.Context, nsFd *os.File, stagingPath string) (mountRef, error)
 }
@@ -89,6 +90,20 @@ func (m *execMounter) MountBundle(ctx context.Context, pid int) (mountRef, error
 }
 
 func (m *execMounter) MountCheckpoint(ctx context.Context, nsFd *os.File, checkpointPath string) (mountRef, error) {
+	return m.mountInNamespace(ctx, nsFd, "mount-checkpoint-fd", "unmount-checkpoint-fd", checkpointPath)
+}
+
+func (m *execMounter) MountCuinterpose(ctx context.Context, nsFd *os.File) (mountRef, error) {
+	return m.mountInNamespace(ctx, nsFd, "mount-cuinterpose-fd", "unmount-cuinterpose-fd")
+}
+
+func (m *execMounter) mountInNamespace(
+	ctx context.Context,
+	nsFd *os.File,
+	mountCmd string,
+	unmountCmd string,
+	args ...string,
+) (mountRef, error) {
 	if nsFd == nil {
 		return nil, fmt.Errorf("mount namespace fd is required")
 	}
@@ -97,7 +112,7 @@ func (m *execMounter) MountCheckpoint(ctx context.Context, nsFd *os.File, checkp
 		return nil, fmt.Errorf("duplicate mount namespace fd: %w", err)
 	}
 	unix.CloseOnExec(dupFd)
-	return m.mount(ctx, os.NewFile(uintptr(dupFd), nsFd.Name()), "mount-checkpoint-fd", "unmount-checkpoint-fd", checkpointPath)
+	return m.mount(ctx, os.NewFile(uintptr(dupFd), nsFd.Name()), mountCmd, unmountCmd, args...)
 }
 
 func (m *execMounter) MountPageBroker(ctx context.Context, nsFd *os.File, stagingPath string) (mountRef, error) {

--- a/agent/internal/nsmount/mount_test.go
+++ b/agent/internal/nsmount/mount_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 )
 
 func writeFakeBinary(t *testing.T, script string) string {
@@ -191,10 +193,29 @@ func TestCHelperRejectsUnsafeSourcesBeforeMountSyscalls(t *testing.T) {
 	for _, args := range [][]string{
 		{"mount-fd", "3", "/etc", "/tmp/checkpoint"},
 		{"mount-bundle-fd", "3", "/etc"},
+		{"mount-cuinterpose-fd", "3", "/etc"},
 		{"unmount-checkpoint-fd", "3", "unexpected"},
 	} {
 		if output, err := exec.Command(binary, args...).CombinedOutput(); err == nil {
 			t.Fatalf("helper accepted %v: %s", args, output)
+		}
+	}
+}
+
+// The C helper hard-codes the cuinterpose destination. It must equal the path
+// podcontract bakes into LD_PRELOAD and the cuda-checkpoint command of the
+// source workload, because CRIU re-opens those file-backed mappings by path.
+func TestCHelperCuinterposeDestinationMatchesPodContract(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", "cmd", "ns-bind-mount", "main.c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`#define CUINTERPOSE_DESTINATION "` + podcontract.CuinterposeMountPath + `"`,
+		`#define CUINTERPOSE_SOURCE "` + SnapshotBinSrc + `/cuinterpose"`,
+	} {
+		if !strings.Contains(string(source), want) {
+			t.Errorf("ns-bind-mount/main.c lacks %q", want)
 		}
 	}
 }

--- a/agent/internal/types/inspect.go
+++ b/agent/internal/types/inspect.go
@@ -31,6 +31,7 @@ type CheckpointContainerSnapshot struct {
 	CUDAHostPIDs   []int    // host-visible PIDs used for checkpoint-side CUDA actions
 	CUDANSPIDs     []int    // namespace-relative PIDs stored in the checkpoint manifest
 	GPUUUIDs       []string // source GPU UUIDs from kubelet PodResources API
+	Cuinterpose    bool     // every CUDA process runs the cuinterpose shim (its control socket is present)
 }
 
 // RestoreContainerSnapshot holds inspected state for the restore target.

--- a/agent/internal/types/manifest.go
+++ b/agent/internal/types/manifest.go
@@ -26,6 +26,23 @@ type CheckpointManifest struct {
 	K8s      SourcePodManifest `yaml:"k8s"`
 	Overlay  OverlayManifest   `yaml:"overlay"`
 	CUDA     CUDAManifest      `yaml:"cudaRestore,omitempty"`
+	// Cuinterpose records whether the CUDA interposer shim was in play. It is
+	// the restore side's only source of truth: the restore Pod's annotations
+	// may be absent or edited, and the state file alone cannot say whether
+	// prepare was supposed to have run.
+	Cuinterpose CuinterposeManifest `yaml:"cuinterpose,omitempty"`
+}
+
+// CuinterposeManifest carries two separate facts about the shim.
+type CuinterposeManifest struct {
+	// Requested is true when the source Pod opted in. Restore then bind-mounts
+	// the shim at its capture path before CRIU, because the checkpointed
+	// processes have it mapped by that path whether or not it did anything.
+	Requested bool `yaml:"requested"`
+	// Prepared is true when the coordinator's prepare step completed and wrote
+	// the state file. Restore then runs the coordinator, and a missing state
+	// file is an error rather than a plain restore.
+	Prepared bool `yaml:"prepared"`
 }
 
 // ArtifactManifest pins an on-disk checkpoint to the Kubernetes content object

--- a/agent/internal/types/manifest_test.go
+++ b/agent/internal/types/manifest_test.go
@@ -177,3 +177,31 @@ func TestManifestRequiresContainerName(t *testing.T) {
 		t.Fatalf("expected missing container name error, got %v", err)
 	}
 }
+
+func TestManifestRoundTripsCuinterpose(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCheckpointManifest("content-uid", "main", CRIUDumpManifest{}, SourcePodManifest{}, OverlayManifest{})
+	m.Cuinterpose = CuinterposeManifest{Requested: true, Prepared: true}
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	read, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !read.Cuinterpose.Requested || !read.Cuinterpose.Prepared {
+		t.Fatalf("cuinterpose = %+v, want both true", read.Cuinterpose)
+	}
+	// Older manifests without the section read as not requested, not prepared.
+	m.Cuinterpose = CuinterposeManifest{}
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	read, err = ReadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Cuinterpose.Requested || read.Cuinterpose.Prepared {
+		t.Fatalf("cuinterpose = %+v, want zero", read.Cuinterpose)
+	}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.26.6
 require (
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 )
 
 require (
@@ -21,7 +22,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/api/podcontract/cuinterpose.go
+++ b/api/podcontract/cuinterpose.go
@@ -1,0 +1,481 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// cuinterpose is the CUDA interposer: an LD_PRELOAD library that lets Snapshot
+// checkpoint and restore CUDA memory shared between processes on one node.
+// This file shapes an opted-in source Pod so the workload runs with the shim
+// preloaded and launched through cuda-checkpoint. The shim and cuda-checkpoint
+// are copied out of the configured Snapshot agent image by an init container
+// into a per-Pod emptyDir; the agent bind-mounts the same two files at the same
+// path when restoring, because CRIU restores file-backed mappings by path.
+const (
+	// CuinterposeVolumeName is the emptyDir that carries the shim and
+	// cuda-checkpoint into the workload containers.
+	CuinterposeVolumeName = "cuinterpose"
+	// CuinterposeInitContainerName copies the two files out of the agent image.
+	CuinterposeInitContainerName = "cuinterpose-install"
+	// CuinterposeMountPath is the fixed path the shim and cuda-checkpoint are
+	// visible at inside every checkpoint target, at capture and at restore. The
+	// agent's ns-bind-mount helper hard-codes the same destination.
+	CuinterposeMountPath = "/tmp/cuinterpose"
+	// CuinterposeLibraryPath is the LD_PRELOAD entry.
+	CuinterposeLibraryPath = CuinterposeMountPath + "/libcuinterpose.so"
+	// CuinterposeCUDACheckpointPath is the cuda-checkpoint that wraps the
+	// workload command with --launch-job.
+	CuinterposeCUDACheckpointPath = CuinterposeMountPath + "/cuda-checkpoint"
+
+	cuinterposeImageLibraryPath    = "/usr/local/lib/snapshot/libcuinterpose.so"
+	cuinterposeImageCUDACheckpoint = "/usr/local/sbin/cuda-checkpoint"
+	cuinterposeInstallMountPath    = "/cuinterpose"
+	ldPreloadEnv                   = "LD_PRELOAD"
+)
+
+// persistCUDAJobFileScript copies cuda-checkpoint's transient launch-job file
+// (handed to the workload as an inherited procfs fd path) into the per-Pod
+// control volume, so the agent can stage it into the checkpoint artifact, then
+// starts the original command.
+const persistCUDAJobFileScript = `set -eu
+job_file="$1"
+shift
+if [ -z "${CUDA_CHECKPOINT_JOB_FILE:-}" ]; then
+    echo "CUDA_CHECKPOINT_JOB_FILE is missing; cuda-checkpoint --launch-job requires NVIDIA driver 610 or newer" >&2
+    exit 1
+fi
+umask 077
+cat "$CUDA_CHECKPOINT_JOB_FILE" > "$job_file"
+export CUDA_CHECKPOINT_JOB_FILE="$job_file"
+exec "$@"`
+
+// imageReferencePattern is the Docker/OCI reference grammar: an optional
+// registry (host[:port]), path components, an optional tag, and an optional
+// sha256 digest. It rejects whitespace, uppercase path components, and other
+// strings the kubelet would fail to pull.
+var imageReferencePattern = regexp.MustCompile(
+	`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*(?::[0-9]+)?/)?` +
+		`[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*` +
+		`(?::[\w][\w.-]{0,127})?` +
+		`(?:@sha256:[a-f0-9]{64})?$`,
+)
+
+// CuinterposeDelivery says where the shim and cuda-checkpoint come from. The
+// Snapshot installation configures it once (Helm chart -> operator flags);
+// workload users never choose an image.
+type CuinterposeDelivery struct {
+	// AgentImage is the Snapshot agent image reference.
+	AgentImage string
+	// PullPolicy for the install init container. Empty selects a safe default:
+	// Always for tag references, IfNotPresent for digest references.
+	PullPolicy corev1.PullPolicy
+	// ImagePullSecrets are secret names, expected to exist in the workload's
+	// namespace, added to the Pod so the init container can pull AgentImage
+	// from a private registry.
+	ImagePullSecrets []string
+}
+
+// CuinterposeEnabled reports whether a workload opted into the CUDA interposer
+// through CuinterposeAnnotation. An absent annotation disables it; any value
+// other than "enabled" is an error rather than a silent no.
+func CuinterposeEnabled(annotations map[string]string) (bool, error) {
+	raw, found := annotations[CuinterposeAnnotation]
+	if !found {
+		return false, nil
+	}
+	if raw != strings.TrimSpace(raw) {
+		return false, fmt.Errorf("%s must not contain surrounding whitespace", CuinterposeAnnotation)
+	}
+	if raw != CuinterposeAnnotationEnabled {
+		return false, fmt.Errorf("%s must be %q", CuinterposeAnnotation, CuinterposeAnnotationEnabled)
+	}
+	return true, nil
+}
+
+// ShapeCuinterposeCapture installs the capture-side contract on every target
+// container in podTemplate when the template opts in: one emptyDir, one init
+// container copying the shim and cuda-checkpoint from the agent image, a
+// read-only mount of that volume in each target, LD_PRELOAD pointing at the
+// shim, and the target command wrapped with cuda-checkpoint --launch-job.
+// Reapplying to an already shaped template is a no-op. On error the template
+// is left unchanged.
+func ShapeCuinterposeCapture(
+	podTemplate *corev1.PodTemplateSpec,
+	targetContainers []string,
+	delivery CuinterposeDelivery,
+) error {
+	if podTemplate == nil {
+		return fmt.Errorf("cuinterpose requires a pod template")
+	}
+	shaped := podTemplate.DeepCopy()
+	if err := shapeCuinterposeCapture(shaped, targetContainers, delivery); err != nil {
+		return err
+	}
+	*podTemplate = *shaped
+	return nil
+}
+
+func shapeCuinterposeCapture(
+	podTemplate *corev1.PodTemplateSpec,
+	targetContainers []string,
+	delivery CuinterposeDelivery,
+) error {
+	enabled, err := CuinterposeEnabled(podTemplate.Annotations)
+	if err != nil || !enabled {
+		return err
+	}
+	if err := ValidateImageReference(delivery.AgentImage); err != nil {
+		return fmt.Errorf("cuinterpose agent image: %w", err)
+	}
+	if len(targetContainers) == 0 {
+		return fmt.Errorf("cuinterpose requires at least one target container")
+	}
+	if err := ensureCuinterposeVolume(&podTemplate.Spec); err != nil {
+		return err
+	}
+	if err := ensureCuinterposeInitContainer(&podTemplate.Spec, delivery); err != nil {
+		return err
+	}
+	ensureImagePullSecrets(&podTemplate.Spec, delivery.ImagePullSecrets)
+
+	seen := make(map[string]struct{}, len(targetContainers))
+	for _, name := range targetContainers {
+		if _, duplicate := seen[name]; duplicate {
+			return fmt.Errorf("duplicate cuinterpose target container %q", name)
+		}
+		seen[name] = struct{}{}
+		container := findContainer(&podTemplate.Spec, name)
+		if container == nil {
+			return fmt.Errorf("cuinterpose target container %q does not exist", name)
+		}
+		if err := ensureCuinterposeMount(container); err != nil {
+			return err
+		}
+		if err := setCuinterposePreload(container); err != nil {
+			return err
+		}
+		if err := EnsureCUDACheckpointLaunchJob(container, CuinterposeCUDACheckpointPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// VerifyCuinterposeCapture reports whether spec already carries the complete
+// capture contract for every target container: the volume, the install init
+// container, and per target the mount, the LD_PRELOAD entry, and the
+// cuda-checkpoint wrapper. The operator uses it to refuse adopting a Job that
+// was created without the contract.
+func VerifyCuinterposeCapture(spec *corev1.PodSpec, targetContainers []string) error {
+	if spec == nil {
+		return fmt.Errorf("cuinterpose requires a pod spec")
+	}
+	if !slices.ContainsFunc(spec.Volumes, func(v corev1.Volume) bool {
+		return v.Name == CuinterposeVolumeName && isEmptyDirVolumeSource(v.VolumeSource)
+	}) {
+		return fmt.Errorf("pod lacks the %s emptyDir volume", CuinterposeVolumeName)
+	}
+	if !slices.ContainsFunc(spec.InitContainers, func(c corev1.Container) bool {
+		return c.Name == CuinterposeInitContainerName
+	}) {
+		return fmt.Errorf("pod lacks the %s init container", CuinterposeInitContainerName)
+	}
+	for _, name := range targetContainers {
+		container := findContainer(spec, name)
+		if container == nil {
+			return fmt.Errorf("cuinterpose target container %q does not exist", name)
+		}
+		if !slices.ContainsFunc(container.VolumeMounts, func(m corev1.VolumeMount) bool {
+			return m.Name == CuinterposeVolumeName && m.MountPath == CuinterposeMountPath
+		}) {
+			return fmt.Errorf("container %q does not mount %s at %s", name, CuinterposeVolumeName, CuinterposeMountPath)
+		}
+		if !slices.Contains(preloadFields(envValue(container.Env, ldPreloadEnv)), CuinterposeLibraryPath) {
+			return fmt.Errorf("container %q does not preload %s", name, CuinterposeLibraryPath)
+		}
+		if len(container.Command) != 1 || container.Command[0] != CuinterposeCUDACheckpointPath ||
+			!isCUDACheckpointLaunchJob(container.Args) {
+			return fmt.Errorf("container %q is not launched through %s --launch-job", name, CuinterposeCUDACheckpointPath)
+		}
+	}
+	return nil
+}
+
+// ValidateImageReference rejects image references the kubelet cannot pull.
+func ValidateImageReference(image string) error {
+	if image == "" {
+		return fmt.Errorf("image reference is required")
+	}
+	if image != strings.TrimSpace(image) {
+		return fmt.Errorf("image reference %q must not contain surrounding whitespace", image)
+	}
+	if !imageReferencePattern.MatchString(image) {
+		return fmt.Errorf("image reference %q is not a valid registry/repository[:tag][@sha256:digest]", image)
+	}
+	return nil
+}
+
+func ensureCuinterposeVolume(spec *corev1.PodSpec) error {
+	found := false
+	for i := range spec.Volumes {
+		volume := &spec.Volumes[i]
+		if volume.Name != CuinterposeVolumeName {
+			continue
+		}
+		if found {
+			return fmt.Errorf("duplicate %s volume", CuinterposeVolumeName)
+		}
+		found = true
+		if !isEmptyDirVolumeSource(volume.VolumeSource) {
+			return fmt.Errorf("volume %q must be an emptyDir", CuinterposeVolumeName)
+		}
+	}
+	if !found {
+		spec.Volumes = append(spec.Volumes, corev1.Volume{
+			Name:         CuinterposeVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
+	return nil
+}
+
+func ensureImagePullSecrets(spec *corev1.PodSpec, names []string) {
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if slices.ContainsFunc(spec.ImagePullSecrets, func(ref corev1.LocalObjectReference) bool {
+			return ref.Name == name
+		}) {
+			continue
+		}
+		spec.ImagePullSecrets = append(spec.ImagePullSecrets, corev1.LocalObjectReference{Name: name})
+	}
+}
+
+func expectedCuinterposeInitContainer(delivery CuinterposeDelivery) corev1.Container {
+	pullPolicy := delivery.PullPolicy
+	if pullPolicy == "" {
+		pullPolicy = corev1.PullAlways
+		if strings.Contains(delivery.AgentImage, "@sha256:") {
+			pullPolicy = corev1.PullIfNotPresent
+		}
+	}
+	return corev1.Container{
+		Name:            CuinterposeInitContainerName,
+		Image:           delivery.AgentImage,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"/bin/cp"},
+		Args: []string{
+			"--",
+			cuinterposeImageLibraryPath,
+			cuinterposeImageCUDACheckpoint,
+			cuinterposeInstallMountPath + "/",
+		},
+		// The agent image runs as root and only copies two files into a
+		// world-writable emptyDir, so RunAsNonRoot is not set; everything else
+		// that a restricted namespace expects is.
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      CuinterposeVolumeName,
+			MountPath: cuinterposeInstallMountPath,
+		}},
+	}
+}
+
+// initContainerMatches compares the fields the contract sets. Fields the API
+// server defaults (termination message path, image pull policy on re-read) are
+// deliberately not compared, so reshaping a live object does not report a
+// conflict.
+func initContainerMatches(actual, expected *corev1.Container) bool {
+	if actual.Name != expected.Name || actual.Image != expected.Image {
+		return false
+	}
+	if !slices.Equal(actual.Command, expected.Command) || !slices.Equal(actual.Args, expected.Args) {
+		return false
+	}
+	if len(actual.VolumeMounts) != len(expected.VolumeMounts) {
+		return false
+	}
+	for i := range expected.VolumeMounts {
+		if actual.VolumeMounts[i].Name != expected.VolumeMounts[i].Name ||
+			actual.VolumeMounts[i].MountPath != expected.VolumeMounts[i].MountPath {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureCuinterposeInitContainer(spec *corev1.PodSpec, delivery CuinterposeDelivery) error {
+	expected := expectedCuinterposeInitContainer(delivery)
+	found := false
+	for i := range spec.InitContainers {
+		container := &spec.InitContainers[i]
+		if container.Name != CuinterposeInitContainerName {
+			continue
+		}
+		if found {
+			return fmt.Errorf("duplicate %s init container", CuinterposeInitContainerName)
+		}
+		found = true
+		if !initContainerMatches(container, &expected) {
+			return fmt.Errorf(
+				"init container %q conflicts with the cuinterpose contract",
+				CuinterposeInitContainerName,
+			)
+		}
+	}
+	if !found {
+		spec.InitContainers = append(spec.InitContainers, expected)
+	}
+	return nil
+}
+
+func ensureCuinterposeMount(container *corev1.Container) error {
+	found := false
+	for i := range container.VolumeMounts {
+		mount := &container.VolumeMounts[i]
+		if mount.Name != CuinterposeVolumeName && mount.MountPath != CuinterposeMountPath {
+			continue
+		}
+		if found {
+			return fmt.Errorf("container %q has duplicate cuinterpose mounts", container.Name)
+		}
+		found = true
+		if mount.Name != CuinterposeVolumeName || mount.MountPath != CuinterposeMountPath ||
+			!mount.ReadOnly || mount.SubPath != "" || mount.SubPathExpr != "" ||
+			mount.RecursiveReadOnly != nil ||
+			(mount.MountPropagation != nil && *mount.MountPropagation != corev1.MountPropagationNone) {
+			return fmt.Errorf("container %q has conflicting options on the cuinterpose mount", container.Name)
+		}
+	}
+	if !found {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      CuinterposeVolumeName,
+			MountPath: CuinterposeMountPath,
+			ReadOnly:  true,
+		})
+	}
+	return nil
+}
+
+// setCuinterposePreload puts the shim first in LD_PRELOAD, keeping any entries
+// the workload already had. First position matters: the dynamic loader
+// resolves symbols in LD_PRELOAD order, and the shim must see CUDA calls
+// before any other interposer.
+func setCuinterposePreload(container *corev1.Container) error {
+	index := -1
+	for i := range container.Env {
+		if container.Env[i].Name != ldPreloadEnv {
+			continue
+		}
+		if index != -1 {
+			return fmt.Errorf("container %q has duplicate %s environment variables", container.Name, ldPreloadEnv)
+		}
+		index = i
+	}
+	if index == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  ldPreloadEnv,
+			Value: CuinterposeLibraryPath,
+		})
+		return nil
+	}
+	env := &container.Env[index]
+	if env.ValueFrom != nil {
+		return fmt.Errorf("container %q uses valueFrom for %s", container.Name, ldPreloadEnv)
+	}
+	fields := preloadFields(env.Value)
+	filtered := make([]string, 0, len(fields)+1)
+	filtered = append(filtered, CuinterposeLibraryPath)
+	for _, field := range fields {
+		if field != CuinterposeLibraryPath {
+			filtered = append(filtered, field)
+		}
+	}
+	env.Value = strings.Join(filtered, " ")
+	return nil
+}
+
+// EnsureCUDACheckpointLaunchJob launches container under
+// `binaryPath --launch-job` and persists the driver's transient job file in
+// the snapshot control volume. Reapplying the same wrapper is a no-op.
+func EnsureCUDACheckpointLaunchJob(container *corev1.Container, binaryPath string) error {
+	if container == nil {
+		return fmt.Errorf("cuda-checkpoint launch-job requires a container")
+	}
+	if binaryPath = strings.TrimSpace(binaryPath); binaryPath == "" {
+		return fmt.Errorf("cuda-checkpoint launch-job requires a binary path")
+	}
+	if len(container.Command) == 1 && container.Command[0] == binaryPath {
+		if isCUDACheckpointLaunchJob(container.Args) {
+			return nil
+		}
+		return fmt.Errorf(
+			"container %q command conflicts with the cuda-checkpoint launch-job contract",
+			container.Name,
+		)
+	}
+	if len(container.Command) == 0 {
+		return fmt.Errorf(
+			"container %q requires container.command for cuda-checkpoint launch-job",
+			container.Name,
+		)
+	}
+
+	original := make([]string, 0, len(container.Command)+len(container.Args))
+	original = append(original, container.Command...)
+	original = append(original, container.Args...)
+	container.Command = []string{binaryPath}
+	container.Args = []string{
+		"--launch-job",
+		"/bin/sh",
+		"-c",
+		persistCUDAJobFileScript,
+		"dynamo-cuda-checkpoint",
+		CUDAJobFilePath,
+	}
+	container.Args = append(container.Args, original...)
+	return nil
+}
+
+func isCUDACheckpointLaunchJob(args []string) bool {
+	return len(args) > 6 &&
+		args[0] == "--launch-job" &&
+		args[1] == "/bin/sh" &&
+		args[2] == "-c" &&
+		args[3] == persistCUDAJobFileScript &&
+		args[4] == "dynamo-cuda-checkpoint" &&
+		args[5] == CUDAJobFilePath
+}
+
+func preloadFields(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		return r == ':' || unicode.IsSpace(r)
+	})
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for i := range env {
+		if env[i].Name == name {
+			return env[i].Value
+		}
+	}
+	return ""
+}

--- a/api/podcontract/cuinterpose_test.go
+++ b/api/podcontract/cuinterpose_test.go
@@ -1,0 +1,330 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testAgentImage = "registry.example/snapshot-agent@sha256:" +
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func testDelivery() CuinterposeDelivery {
+	return CuinterposeDelivery{AgentImage: testAgentImage}
+}
+
+func enabledTemplate(containers ...corev1.Container) *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{CuinterposeAnnotation: CuinterposeAnnotationEnabled},
+		},
+		Spec: corev1.PodSpec{Containers: containers},
+	}
+}
+
+func TestShapeCuinterposeCapture(t *testing.T) {
+	template := enabledTemplate(
+		corev1.Container{
+			Name:    "worker-a",
+			Command: []string{"python3", "-m", "worker"},
+			Args:    []string{"--rank", "0"},
+			Env:     []corev1.EnvVar{{Name: ldPreloadEnv, Value: "/opt/first.so:/opt/second.so"}},
+		},
+		corev1.Container{Name: "worker-b", Command: []string{"/usr/bin/worker"}},
+		corev1.Container{Name: "helper"},
+	)
+
+	// Shaping twice must be a no-op the second time.
+	for range 2 {
+		if err := ShapeCuinterposeCapture(template, []string{"worker-a", "worker-b"}, testDelivery()); err != nil {
+			t.Fatalf("ShapeCuinterposeCapture() failed: %v", err)
+		}
+	}
+
+	if len(template.Spec.Volumes) != 1 ||
+		template.Spec.Volumes[0].Name != CuinterposeVolumeName ||
+		template.Spec.Volumes[0].EmptyDir == nil {
+		t.Fatalf("unexpected volumes: %#v", template.Spec.Volumes)
+	}
+	wantInit := expectedCuinterposeInitContainer(testDelivery())
+	if len(template.Spec.InitContainers) != 1 ||
+		!reflect.DeepEqual(template.Spec.InitContainers[0], wantInit) {
+		t.Fatalf("init containers = %#v, want %#v", template.Spec.InitContainers, wantInit)
+	}
+	if wantInit.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("digest reference should default to IfNotPresent, got %s", wantInit.ImagePullPolicy)
+	}
+	if wantInit.SecurityContext.SeccompProfile == nil ||
+		wantInit.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("init container lacks the RuntimeDefault seccomp profile: %#v", wantInit.SecurityContext)
+	}
+	for _, name := range []string{"worker-a", "worker-b"} {
+		container := findContainer(&template.Spec, name)
+		if got := container.VolumeMounts; len(got) != 1 ||
+			got[0].Name != CuinterposeVolumeName ||
+			got[0].MountPath != CuinterposeMountPath ||
+			!got[0].ReadOnly {
+			t.Fatalf("%s mounts: %#v", name, got)
+		}
+	}
+	if got := findContainer(&template.Spec, "helper"); len(got.VolumeMounts) != 0 {
+		t.Fatalf("non-target helper mounts: %#v", got.VolumeMounts)
+	}
+	wantPreload := CuinterposeLibraryPath + " /opt/first.so /opt/second.so"
+	if got := envValue(findContainer(&template.Spec, "worker-a").Env, ldPreloadEnv); got != wantPreload {
+		t.Fatalf("%s = %q, want %q", ldPreloadEnv, got, wantPreload)
+	}
+	if got := envValue(findContainer(&template.Spec, "worker-b").Env, ldPreloadEnv); got != CuinterposeLibraryPath {
+		t.Fatalf("%s = %q, want %q", ldPreloadEnv, got, CuinterposeLibraryPath)
+	}
+	assertCuinterposeLaunchJob(
+		t, findContainer(&template.Spec, "worker-a"), []string{"python3", "-m", "worker", "--rank", "0"})
+	assertCuinterposeLaunchJob(t, findContainer(&template.Spec, "worker-b"), []string{"/usr/bin/worker"})
+	if got := findContainer(&template.Spec, "helper").Command; len(got) != 0 {
+		t.Fatalf("non-target helper command: %#v", got)
+	}
+	if err := VerifyCuinterposeCapture(&template.Spec, []string{"worker-a", "worker-b"}); err != nil {
+		t.Fatalf("VerifyCuinterposeCapture() on a shaped template failed: %v", err)
+	}
+}
+
+func TestShapeCuinterposeCaptureDeliveryOptions(t *testing.T) {
+	template := enabledTemplate(corev1.Container{Name: "worker", Command: []string{"worker"}})
+	template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "existing"}}
+	delivery := CuinterposeDelivery{
+		AgentImage:       "registry.example/snapshot-agent:v1.2.3",
+		PullPolicy:       corev1.PullNever,
+		ImagePullSecrets: []string{"registry-creds", " ", "existing", "registry-creds"},
+	}
+	if err := ShapeCuinterposeCapture(template, []string{"worker"}, delivery); err != nil {
+		t.Fatalf("ShapeCuinterposeCapture() failed: %v", err)
+	}
+	if got := template.Spec.InitContainers[0].ImagePullPolicy; got != corev1.PullNever {
+		t.Fatalf("pull policy = %s, want the configured Never", got)
+	}
+	var names []string
+	for _, ref := range template.Spec.ImagePullSecrets {
+		names = append(names, ref.Name)
+	}
+	if want := []string{"existing", "registry-creds"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("imagePullSecrets = %v, want %v", names, want)
+	}
+
+	tagged := CuinterposeDelivery{AgentImage: "registry.example/snapshot-agent:v1.2.3"}
+	if got := expectedCuinterposeInitContainer(tagged).ImagePullPolicy; got != corev1.PullAlways {
+		t.Fatalf("tag reference should default to Always, got %s", got)
+	}
+}
+
+func TestShapeCuinterposeCaptureToleratesDefaultedInitContainer(t *testing.T) {
+	template := enabledTemplate(corev1.Container{Name: "worker", Command: []string{"worker"}})
+	if err := ShapeCuinterposeCapture(template, []string{"worker"}, testDelivery()); err != nil {
+		t.Fatalf("ShapeCuinterposeCapture() failed: %v", err)
+	}
+	// Simulate API server defaulting on a live object.
+	template.Spec.InitContainers[0].TerminationMessagePath = "/dev/termination-log"
+	template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	if err := ShapeCuinterposeCapture(template, []string{"worker"}, testDelivery()); err != nil {
+		t.Fatalf("reshaping a defaulted template failed: %v", err)
+	}
+	template.Spec.InitContainers[0].Image = "someone-else/image:latest"
+	if err := ShapeCuinterposeCapture(template, []string{"worker"}, testDelivery()); err == nil {
+		t.Fatal("init container with a different image was accepted")
+	}
+}
+
+func TestShapeCuinterposeCaptureDisabled(t *testing.T) {
+	template := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "worker"}}},
+	}
+	if err := ShapeCuinterposeCapture(template, []string{"worker"}, CuinterposeDelivery{}); err != nil {
+		t.Fatalf("disabled ShapeCuinterposeCapture() failed: %v", err)
+	}
+	if len(template.Spec.Volumes) != 0 || len(template.Spec.InitContainers) != 0 {
+		t.Fatalf("disabled capture was mutated: %#v", template.Spec)
+	}
+}
+
+func TestShapeCuinterposeCaptureRejectsInvalidContract(t *testing.T) {
+	worker := corev1.Container{Name: "worker", Command: []string{"worker"}}
+	tests := map[string]struct {
+		template *corev1.PodTemplateSpec
+		targets  []string
+		delivery CuinterposeDelivery
+	}{
+		"invalid annotation": {
+			template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CuinterposeAnnotation: "true"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{worker}},
+			},
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"implicit image entrypoint": {
+			template: enabledTemplate(corev1.Container{Name: "worker"}),
+			targets:  []string{"worker"}, delivery: testDelivery(),
+		},
+		"missing agent image": {
+			template: enabledTemplate(worker),
+			targets:  []string{"worker"}, delivery: CuinterposeDelivery{},
+		},
+		"malformed agent image": {
+			template: enabledTemplate(worker),
+			targets:  []string{"worker"},
+			delivery: CuinterposeDelivery{
+				AgentImage: "registry.example/not valid@sha256:" + strings.Repeat("0", 64),
+			},
+		},
+		"unknown target": {
+			template: enabledTemplate(worker),
+			targets:  []string{"other"}, delivery: testDelivery(),
+		},
+		"duplicate target": {
+			template: enabledTemplate(worker),
+			targets:  []string{"worker", "worker"}, delivery: testDelivery(),
+		},
+		"no targets": {
+			template: enabledTemplate(worker),
+			targets:  nil, delivery: testDelivery(),
+		},
+		"LD_PRELOAD from valueFrom": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				Env: []corev1.EnvVar{{Name: ldPreloadEnv, ValueFrom: &corev1.EnvVarSource{}}},
+			}),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"conflicting mount options": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				VolumeMounts: []corev1.VolumeMount{{Name: CuinterposeVolumeName, MountPath: CuinterposeMountPath, SubPath: "x"}},
+			}),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"volume is not an emptyDir": {
+			template: func() *corev1.PodTemplateSpec {
+				tpl := enabledTemplate(worker)
+				tpl.Spec.Volumes = []corev1.Volume{{
+					Name:         CuinterposeVolumeName,
+					VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp"}},
+				}}
+				return tpl
+			}(),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"foreign cuda-checkpoint wrapper": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{CuinterposeCUDACheckpointPath}, Args: []string{"--something-else"},
+			}),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			before := tc.template.DeepCopy()
+			if err := ShapeCuinterposeCapture(tc.template, tc.targets, tc.delivery); err == nil {
+				t.Fatal("ShapeCuinterposeCapture() succeeded, want error")
+			}
+			if !reflect.DeepEqual(tc.template, before) {
+				t.Fatalf("failed shape mutated template:\ngot:  %#v\nwant: %#v", tc.template, before)
+			}
+		})
+	}
+}
+
+func TestVerifyCuinterposeCaptureRejectsUnshapedSpecs(t *testing.T) {
+	shaped := enabledTemplate(corev1.Container{Name: "worker", Command: []string{"worker"}})
+	if err := ShapeCuinterposeCapture(shaped, []string{"worker"}, testDelivery()); err != nil {
+		t.Fatal(err)
+	}
+	mutations := map[string]func(*corev1.PodSpec){
+		"no volume":         func(s *corev1.PodSpec) { s.Volumes = nil },
+		"no init container": func(s *corev1.PodSpec) { s.InitContainers = nil },
+		"no mount":          func(s *corev1.PodSpec) { s.Containers[0].VolumeMounts = nil },
+		"no preload":        func(s *corev1.PodSpec) { s.Containers[0].Env = nil },
+		"unwrapped command": func(s *corev1.PodSpec) {
+			s.Containers[0].Command = []string{"worker"}
+			s.Containers[0].Args = nil
+		},
+		"missing target": func(s *corev1.PodSpec) { s.Containers[0].Name = "other" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			spec := shaped.Spec.DeepCopy()
+			mutate(spec)
+			if err := VerifyCuinterposeCapture(spec, []string{"worker"}); err == nil {
+				t.Fatal("VerifyCuinterposeCapture() accepted an unshaped spec")
+			}
+		})
+	}
+}
+
+func TestCuinterposeEnabled(t *testing.T) {
+	for name, annotations := range map[string]map[string]string{
+		"absent":  nil,
+		"enabled": {CuinterposeAnnotation: CuinterposeAnnotationEnabled},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := CuinterposeEnabled(annotations)
+			if err != nil {
+				t.Fatalf("CuinterposeEnabled() failed: %v", err)
+			}
+			if got != (name == "enabled") {
+				t.Fatalf("CuinterposeEnabled() = %v", got)
+			}
+		})
+	}
+	for _, value := range []string{"", "true", " enabled ", "Enabled"} {
+		if _, err := CuinterposeEnabled(map[string]string{CuinterposeAnnotation: value}); err == nil {
+			t.Fatalf("CuinterposeEnabled() accepted %q", value)
+		}
+	}
+}
+
+func TestValidateImageReference(t *testing.T) {
+	valid := []string{
+		"ghcr.io/ai-dynamo/snapshot/agent:v0.1.0",
+		"ghcr.io/ai-dynamo/snapshot/agent",
+		"localhost:5000/agent:dev",
+		"agent",
+		testAgentImage,
+		"registry.example/agent:v1@sha256:" + strings.Repeat("a", 64),
+	}
+	for _, image := range valid {
+		if err := ValidateImageReference(image); err != nil {
+			t.Errorf("ValidateImageReference(%q) = %v, want nil", image, err)
+		}
+	}
+	invalid := []string{
+		"",
+		" ghcr.io/agent:v1",
+		"registry.example/not valid@sha256:" + strings.Repeat("0", 64),
+		"registry.example/Agent:v1",
+		"registry.example/agent@sha256:short",
+		"registry.example/agent:tag with space",
+	}
+	for _, image := range invalid {
+		if err := ValidateImageReference(image); err == nil {
+			t.Errorf("ValidateImageReference(%q) = nil, want error", image)
+		}
+	}
+}
+
+func assertCuinterposeLaunchJob(t *testing.T, container *corev1.Container, original []string) {
+	t.Helper()
+	if !reflect.DeepEqual(container.Command, []string{CuinterposeCUDACheckpointPath}) {
+		t.Fatalf("%s command = %#v", container.Name, container.Command)
+	}
+	if !isCUDACheckpointLaunchJob(container.Args) {
+		t.Fatalf("%s is not wrapped with cuda-checkpoint: %#v", container.Name, container.Args)
+	}
+	if got := container.Args[6:]; !reflect.DeepEqual(got, original) {
+		t.Fatalf("%s original command = %#v, want %#v", container.Name, got, original)
+	}
+}

--- a/api/podcontract/protocol.go
+++ b/api/podcontract/protocol.go
@@ -22,6 +22,16 @@ const (
 	// uses the captured container name as the destination.
 	RestoreContainerMapAnnotation = "nvidia.com/restore-container-map"
 
+	// CuinterposeAnnotation opts a SnapshotJob's checkpoint targets into the
+	// CUDA interposer (cuinterpose), which lets Snapshot checkpoint and restore
+	// CUDA memory shared between processes. The only supported value is
+	// CuinterposeAnnotationEnabled. Snapshot supplies the shim from its own
+	// configured agent image; workload users do not select an image.
+	CuinterposeAnnotation = "nvidia.com/cuinterpose"
+
+	// CuinterposeAnnotationEnabled is the only accepted CuinterposeAnnotation value.
+	CuinterposeAnnotationEnabled = "enabled"
+
 	// DefaultSeccompLocalhostProfile is the kubelet-local profile installed by
 	// the Snapshot Helm chart to block io_uring for CRIU.
 	DefaultSeccompLocalhostProfile = "profiles/block-iouring.json"

--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -72,6 +72,14 @@ Name of the operator service account.
 {{- end }}
 
 {{/*
+The one configured agent image used by both the DaemonSet and the cuinterpose
+init container injected into opted-in source Pods.
+*/}}
+{{- define "snapshot.agentImage" -}}
+{{- printf "%s:%s" .Values.image.agent.repository (.Values.image.agent.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
 Fail fast on unsupported runtime.type values. Called once from daemonset.yaml.
 */}}
 {{- define "snapshot.validateRuntime" -}}

--- a/charts/snapshot/templates/daemonset.yaml
+++ b/charts/snapshot/templates/daemonset.yaml
@@ -135,7 +135,7 @@ spec:
               mountPath: {{ .Values.storage.pvc.basePath }}
         {{- end }}
         - name: agent
-          image: "{{ .Values.image.agent.repository }}:{{ .Values.image.agent.tag | default .Chart.AppVersion }}"
+          image: {{ include "snapshot.agentImage" . | quote }}
           imagePullPolicy: {{ .Values.image.agent.pullPolicy }}
           args:
             - "--runtime"

--- a/charts/snapshot/templates/operator-deployment.yaml
+++ b/charts/snapshot/templates/operator-deployment.yaml
@@ -71,6 +71,10 @@ spec:
             - {{ printf "--artifact-cleanup-scan-interval=%v" .Values.operator.artifactCleanup.scanInterval | quote }}
             - {{ printf "--artifact-cleanup-batch-size=%v" .Values.operator.artifactCleanup.batchSize | quote }}
             - {{ printf "--artifact-cleanup-list-attempts=%v" .Values.operator.artifactCleanup.listAttempts | quote }}
+            # cuinterpose delivery (nvidia.com/cuinterpose: enabled on source Pods).
+            - {{ printf "--agent-image=%s" (include "snapshot.agentImage" .) | quote }}
+            - {{ printf "--agent-image-pull-policy=%s" .Values.image.agent.pullPolicy | quote }}
+            - {{ printf "--agent-image-pull-secrets=%s" (join "," .Values.cuinterpose.imagePullSecrets) | quote }}
           volumeMounts:
             - name: checkpoints
               mountPath: {{ .Values.storage.pvc.basePath | quote }}

--- a/charts/snapshot/tests/cuinterpose_test.yaml
+++ b/charts/snapshot/tests/cuinterpose_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: cuinterpose delivery flags on the operator
+templates:
+  - templates/operator-deployment.yaml
+tests:
+  - it: passes the agent image, pull policy, and no pull secrets by default
+    set:
+      image.agent.tag: v9.9.9
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image=ghcr.io/ai-dynamo/snapshot/agent:v9.9.9"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image-pull-policy=Always"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image-pull-secrets="
+
+  - it: joins configured workload pull secrets
+    set:
+      cuinterpose.imagePullSecrets:
+        - registry-creds
+        - mirror-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image-pull-secrets=registry-creds,mirror-creds"

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -14,6 +14,16 @@ image:
     tag: ""
     pullPolicy: Always
 
+# cuinterpose is the CUDA interposer that lets Snapshot checkpoint CUDA memory
+# shared between processes. Source Pods opt in with the annotation
+# nvidia.com/cuinterpose: enabled; the operator then adds an init container that
+# copies the shim out of image.agent into the workload Pod.
+cuinterpose:
+  # Names of imagePullSecrets that exist in the workload namespaces, added to
+  # opted-in source Pods so the init container can pull image.agent from a
+  # private registry. The DaemonSet's own pull secrets do not apply there.
+  imagePullSecrets: []
+
 replicaCount: 1
 
 operator:

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -6,13 +6,16 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	"github.com/ai-dynamo/snapshot/api/v1alpha1"
 	"github.com/ai-dynamo/snapshot/operator/internal/controller"
 )
@@ -24,6 +27,21 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	artifactCleanupConfig := bindArtifactCleanupFlags(flag.CommandLine)
+	agentImage := flag.String(
+		"agent-image",
+		"",
+		"Snapshot agent image the cuinterpose shim is copied from into opted-in source workloads",
+	)
+	agentImagePullPolicy := flag.String(
+		"agent-image-pull-policy",
+		"",
+		"Pull policy for the cuinterpose install init container (Always, IfNotPresent, Never); empty picks a default from the reference",
+	)
+	agentImagePullSecrets := flag.String(
+		"agent-image-pull-secrets",
+		"",
+		"Comma-separated imagePullSecret names, present in workload namespaces, added to opted-in source Pods",
+	)
 	flag.Parse()
 	if err := artifactCleanupConfig.Validate(); err != nil {
 		ctrl.Log.Error(err, "invalid artifact cleanup configuration")
@@ -87,6 +105,11 @@ func main() {
 		Client:             mgr.GetClient(),
 		NonCacheReadClient: mgr.GetAPIReader(),
 		Recorder:           mgr.GetEventRecorderFor("snapshotjob-controller"),
+		Cuinterpose: podcontract.CuinterposeDelivery{
+			AgentImage:       *agentImage,
+			PullPolicy:       corev1.PullPolicy(*agentImagePullPolicy),
+			ImagePullSecrets: splitNonEmpty(*agentImagePullSecrets),
+		},
 	}
 	if err := snapshotJobReconciler.SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to set up SnapshotJob controller")
@@ -97,4 +120,15 @@ func main() {
 		ctrl.Log.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+}
+
+// splitNonEmpty splits a comma-separated flag value, dropping blanks.
+func splitNonEmpty(value string) []string {
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/operator/internal/controller/snapshotjob_job.go
+++ b/operator/internal/controller/snapshotjob_job.go
@@ -21,11 +21,18 @@ import (
 // Dynamo-specific code — and adds only the owner label so the PodSnapshot created
 // later (PR 4) can be mapped back to this SnapshotJob without an ownerReference.
 //
-// No storage is injected (spec §5.3: the agent falls back to its own config), and
-// WrapLaunchJob is always false (spec §5.4: PodSnapshotTemplate has no field to
-// source it from — a caller needing cuda-checkpoint --launch-job wrapping sets it
-// up themselves in spec.podTemplate).
+// No storage is injected (spec §5.3: the agent falls back to its own config).
+// The generic source protocol does not wrap the command; when the template
+// opts into cuinterpose, podcontract supplies cuda-checkpoint and the shim
+// from the configured agent image and wraps the target at a stable path.
 func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
+	return buildSourceJobWithDelivery(sj, podcontract.CuinterposeDelivery{})
+}
+
+func buildSourceJobWithDelivery(
+	sj *snapshotv1alpha1.SnapshotJob,
+	delivery podcontract.CuinterposeDelivery,
+) (*batchv1.Job, error) {
 	// sj.Name is also used as a SnapshotJobOwnerLabel value. Admission caps
 	// metadata.name at the label-value limit;
 	// retain this check for objects that predate or bypass that schema.
@@ -51,7 +58,7 @@ func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
 	podTemplate.Labels[snapshotv1alpha1.SnapshotJobOwnerLabel] = sj.Name
 	podTemplate.Labels[snapshotv1alpha1.SnapshotJobOwnerUIDLabel] = string(sj.UID)
 
-	return protocol.NewSourceJob(podTemplate, protocol.SourceJobOptions{
+	job, err := protocol.NewSourceJob(podTemplate, protocol.SourceJobOptions{
 		Namespace:             sj.Namespace,
 		Name:                  sj.Name,
 		TargetContainer:       targetContainer,
@@ -60,4 +67,15 @@ func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
 		TTLSecondsAfterFinish: nil,
 		WrapLaunchJob:         false,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if err := podcontract.ShapeCuinterposeCapture(
+		&job.Spec.Template,
+		sj.Spec.PodSnapshotTemplate.TargetContainers,
+		delivery,
+	); err != nil {
+		return nil, err
+	}
+	return job, nil
 }

--- a/operator/internal/controller/snapshotjob_job_test.go
+++ b/operator/internal/controller/snapshotjob_job_test.go
@@ -123,18 +123,6 @@ func TestBuildSourceJob(t *testing.T) {
 			"the target container must mount the control volume the probe and sentinel live in")
 	})
 
-	t.Run("WrapLaunchJob is always false: command/args pass through unchanged", func(t *testing.T) {
-		sj := minimalSnapshotJob()
-		sj.Spec.PodTemplate.Spec.Containers[0].Command = []string{"python3", "-m", "worker"}
-
-		job, err := buildSourceJob(sj)
-		require.NoError(t, err)
-
-		main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
-		assert.Equal(t, []string{"python3", "-m", "worker"}, main.Command,
-			"PodSnapshotTemplate has no multi-GPU field (spec §5.4) — command must never be wrapped")
-	})
-
 	t.Run("SnapshotJob name longer than a label value is a terminal spec error", func(t *testing.T) {
 		// Admission rejects this today, but construction keeps the check for
 		// objects that predate or bypass the current CRD schema.
@@ -237,4 +225,45 @@ func getBatchJobByName(jobs *batchv1.JobList, name string) *batchv1.Job {
 		}
 	}
 	return nil
+}
+
+func cuinterposeSnapshotJob() *snapshotv1alpha1.SnapshotJob {
+	sj := minimalSnapshotJob()
+	sj.Spec.PodTemplate.Annotations = map[string]string{
+		podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+	}
+	sj.Spec.PodTemplate.Spec.Containers[0].Command = []string{"python3", "-m", "worker"}
+	return sj
+}
+
+func testCuinterposeDelivery() podcontract.CuinterposeDelivery {
+	return podcontract.CuinterposeDelivery{AgentImage: "registry.example/snapshot-agent:v1.2.3"}
+}
+
+func TestBuildSourceJobWithDeliveryShapesCuinterpose(t *testing.T) {
+	sj := cuinterposeSnapshotJob()
+
+	job, err := buildSourceJobWithDelivery(sj, testCuinterposeDelivery())
+	require.NoError(t, err)
+
+	require.NoError(t, podcontract.VerifyCuinterposeCapture(&job.Spec.Template.Spec, []string{"worker"}))
+	main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
+	assert.Equal(t, []string{podcontract.CuinterposeCUDACheckpointPath}, main.Command,
+		"the opted-in target is launched through the cuda-checkpoint copied from the agent image")
+	assert.Equal(t, []string{"python3", "-m", "worker"}, main.Args[len(main.Args)-3:],
+		"the original command follows the launch-job wrapper")
+	init := requireContainer(t, job.Spec.Template.Spec.InitContainers, podcontract.CuinterposeInitContainerName)
+	assert.Equal(t, "registry.example/snapshot-agent:v1.2.3", init.Image)
+
+	t.Run("an opted-in SnapshotJob needs a configured agent image", func(t *testing.T) {
+		_, err := buildSourceJob(cuinterposeSnapshotJob())
+		require.Error(t, err)
+	})
+
+	t.Run("a SnapshotJob without the annotation is untouched", func(t *testing.T) {
+		job, err := buildSourceJobWithDelivery(minimalSnapshotJob(), testCuinterposeDelivery())
+		require.NoError(t, err)
+		assert.Empty(t, job.Spec.Template.Spec.InitContainers)
+		assert.Empty(t, requireContainer(t, job.Spec.Template.Spec.Containers, "worker").Command)
+	})
 }

--- a/operator/internal/controller/snapshotjob_podsnapshot.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -194,6 +195,20 @@ func buildPodSnapshot(sj *snapshotv1alpha1.SnapshotJob, pod *corev1.Pod) (*snaps
 	labels, annotations, err := podSnapshotTemplateMetadata(sj)
 	if err != nil {
 		return nil, err
+	}
+	// Record on the PodSnapshot whether the source ran with cuinterpose, so
+	// the restore side knows to mount the shim at its capture-time path.
+	cuinterposeEnabled, err := podcontract.CuinterposeEnabled(pod.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	if cuinterposeEnabled {
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[podcontract.CuinterposeAnnotation] = podcontract.CuinterposeAnnotationEnabled
+	} else {
+		delete(annotations, podcontract.CuinterposeAnnotation)
 	}
 	return &snapshotv1alpha1.PodSnapshot{
 		TypeMeta: metav1.TypeMeta{

--- a/operator/internal/controller/snapshotjob_podsnapshot_test.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -35,7 +36,14 @@ func TestBuildPodSnapshot(t *testing.T) {
 		Annotations: map[string]string{"dynamo.nvidia.com/gms-mode": "enabled"},
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "warm-worker-abcde", Namespace: "inference", UID: types.UID("pod-uid")},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-worker-abcde",
+			Namespace: "inference",
+			UID:       types.UID("pod-uid"),
+			Annotations: map[string]string{
+				podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+			},
+		},
 	}
 
 	snap, err := buildPodSnapshot(sj, pod)
@@ -54,6 +62,10 @@ func TestBuildPodSnapshot(t *testing.T) {
 	t.Run("propagates caller metadata", func(t *testing.T) {
 		assert.Equal(t, "abc123", snap.Labels["dynamo.nvidia.com/worker-generation"])
 		assert.Equal(t, "enabled", snap.Annotations["dynamo.nvidia.com/gms-mode"])
+	})
+
+	t.Run("records cuinterpose for restore", func(t *testing.T) {
+		assert.Equal(t, podcontract.CuinterposeAnnotationEnabled, snap.Annotations[podcontract.CuinterposeAnnotation])
 	})
 
 	t.Run("pins the source pod name and UID", func(t *testing.T) {
@@ -800,4 +812,16 @@ func TestMapPodSnapshotToSnapshotJob(t *testing.T) {
 func TestSnapshotJobOwnerFromPodSnapshotObjRejectsWrongType(t *testing.T) {
 	_, err := snapshotJobOwnerFromPodSnapshotObj(&corev1.Pod{})
 	require.Error(t, err)
+}
+
+func TestBuildPodSnapshotRejectsInvalidCuinterposeAnnotation(t *testing.T) {
+	sj := minimalSnapshotJob()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "warm-worker-abcde", Namespace: "inference", UID: types.UID("pod-uid"),
+			Annotations: map[string]string{podcontract.CuinterposeAnnotation: "true"},
+		},
+	}
+	_, err := buildPodSnapshot(sj, pod)
+	require.Error(t, err, "an unrecognized value must not silently produce a PodSnapshot without the shim recorded")
 }

--- a/operator/internal/controller/snapshotjob_reconciler.go
+++ b/operator/internal/controller/snapshotjob_reconciler.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -56,6 +57,9 @@ type SnapshotJobReconciler struct {
 	client.Client
 	NonCacheReadClient client.Reader
 	Recorder           record.EventRecorder
+	// Cuinterpose says where the CUDA interposer shim is delivered from when a
+	// SnapshotJob opts in (podcontract.CuinterposeAnnotation).
+	Cuinterpose podcontract.CuinterposeDelivery
 }
 
 type snapshotJobFailure struct {
@@ -146,7 +150,7 @@ func (r *SnapshotJobReconciler) reconcileResources(ctx context.Context, sj *snap
 			}
 			return r.reconcileAcceptedSourceJob(ctx, sj, authoritativeJob)
 		}
-		desiredJob, buildErr := buildSourceJob(sj)
+		desiredJob, buildErr := buildSourceJobWithDelivery(sj, r.Cuinterpose)
 		if buildErr != nil {
 			return terminalObservation(snapshotv1alpha1.ReasonInvalidSpec, buildErr), ctrl.Result{}, nil
 		}

--- a/operator/internal/controller/snapshotjob_reconciler_test.go
+++ b/operator/internal/controller/snapshotjob_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -785,4 +786,57 @@ func TestSnapshotJobReconcileSkipsTerminalAndDeleted(t *testing.T) {
 		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "inference", Name: "gone"}})
 		require.NoError(t, err)
 	})
+}
+
+func TestSnapshotJobReconcileRejectsUnshapedJobWhenCuinterposeEnabled(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := cuinterposeSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	// A Job created by an operator that had no agent image: the Pod template is
+	// annotated but carries none of the capture contract.
+	plain := sj.DeepCopy()
+	delete(plain.Spec.PodTemplate.Annotations, podcontract.CuinterposeAnnotation)
+	job, err := buildSourceJob(plain)
+	require.NoError(t, err)
+	job.Spec.Template.Annotations = map[string]string{
+		podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+	}
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.Cuinterpose = testCuinterposeDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	failed := meta.FindStatusCondition(updated.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
+	require.NotNil(t, failed, "adopting a Job without the shim would checkpoint without interposition")
+	assert.Equal(t, snapshotv1alpha1.ReasonJobNameConflict, failed.Reason)
+	assert.Contains(t, failed.Message, "cuinterpose capture contract")
+	assert.Empty(t, updated.Status.SourceJobUID)
+}
+
+func TestSnapshotJobReconcileAdoptsShapedJobWhenCuinterposeEnabled(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := cuinterposeSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	job, err := buildSourceJobWithDelivery(sj, testCuinterposeDelivery())
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.Cuinterpose = testCuinterposeDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	assert.Equal(t, job.UID, updated.Status.SourceJobUID, "a correctly shaped Job is adopted")
 }

--- a/operator/internal/controller/snapshotjob_source_job.go
+++ b/operator/internal/controller/snapshotjob_source_job.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -49,7 +50,7 @@ func (r *SnapshotJobReconciler) observeExistingSourceJob(ctx context.Context, sj
 // reconcileExistingSourceJob applies the one-shot Job identity gate shared by
 // steady-state reconciliation and Create-AlreadyExists recovery.
 func (r *SnapshotJobReconciler) reconcileExistingSourceJob(ctx context.Context, sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Job) (snapshotJobObservation, ctrl.Result, error) {
-	if failure := classifyExistingSourceJob(sj, job); failure != nil {
+	if failure := r.classifyExistingSourceJob(sj, job); failure != nil {
 		return snapshotJobObservation{failure: failure}, ctrl.Result{}, nil
 	}
 	return r.reconcileAcceptedSourceJob(ctx, sj, job)
@@ -74,7 +75,7 @@ func (r *SnapshotJobReconciler) readAuthoritativeSourceJob(ctx context.Context, 
 		}
 		return nil, nil, err
 	}
-	if failure := classifyExistingSourceJob(sj, job); failure != nil {
+	if failure := r.classifyExistingSourceJob(sj, job); failure != nil {
 		return job, failure, nil
 	}
 	return job, nil, nil
@@ -88,7 +89,10 @@ func sourceJobDeletedFailure(sj *snapshotv1alpha1.SnapshotJob) *snapshotJobFailu
 }
 
 // classifyExistingSourceJob validates ownership and one-shot Job identity.
-func classifyExistingSourceJob(sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Job) *snapshotJobFailure {
+func (r *SnapshotJobReconciler) classifyExistingSourceJob(
+	sj *snapshotv1alpha1.SnapshotJob,
+	job *batchv1.Job,
+) *snapshotJobFailure {
 	if !metav1.IsControlledBy(job, sj) {
 		return &snapshotJobFailure{
 			reason: snapshotv1alpha1.ReasonJobNameConflict,
@@ -106,7 +110,7 @@ func classifyExistingSourceJob(sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Jo
 		return nil
 	}
 
-	desired, err := buildSourceJob(sj)
+	desired, err := buildSourceJobWithDelivery(sj, r.Cuinterpose)
 	if err != nil {
 		return &snapshotJobFailure{reason: snapshotv1alpha1.ReasonInvalidSpec, cause: err}
 	}
@@ -119,6 +123,21 @@ func classifyExistingSourceJob(sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Jo
 			reason: snapshotv1alpha1.ReasonJobNameConflict,
 			cause: fmt.Errorf("existing source Job %q does not carry the immutable identity expected for this SnapshotJob",
 				job.Name),
+		}
+	}
+	// A Job created before cuinterpose was configured, or by an operator
+	// without --agent-image, carries none of the capture contract even though
+	// its Pod is annotated. Adopting it would produce a checkpoint whose
+	// PodSnapshot claims interposition that never happened.
+	if enabled, err := podcontract.CuinterposeEnabled(desired.Spec.Template.Annotations); err == nil && enabled {
+		if err := podcontract.VerifyCuinterposeCapture(
+			&job.Spec.Template.Spec,
+			sj.Spec.PodSnapshotTemplate.TargetContainers,
+		); err != nil {
+			return &snapshotJobFailure{
+				reason: snapshotv1alpha1.ReasonJobNameConflict,
+				cause:  fmt.Errorf("existing source Job %q lacks the cuinterpose capture contract: %w", job.Name, err),
+			}
 		}
 	}
 	return nil

--- a/operator/internal/protocol/source_job.go
+++ b/operator/internal/protocol/source_job.go
@@ -87,13 +87,9 @@ func NewSourceJob(podTemplate *corev1.PodTemplateSpec, opts SourceJobOptions) (*
 	targetContainer.StartupProbe = nil
 
 	if opts.WrapLaunchJob {
-		if len(targetContainer.Command) == 0 {
-			return nil, fmt.Errorf("source job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
+		if err := podcontract.EnsureCUDACheckpointLaunchJob(targetContainer, "cuda-checkpoint"); err != nil {
+			return nil, fmt.Errorf("source job: %w", err)
 		}
-		targetContainer.Command, targetContainer.Args = wrapWithCudaCheckpointLaunchJob(
-			targetContainer.Command,
-			targetContainer.Args,
-		)
 	}
 
 	return &batchv1.Job{
@@ -143,30 +139,4 @@ func DisableSidecarInjection(annotations map[string]string) map[string]string {
 	annotations[linkerdInjectAnnotation] = linkerdInjectDisabled
 	annotations[istioSidecarInjectAnnotation] = istioSidecarInjectDisabled
 	return annotations
-}
-
-// wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the
-// workload is launched under `cuda-checkpoint --launch-job`, required for
-// multi-GPU checkpoints. The launch-job file is copied from its transient
-// procfs FD into the per-pod snapshot control volume before the original
-// command starts. The workload inherits that stable path, while the snapshot
-// agent stages the capture-time contents into the content-owned artifact.
-func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	const persistJobFileScript = `set -eu
-job_file="$1"
-shift
-if [ -z "${CUDA_CHECKPOINT_JOB_FILE:-}" ]; then
-    echo "CUDA_CHECKPOINT_JOB_FILE is missing; cuda-checkpoint --launch-job requires NVIDIA driver 610 or newer" >&2
-    exit 1
-fi
-umask 077
-cat "$CUDA_CHECKPOINT_JOB_FILE" > "$job_file"
-export CUDA_CHECKPOINT_JOB_FILE="$job_file"
-exec "$@"`
-
-	wrappedArgs := make([]string, 0, len(command)+len(args)+7)
-	wrappedArgs = append(wrappedArgs, "--launch-job", "/bin/sh", "-c", persistJobFileScript, "dynamo-cuda-checkpoint", podcontract.CUDAJobFilePath)
-	wrappedArgs = append(wrappedArgs, command...)
-	wrappedArgs = append(wrappedArgs, args...)
-	return []string{"cuda-checkpoint"}, wrappedArgs
 }

--- a/operator/internal/protocol/source_job_identity_test.go
+++ b/operator/internal/protocol/source_job_identity_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ai-dynamo/snapshot/api/podcontract"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
@@ -25,10 +26,14 @@ func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, args := wrapWithCudaCheckpointLaunchJob(
-		[]string{"/bin/sh", "-c"},
-		[]string{`printf '%s' "$CUDA_CHECKPOINT_JOB_FILE" > "$1"`, "workload", observedEnvironment},
-	)
+	container := &corev1.Container{
+		Command: []string{"/bin/sh", "-c"},
+		Args:    []string{`printf '%s' "$CUDA_CHECKPOINT_JOB_FILE" > "$1"`, "workload", observedEnvironment},
+	}
+	if err := podcontract.EnsureCUDACheckpointLaunchJob(container, "cuda-checkpoint"); err != nil {
+		t.Fatal(err)
+	}
+	args := container.Args
 	args[5] = stableJobFile
 	cmd := exec.Command(args[1], args[2:]...)
 	cmd.Env = append(os.Environ(), "CUDA_CHECKPOINT_JOB_FILE="+transientJobFile)
@@ -60,7 +65,11 @@ func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
 }
 
 func TestCudaCheckpointLaunchJobWrapperReportsMissingJobFile(t *testing.T) {
-	_, args := wrapWithCudaCheckpointLaunchJob([]string{"/bin/true"}, nil)
+	container := &corev1.Container{Command: []string{"/bin/true"}}
+	if err := podcontract.EnsureCUDACheckpointLaunchJob(container, "cuda-checkpoint"); err != nil {
+		t.Fatal(err)
+	}
+	args := container.Args
 	cmd := exec.Command(args[1], args[2:]...)
 	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION

## Summary

First of eight pull requests that add **cuinterpose**, the CUDA interposer that lets Snapshot checkpoint and restore CUDA memory shared between processes (tensor-parallel workers, NCCL, FlashInfer, PyTorch symmetric memory) and CUDA multicast objects. Design: `docs/reference/cuinterpose.md` (lands in the last PR).

This is the only PR that touches Go, the chart, the Dockerfile, or the Makefile. Everything above it adds C under `agent/cmd/cuinterpose`.

- `api/podcontract/cuinterpose.go`: `CuinterposeEnabled` (annotation `nvidia.com/cuinterpose: enabled`), `ShapeCuinterposeCapture` (init container copying `libcuinterpose.so` and `cuda-checkpoint` out of the agent image into an emptyDir at `/tmp/cuinterpose`, `LD_PRELOAD`, the `cuda-checkpoint --launch-job` wrapper, pull secrets), `VerifyCuinterposeCapture` for the adoption path, `ValidateImageReference`.
- Operator: `CuinterposeDelivery{AgentImage, PullPolicy, ImagePullSecrets}` from `--agent-image`/`--agent-image-pull-secrets`; SnapshotJob source Jobs are shaped and verified on adoption; PodSnapshots record the request. Chart: `snapshot.agentImage` helper, `cuinterpose.imagePullSecrets`, unit test.
- Agent: manifest `cuinterpose.requested`/`cuinterpose.prepared`; fail-closed detection (`CheckCuinterposeEnablement`: an annotated Pod must show a control socket for every CUDA process, an un-annotated one none); coordinator invocation with the binary opened before the mount namespace changes; stale socket unlink before CRIU; the coordinator's phase lines logged as structured fields; timing phases `cuinterpose_prepare`/`cuinterpose_restore`; restore mount of the bundle through `ns-bind-mount mount-cuinterpose-fd`. Go constants pinned to `protocol.h`; argv contract tested against a fake binary.
- Packaging: the Dockerfile's cuda-helper-builder stage installs CUDA 13.1 headers and GoogleTest and runs `make all test`; the Makefile is written once (every C file is part of the shim except `coordinator.c`; tests are found by name: `<name>_unit_test.cc`, `<name>_preload_test.cc`, `coordinator_test.cc`); `protocol.h` and `util.c` are final.
- The shim and the coordinator are placeholders that build and package and do nothing; with fail-closed detection an annotated Pod is refused until PR 5 lands. The placeholder image stage is untouched.

## Origin

Re-cut of #110 (renamed, placeholder removal dropped) plus the Go orchestration of #155 and the detection rule of #152/#165.

<details><summary>#110 feat(agent): scaffold CUDA interposer delivery (verbatim, bot blocks removed)</summary>

> ## Summary
> - establish the final `cuinterpose` source layout and build targets, with thin inert skeletons in the final filenames
> - build and package a valid no-op `libcuinterposer.so` and static no-op `cuinterposer-coordinator`
> - add the `nvidia.com/cuda-interposer: enabled` SnapshotJob opt-in; no agent-image field is added to the API
> - centralize capture shaping in `api/podcontract`: one `emptyDir` and one init container using the Helm-configured agent image
> - copy both `libcuinterposer.so` and `cuda-checkpoint` from that image, mount them only on checkpoint targets, set `LD_PRELOAD`, and wrap the target with the injected `cuda-checkpoint --launch-job`
> - record enablement on the generated `PodSnapshot`
> - restore the same executable bundle path through the fixed `ns-bind-mount` helper, without a restore init container
> - remove the obsolete placeholder image target
>
> This is layer 1 of [stack #156](https://github.com/ai-dynamo/snapshot/stack/156). It intentionally provides final packaging and file seams without CUDA interception or coordinator protocol behavior.
>
> ## Validation
> - `make check` on #110 and at stack top
> - all Go module tests on every intermediate branch
> - production CUDA-builder compile on implementation layers
> - full top-of-stack agent image build
> - POSIX forwarding test on #78
> - multicast forwarding test on #79 and final behavior test on #133

</details>

## Review threads carried

| Old thread | Raised | Disposition |
| --- | --- | --- |
| #110 Copilot `vmm_interpose.go:121`, `cuinterpose.go:121` (empty `--proc-root` on restore) | Restore invokes the coordinator with an empty proc root. | By design: on restore the coordinator runs inside the restored container's mount namespace, where the sockets are reachable directly under the control directory; the empty proc root selects that mode (`coordinator --help`, `coordinator_test`). |
| #110 Copilot `cuinterpose.go:23`, CodeRabbit `vmm_interpose.go:22`, `cuinterpose.go:22`; #78 CodeRabbit `vmm_interpose.go:51` | Constant names disagreed between description, Go, and C; the control directory was defined in several places. | Fixed: one name, `cuinterpose`, in Go, C, chart, and docs; the Go constants are pinned to `protocol.h` by a test. |
| #110 Copilot `nsrestore.go:252/255`, CodeRabbit `nsrestore.go:269`; #78 CodeRabbit `nsrestore.go:254` | The coordinator runs after `RestoreAndUnlockProcessTree`, so CUDA execution could resume before sharing is rebuilt. | Clarified, not changed: the workload is parked in its restore-complete poll loop and issues no CUDA calls until the agent writes the sentinel after the coordinator succeeds (quiescence contract, doc §6). |
| #110 CodeRabbit `cuda_interposer.go:98`, `restore_pod.go:248` | Lines over 120 characters failed `lll`. | Fixed; `make lint` passes. |
| #110 galletas1712 `agent/Dockerfile:312` (human) | "Do not merge - we need to wait for statically linked tar etc first before we can get rid of placeholder, unless all workloads we support are already on the latest glibc matching 24.04" | Done: this stack does not touch the placeholder stage; its removal stays with the separate effort. |
| #110 CodeRabbit `cuda_interposer.go:54` | Malformed image references were accepted. | Fixed: `ValidateImageReference` (OCI reference grammar) with tests. |
| #110 CodeRabbit `cuda_interposer.go:73` | Wanted digest-pinned agent images only. | Not done: tags stay allowed; the pull policy defaults to `Always` for tags and `IfNotPresent` for digests. |
| #110 CodeRabbit `snapshotjob_source_job.go:112` | Adoption of an existing Job did not verify the interposer shape. | Fixed: `VerifyCuinterposeCapture` on adoption compares the init container by name, image, and command, the volume, mount, `LD_PRELOAD`, and the launch-job command. |
| #110 CodeRabbit `cuda_interposer.go:297` (static analysis) | Notes on the shaping helper. | Superseded: the shaping was rewritten (`ShapeCuinterposeCapture`, `VerifyCuinterposeCapture`) with table-driven tests. |
| #78 Copilot `snapshotctl/checkpoint.go:97`, CodeRabbit `snapshotctl/checkpoint.go:97/174`, `protocol/checkpoint.go:168` | `snapshotctl --cuda-vmm-interpose` command rewriting lacked tests; `SPT_NOENV` handling. | Not carried: command rewriting lives in `api/podcontract`, where it is tested; `snapshotctl` is untouched. |
| #78 CodeRabbit `vmm_interpose.go:38/74`, `checkpoint.go:288` | Detection inconsistencies; a counter computed but never enforced; prepare excluded from timings. | Superseded: detection is the fail-closed truth table in `CheckCuinterposeEnablement`; `cuinterpose_prepare` and `cuinterpose_restore` are timing phases. |
| #78 CodeRabbit `agent/Dockerfile:386`, Copilot `agent/Dockerfile:383/110` | A launcher script was described but not shipped; sources copied file by file. | Superseded/fixed: no launcher script (the podcontract wraps the command with `cuda-checkpoint --launch-job`); `COPY cmd/cuinterpose/` with a `.dockerignore`. |

## Validation

- Fake-driver suites (GoogleTest, AddressSanitizer + UndefinedBehaviorSanitizer) run in the agent image build against CUDA 13.1 headers at every layer of the stack; at the top: proto 22, table 3, forward 12, coordinator 12, state 14, lifecycle 4, multicast 6, no sanitizer reports.
- `go test ./...` in `api`, `operator`, `agent`; `make lint`, `make helm-lint`, `make verify-license-headers`.
- Agent image built from the top of the stack and deployed on nscale-dev (B200, kernel driver 595.58.03) with this chart.
- GPU tests (two B200s, `cuda-checkpoint --launch-job`): POSIX round trip with seeded 1 GiB carriers per rank, multicast round trip with PyTorch's multimem all-reduce and a `cuMulticastBindAddr` rebind, refusal while a raw import is alive: 3 passed. Host-carrier restore phase 87 to 108 GB/s aggregate over two GPUs (pinned-copy baseline 55 GB/s per GPU).
- End to end: vLLM 0.27.1 `AsyncLLM`, Qwen3-0.6B, tensor parallel 2, FlashInfer TRT-LLM attention and fused allreduce (`trtllm` backend), PodSnapshot of a Deployment shaped with `podcontract.ShapeCuinterposeCapture`, then restore: checkpoint 52 s (CRIU dump 49 s, cuinterpose prepare 0.43 s; 4 CUDA processes, 1052 records, 382 host carriers, 2.08 GB); restore 5.7 s (cuinterpose 0.35 s: carriers 0.05 s, unicast 0.09 s, multicast 0.18 s); the restored replica answers coherently ("The capital of Italy is Rome").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
