### PR TITLE
feat(agent): checkpoint and restore POSIX CUDA VMM state

### DIFF
--- a/agent/cmd/cuinterpose/context.c
+++ b/agent/cmd/cuinterpose/context.c
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "context.h"
+
+#include <string.h>
+
+#include "symbols.h"
+
+typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+typedef CUresult(CUDAAPI* context_set_fn)(CUcontext);
+typedef CUresult(CUDAAPI* primary_retain_fn)(CUcontext*, CUdevice);
+typedef CUresult(CUDAAPI* primary_release_fn)(CUdevice);
+
+void
+cuinterpose_capture_context(CUcontext* context)
+{
+  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
+  CUcontext current = NULL;
+
+  *context = get_current != NULL && get_current(&current) == CUDA_SUCCESS ? current : NULL;
+}
+
+static void
+release_primary(struct cuinterpose_context_scope* scope)
+{
+  primary_release_fn release = (primary_release_fn)cuinterpose_lookup_real_symbol("cuDevicePrimaryCtxRelease_v2");
+
+  if (scope->retained_primary && release != NULL)
+    (void)release(scope->primary_device);
+  scope->retained_primary = false;
+}
+
+int
+cuinterpose_enter_context(CUcontext context, CUdevice fallback_device, struct cuinterpose_context_scope* scope)
+{
+  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
+  context_set_fn set_current = (context_set_fn)cuinterpose_lookup_real_symbol("cuCtxSetCurrent");
+
+  memset(scope, 0, sizeof(*scope));
+  if (get_current == NULL || set_current == NULL)
+    return -1;
+  if (context == NULL) {
+    primary_retain_fn retain = (primary_retain_fn)cuinterpose_lookup_real_symbol("cuDevicePrimaryCtxRetain");
+
+    if (retain == NULL || fallback_device == CUINTERPOSE_NO_DEVICE || retain(&context, fallback_device) != CUDA_SUCCESS ||
+        context == NULL)
+      return -1;
+    scope->retained_primary = true;
+    scope->primary_device = fallback_device;
+  }
+  if (get_current(&scope->previous) != CUDA_SUCCESS) {
+    release_primary(scope);
+    return -1;
+  }
+  if (scope->previous != context) {
+    if (set_current(context) != CUDA_SUCCESS) {
+      release_primary(scope);
+      return -1;
+    }
+    scope->changed = true;
+  }
+  return 0;
+}
+
+int
+cuinterpose_leave_context(struct cuinterpose_context_scope* scope)
+{
+  context_set_fn set_current = (context_set_fn)cuinterpose_lookup_real_symbol("cuCtxSetCurrent");
+  int result = !scope->changed || (set_current != NULL && set_current(scope->previous) == CUDA_SUCCESS) ? 0 : -1;
+
+  release_primary(scope);
+  return result;
+}

--- a/agent/cmd/cuinterpose/context.h
+++ b/agent/cmd/cuinterpose/context.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_CONTEXT_H
+#define CUINTERPOSE_CONTEXT_H
+
+#include <cuda.h>
+#include <stdbool.h>
+
+/*
+ * Driver calls that act on an allocation or a multicast object must run in the
+ * CUDA context it belongs to. The shim remembers that context when it can
+ * (create, import, first map or export) and switches to it for the duration
+ * of a scope during checkpoint and restore, switching back afterwards.
+ */
+
+#define CUINTERPOSE_NO_DEVICE ((CUdevice)-1)
+
+struct cuinterpose_context_scope {
+  CUcontext previous;
+  bool changed;
+  bool retained_primary; /* the device's primary context was retained for this scope */
+  CUdevice primary_device;
+};
+
+/* Remembers the current context, or NULL when there is none. */
+void cuinterpose_capture_context(CUcontext* context);
+
+/*
+ * Makes `context` current. When it is NULL (the object never had a context)
+ * and fallback_device is a real device, that device's primary context is
+ * retained for the scope and released on leave. Returns -1 on failure.
+ */
+int cuinterpose_enter_context(
+    CUcontext context, CUdevice fallback_device, struct cuinterpose_context_scope* scope);
+int cuinterpose_leave_context(struct cuinterpose_context_scope* scope);
+
+#endif

--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -114,7 +114,12 @@ struct carrier_job {
   struct allocation* allocations;
   uint16_t operation;
   int result;
+  uint32_t copy_us; /* the shim's own timing of its copies */
 };
+
+/* Longest copy time any participant reported in the last carrier phase; the
+ * participants copy concurrently, so this is the copy's share of the phase. */
+static uint32_t last_carrier_copy_us;
 
 static int
 connect_endpoint(const char* endpoint)
@@ -809,7 +814,7 @@ done:
 static int
 exchange_carrier(
     struct participant* participant, uint16_t operation, const uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE],
-    uint64_t size)
+    uint64_t size, uint32_t* copy_us)
 {
   struct cuinterpose_header request;
   struct cuinterpose_header response;
@@ -830,11 +835,18 @@ exchange_carrier(
     goto done;
   if (response_fd >= 0 || !cuinterpose_header_strings_terminated(&response) || response.magic != CUINTERPOSE_MAGIC ||
       response.version != CUINTERPOSE_VERSION || response.operation != operation || response.status != 0 ||
-      response.count != 0 || response.payload_size != 0 || strcmp(response.participant_id, participant->id) != 0) {
+      response.count != 0 || strcmp(response.participant_id, participant->id) != 0) {
     if (cuinterpose_header_strings_terminated(&response) && response.message[0] != '\0')
       fprintf(stderr, "%s: %s\n", participant->endpoint, response.message);
     goto done;
   }
+  if (response.payload_size != size) {
+    fprintf(
+        stderr, "%s: carrier transfer moved %llu bytes, expected %llu\n", participant->endpoint,
+        (unsigned long long)response.payload_size, (unsigned long long)size);
+    goto done;
+  }
+  *copy_us = response.copy_us;
   result = 0;
 done:
   if (response_fd >= 0)
@@ -844,21 +856,26 @@ done:
   return result;
 }
 
+/*
+ * One request per participant: the shim copies every carrier allocation it
+ * owns in one batch (all copies issued on one stream, one wait), and reports
+ * the byte count in the reply's payload_size. The expected total is checked
+ * against the topology so a shim that silently skipped an allocation fails
+ * here rather than at restore.
+ */
 static void*
 run_carrier_job(void* argument)
 {
   struct carrier_job* job = argument;
   struct allocation* allocation;
+  uint64_t expected = 0;
+  uint8_t all_allocations[CUINTERPOSE_ALLOCATION_ID_SIZE] = {0};
 
-  job->result = 0;
   for (allocation = job->allocations; allocation != NULL; allocation = allocation->next) {
-    if (!allocation->host_carrier || strcmp(allocation->creator, job->participant->id) != 0)
-      continue;
-    job->result =
-        exchange_carrier(job->participant, job->operation, allocation->id, allocation->size);
-    if (job->result != 0)
-      break;
+    if (allocation->host_carrier && strcmp(allocation->creator, job->participant->id) == 0)
+      expected += allocation->size;
   }
+  job->result = exchange_carrier(job->participant, job->operation, all_allocations, expected, &job->copy_us);
   return NULL;
 }
 
@@ -873,6 +890,7 @@ transfer_host_carriers(
   size_t index;
   int result = 0;
 
+  last_carrier_copy_us = 0;
   jobs = calloc(participant_count, sizeof(*jobs));
   threads = calloc(participant_count, sizeof(*threads));
   launched = calloc(participant_count, sizeof(*launched));
@@ -902,8 +920,12 @@ transfer_host_carriers(
     launched[index] = true;
   }
   for (index = 0; index < participant_count; index++) {
-    if (launched[index] && (pthread_join(threads[index], NULL) != 0 || jobs[index].result != 0))
+    if (!launched[index])
+      continue;
+    if (pthread_join(threads[index], NULL) != 0 || jobs[index].result != 0)
       result = -1;
+    else if (jobs[index].copy_us > last_carrier_copy_us)
+      last_carrier_copy_us = jobs[index].copy_us;
   }
 done:
   free(launched);
@@ -982,9 +1004,12 @@ carrier_extra(char* buffer, size_t size, const struct allocation* allocations, c
   double ms = elapsed_ms(start);
 
   carrier_totals(allocations, &count, &bytes);
+  /* gb_per_s covers the whole phase (memory setup, copies, teardown, sockets);
+   * copy_gb_per_s is the copies alone, as timed by the slowest shim. */
   snprintf(
-      buffer, size, "carrier_count=%zu carrier_bytes=%llu gb_per_s=%.2f", count, (unsigned long long)bytes,
-      ms > 0.0 ? ((double)bytes / 1e9) / (ms / 1000.0) : 0.0);
+      buffer, size, "carrier_count=%zu carrier_bytes=%llu gb_per_s=%.2f copy_gb_per_s=%.2f", count,
+      (unsigned long long)bytes, ms > 0.0 ? ((double)bytes / 1e9) / (ms / 1000.0) : 0.0,
+      last_carrier_copy_us > 0 ? ((double)bytes / 1e9) / ((double)last_carrier_copy_us / 1e6) : 0.0);
 }
 
 /* Prepare must not start while any participant still holds an untracked import:

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -31,19 +31,24 @@
 #include "interpose.h"
 
 #include <errno.h>
+#include <dirent.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <time.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <unistd.h>
 
 #include "export.h"
+#include "context.h"
 #include "export_cache.h"
 #include "posix.h"
 #include "protocol.h"
@@ -71,7 +76,16 @@ typedef CUresult(CUDAAPI* export_fn)(
     void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
 typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
 typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
-typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+typedef CUresult(CUDAAPI* address_reserve_fn)(CUdeviceptr*, size_t, size_t, CUdeviceptr, unsigned long long);
+typedef CUresult(CUDAAPI* address_free_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* host_register_fn)(void*, size_t, unsigned int);
+typedef CUresult(CUDAAPI* host_unregister_fn)(void*);
+typedef CUresult(CUDAAPI* host_get_flags_fn)(unsigned int*, void*);
+typedef CUresult(CUDAAPI* copy_dtoh_async_fn)(void*, CUdeviceptr, size_t, CUstream);
+typedef CUresult(CUDAAPI* copy_htod_async_fn)(CUdeviceptr, const void*, size_t, CUstream);
+typedef CUresult(CUDAAPI* stream_create_fn)(CUstream*, unsigned int);
+typedef CUresult(CUDAAPI* stream_synchronize_fn)(CUstream);
+typedef CUresult(CUDAAPI* stream_destroy_fn)(CUstream);
 
 struct allocation {
   uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE];
@@ -86,6 +100,10 @@ struct allocation {
   bool shared; /* a ticket was issued (creator) or imported (importer) */
   unsigned live_handles;
   unsigned live_mappings;
+  /* Checkpoint state. */
+  bool checkpointed; /* PREPARE ran: mappings are unmapped and driver handles released */
+  void* host_carrier; /* creator: pinned host copy of the contents while checkpointed */
+  bool host_checkpointed; /* creator: the device backing was freed after copying to host */
 };
 
 struct handle {
@@ -101,10 +119,24 @@ struct mapping {
   CUmemAccessDesc access[CUINTERPOSE_MAX_ACCESS];
   size_t access_count;
   bool access_unknown; /* a driver access call failed part-way; replay cannot be trusted */
+  bool checkpointed; /* unmapped for the checkpoint; to be mapped again on restore */
 };
 
+/*
+ * Where this process is in the checkpoint/restore lifecycle. The coordinator
+ * drives the transitions; while not ACTIVE every tracked entry point answers
+ * CUDA_ERROR_NOT_READY, which is safe only because the workload is parked
+ * (see docs/reference/cuinterpose.md, "Quiescence").
+ */
 enum phase {
   PHASE_ACTIVE,
+  PHASE_CARRIERS, /* PREPARE_MULTICAST done: every creator allocation has a carrier handle */
+  PHASE_PREPARED, /* PREPARE done: nothing shared is mapped or held */
+  PHASE_CREATORS_RESTORED,
+  PHASE_UNICAST_RESTORED,
+  PHASE_MULTICAST_CREATED,
+  PHASE_MULTICAST_IMPORTED,
+  PHASE_MULTICAST_JOINED,
   PHASE_FAILED,
 };
 
@@ -124,6 +156,9 @@ static uint64_t next_logical_handle = 1;
 static _Atomic uint32_t live_raw_imports;
 static _Atomic uint32_t passthrough_creations;
 static _Atomic bool fabric_passthrough_logged;
+
+static uint8_t phase_code(void);
+static int request_export(const struct cuinterpose_posix_ticket* ticket, int* output, char* error, size_t error_size);
 
 static void
 set_failure(const char* message)
@@ -209,7 +244,7 @@ settle_allocation(struct allocation* allocation)
     result = release != NULL ? release(allocation->driver) : cuinterpose_unavailable();
     allocation->driver = 0;
   }
-  if (allocation->live_handles == 0 && allocation->live_mappings == 0) {
+  if (allocation->live_handles == 0 && allocation->live_mappings == 0 && !allocation->checkpointed) {
     /* No local reference is left, so any ticket for this allocation is dead. */
     cuinterpose_export_cache_drop(allocation->id);
     cuinterpose_table_remove(&allocations, cuinterpose_key_bytes(allocation->id));
@@ -218,12 +253,18 @@ settle_allocation(struct allocation* allocation)
   return result;
 }
 
-static int
-current_context(CUcontext* context)
+/*
+ * The driver does not need a context for cuMemCreate or
+ * cuMemImportFromShareableHandle, so neither may the shim: an allocation
+ * without a context adopts the one current at its first map or export, and if
+ * it never gets one the lifecycle code falls back to the primary context of
+ * the allocation's device (context.c).
+ */
+static void
+adopt_context(struct allocation* allocation)
 {
-  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
-
-  return get_current != NULL && get_current(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
+  if (allocation->context == NULL)
+    cuinterpose_capture_context(&allocation->context);
 }
 
 /*
@@ -279,7 +320,7 @@ cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
   stats->mappings = mappings.count;
   stats->live_raw_imports = atomic_load(&live_raw_imports);
   stats->passthrough_creations = atomic_load(&passthrough_creations);
-  stats->phase = current_phase == PHASE_ACTIVE ? CUINTERPOSE_PHASE_ACTIVE : CUINTERPOSE_PHASE_FAILED;
+  stats->phase = phase_code();
   pthread_mutex_unlock(&state_lock);
   stats->cached_exports = cuinterpose_export_cache_count();
 }
@@ -291,7 +332,983 @@ cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
 static uint8_t
 phase_code(void)
 {
-  return current_phase == PHASE_ACTIVE ? CUINTERPOSE_PHASE_ACTIVE : CUINTERPOSE_PHASE_FAILED;
+  switch (current_phase) {
+    case PHASE_ACTIVE:
+      return CUINTERPOSE_PHASE_ACTIVE;
+    case PHASE_CARRIERS:
+      return CUINTERPOSE_PHASE_PREPARING;
+    case PHASE_PREPARED:
+      return CUINTERPOSE_PHASE_PREPARED;
+    case PHASE_FAILED:
+      return CUINTERPOSE_PHASE_FAILED;
+    default:
+      return CUINTERPOSE_PHASE_RESTORING;
+  }
+}
+
+
+/* ------------------------------------------------------------------------- */
+/* Checkpoint and restore of tracked allocations. Caller holds state_lock.    */
+/*                                                                            */
+/* The sequence, driven by the coordinator across every process at once:      */
+/*   PREPARE_MULTICAST  give every creator allocation a "carrier" handle       */
+/*   SAVE_HOST_CARRIER  copy each creator allocation to pinned host memory     */
+/*   PREPARE            unmap everything shared, release every driver handle  */
+/*   (native CUDA checkpoint, CRIU dump; later CRIU restore, native restore)  */
+/*   RESTORE_HOST_CARRIER  new device memory, copy the bytes back             */
+/*   RESTORE_CREATORS   map creators' memory back where it was, re-export     */
+/*   RESTORE_IMPORTERS  fetch fresh descriptors from creators, import, remap  */
+/*   RESTORE_MULTICAST* (no multicast state in this layer)                    */
+/* ------------------------------------------------------------------------- */
+
+static int
+enter_allocation_context(const struct allocation* allocation, struct cuinterpose_context_scope* scope)
+{
+  CUdevice fallback = allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE
+                          ? (CUdevice)allocation->properties.location.id
+                          : CUINTERPOSE_NO_DEVICE;
+
+  return cuinterpose_enter_context(allocation->context, fallback, scope);
+}
+
+static int
+leave_context(struct cuinterpose_context_scope* scope)
+{
+  return cuinterpose_leave_context(scope);
+}
+
+struct allocation_list {
+  struct allocation** items;
+  size_t count;
+};
+
+static int
+collect_allocation(struct cuinterpose_key key, void* value, void* arg)
+{
+  struct allocation_list* list = arg;
+
+  (void)key;
+  list->items[list->count++] = value;
+  return 0;
+}
+
+/* Snapshot of the allocation table as an array, so callers can mutate the
+ * table while walking. Returns -1 on allocation failure. */
+static int
+list_allocations(struct allocation_list* list)
+{
+  list->count = 0;
+  list->items = calloc(allocations.count == 0 ? 1 : allocations.count, sizeof(*list->items));
+  if (list->items == NULL)
+    return -1;
+  cuinterpose_table_each(&allocations, collect_allocation, list);
+  return 0;
+}
+
+/* Every tracked creator allocation travels through a host carrier. */
+static bool
+needs_host_carrier(const struct allocation* allocation)
+{
+  return allocation->creator && allocation->properties.type == CU_MEM_ALLOCATION_TYPE_PINNED &&
+         allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE;
+}
+
+static struct cuinterpose_record*
+inspect_records(uint32_t* count, const char** error)
+{
+  struct cuinterpose_record* records;
+  struct cuinterpose_record* record;
+  struct allocation_list list;
+  size_t total;
+  size_t index;
+
+  *error = NULL;
+  total = allocations.count + mappings.count;
+  if (total > CUINTERPOSE_MAX_RECORDS) {
+    *error = "too many tracked records for one participant";
+    return NULL;
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate inspect records";
+    return NULL;
+  }
+  records = calloc(total == 0 ? 1 : total, sizeof(*records));
+  if (records == NULL) {
+    free(list.items);
+    *error = "cannot allocate inspect records";
+    return NULL;
+  }
+  record = records;
+  for (index = 0; index < list.count; index++) {
+    const struct allocation* allocation = list.items[index];
+
+    record->kind = CUINTERPOSE_ALLOCATION;
+    if (allocation->creator)
+      record->flags |= CUINTERPOSE_CREATOR;
+    if (allocation->live_handles != 0)
+      record->flags |= CUINTERPOSE_APPLICATION_HANDLE_LIVE;
+    if (needs_host_carrier(allocation))
+      record->flags |= CUINTERPOSE_HOST_CARRIER;
+    if (allocation->creator && !allocation->shared)
+      record->flags |= CUINTERPOSE_CARRIER_ONLY;
+    memcpy(record->allocation_id, allocation->id, sizeof(record->allocation_id));
+    record->allocation_size = allocation->size;
+    record->allocation_type = allocation->properties.type;
+    record->requested_handle_types = allocation->properties.requestedHandleTypes;
+    record->allocation_location_type = allocation->properties.location.type;
+    record->allocation_location_id = allocation->properties.location.id;
+    record->application_handle_count = allocation->live_handles;
+    record++;
+  }
+  free(list.items);
+  for (index = 0; index < mappings.count; index++) {
+    const struct mapping* mapping = mappings.items[index].value;
+    size_t access;
+
+    if (mapping->access_unknown) {
+      free(records);
+      *error = "a mapping's access state is unknown after a failed cuMemSetAccess";
+      return NULL;
+    }
+    record->kind = CUINTERPOSE_MAPPING;
+    record->flags = mapping->allocation->creator ? CUINTERPOSE_CREATOR : 0;
+    memcpy(record->allocation_id, mapping->allocation->id, sizeof(record->allocation_id));
+    record->address = mapping->address;
+    record->size = mapping->size;
+    record->offset = mapping->offset;
+    record->access_count = (uint32_t)mapping->access_count;
+    for (access = 0; access < mapping->access_count; access++) {
+      record->access[access].location_type = mapping->access[access].location.type;
+      record->access[access].location_id = mapping->access[access].location.id;
+      record->access[access].flags = mapping->access[access].flags;
+    }
+    record++;
+  }
+  *count = (uint32_t)total;
+  return records;
+}
+
+/*
+ * PREPARE_MULTICAST, unicast part: make sure every creator allocation has a
+ * driver handle to work with. A creator that released its handles but still
+ * has a mapping gets one back through cuMemRetainAllocationHandle.
+ */
+static int
+create_carriers(const char** error)
+{
+  retain_fn retain = (retain_fn)cuinterpose_lookup_real_symbol("cuMemRetainAllocationHandle");
+  struct allocation_list list;
+  size_t index;
+
+  if (retain == NULL) {
+    *error = "cuMemRetainAllocationHandle is unavailable";
+    return -1;
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t range;
+    CUresult result = CUDA_ERROR_INVALID_VALUE;
+
+    if (!allocation->creator || allocation->driver != 0)
+      continue;
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    for (range = 0; range < mappings.count; range++) {
+      const struct mapping* mapping = mappings.items[range].value;
+      if (mapping->allocation == allocation) {
+        result = retain(&allocation->driver, (void*)(uintptr_t)mapping->address);
+        break;
+      }
+    }
+    if (leave_context(&scope) != 0 || result != CUDA_SUCCESS) {
+      free(list.items);
+      *error = "cannot retain a carrier handle for a creator allocation";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Host carriers                                                              */
+/* ------------------------------------------------------------------------- */
+
+/*
+ * Every creator allocation's contents cross to the host before the native
+ * checkpoint and back after the native restore. Why: the r615 driver attaches
+ * fabric (FLA) state to device allocations at creation and does not rebuild
+ * it on restore, so an allocation restored natively cannot be exported again;
+ * creating a fresh allocation on restore and copying the bytes back avoids
+ * that.
+ *
+ * The host side is one pinned arena per process: a single anonymous mapping,
+ * pinned with one cuMemHostRegister, that CRIU saves as ordinary process
+ * memory. The device side is one staging range per CUDA context with every
+ * allocation mapped at consecutive offsets. One registration and one range
+ * instead of one per allocation matters: vLLM's allocator hands out hundreds
+ * of 2 MiB pieces, and pinning, mapping, and unpinning each one separately
+ * costs more than the copies. All copies are issued asynchronously on one
+ * stream per context and waited for once, so the transfer runs at the link's
+ * speed; the copy time is reported apart from the phase as a whole, and the
+ * arena is unpinned only after the restore reply has gone out.
+ */
+struct carrier_arena {
+  void* base;
+  size_t size;
+  CUcontext context; /* where it was registered; the deferred unregister enters it again */
+  CUdevice device; /* fallback when that context is NULL */
+};
+
+static struct carrier_arena arena;
+
+struct staging_range {
+  CUdeviceptr base;
+  size_t size;
+};
+
+static double
+elapsed_milliseconds(const struct timespec* start, const struct timespec* end)
+{
+  return (double)(end->tv_sec - start->tv_sec) * 1e3 + (double)(end->tv_nsec - start->tv_nsec) / 1e6;
+}
+
+static int
+compare_by_context(const void* left, const void* right)
+{
+  uintptr_t a = (uintptr_t)(*(struct allocation* const*)left)->context;
+  uintptr_t b = (uintptr_t)(*(struct allocation* const*)right)->context;
+
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/* The allocations `wanted` selects, sorted by context so each context is entered once. */
+static int
+collect_carriers(bool (*wanted)(const struct allocation*), struct allocation_list* list, uint64_t* total)
+{
+  size_t kept = 0;
+  size_t index;
+
+  *total = 0;
+  if (list_allocations(list) != 0)
+    return -1;
+  for (index = 0; index < list->count; index++) {
+    if (wanted(list->items[index])) {
+      list->items[kept++] = list->items[index];
+      *total += list->items[index]->size;
+    }
+  }
+  list->count = kept;
+  qsort(list->items, list->count, sizeof(*list->items), compare_by_context);
+  return 0;
+}
+
+static bool
+wants_saving(const struct allocation* allocation)
+{
+  return needs_host_carrier(allocation) && allocation->host_carrier == NULL;
+}
+
+static bool
+wants_restoring(const struct allocation* allocation)
+{
+  return allocation->host_checkpointed;
+}
+
+/* End of the run of allocations sharing list->items[begin]'s context; *bytes gets their sum. */
+static size_t
+context_batch_end(const struct allocation_list* list, size_t begin, uint64_t* bytes)
+{
+  size_t end = begin;
+
+  *bytes = 0;
+  while (end < list->count && list->items[end]->context == list->items[begin]->context) {
+    *bytes += list->items[end]->size;
+    end++;
+  }
+  return end;
+}
+
+/*
+ * Reserves one range and maps handles[i] at consecutive offsets with read/write
+ * access for each allocation's device. Nothing stays mapped on failure.
+ */
+static CUresult
+map_staging_range(
+    struct allocation* const* items, const CUmemGenericAllocationHandle* handles, size_t count, size_t total,
+    struct staging_range* range)
+{
+  address_reserve_fn reserve = (address_reserve_fn)cuinterpose_lookup_real_symbol("cuMemAddressReserve");
+  address_free_fn free_address = (address_free_fn)cuinterpose_lookup_real_symbol("cuMemAddressFree");
+  map_fn map = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  access_fn set_access = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  size_t offset = 0;
+  size_t mapped = 0;
+  size_t index;
+  CUresult result;
+
+  range->base = 0;
+  range->size = 0;
+  if (reserve == NULL || free_address == NULL || map == NULL || unmap == NULL || set_access == NULL)
+    return CUDA_ERROR_NOT_INITIALIZED;
+  result = reserve(&range->base, total, 0, 0, 0);
+  if (result != CUDA_SUCCESS) {
+    range->base = 0;
+    return result;
+  }
+  for (index = 0; index < count; index++) {
+    CUmemAccessDesc access;
+
+    result = map(range->base + offset, items[index]->size, 0, handles[index], 0);
+    if (result != CUDA_SUCCESS)
+      break;
+    mapped = offset + items[index]->size;
+    memset(&access, 0, sizeof(access));
+    access.location = items[index]->properties.location;
+    access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    result = set_access(range->base + offset, items[index]->size, &access, 1);
+    if (result != CUDA_SUCCESS)
+      break;
+    offset = mapped;
+  }
+  if (result != CUDA_SUCCESS) {
+    if (mapped != 0)
+      (void)unmap(range->base, mapped);
+    (void)free_address(range->base, total);
+    range->base = 0;
+    return result;
+  }
+  range->size = total;
+  return CUDA_SUCCESS;
+}
+
+static void
+unmap_staging_range(struct staging_range* range)
+{
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  address_free_fn free_address = (address_free_fn)cuinterpose_lookup_real_symbol("cuMemAddressFree");
+
+  if (range->base == 0)
+    return;
+  if (unmap != NULL)
+    (void)unmap(range->base, range->size);
+  if (free_address != NULL)
+    (void)free_address(range->base, range->size);
+  range->base = 0;
+  range->size = 0;
+}
+
+/*
+ * SAVE_HOST_CARRIER. Returns the bytes copied through *bytes and the time the
+ * copies took through *copy_us. On failure nothing is left pinned or recorded.
+ */
+static int
+save_host_carriers(uint64_t* bytes, uint32_t* copy_us, const char** error)
+{
+  host_register_fn register_host = (host_register_fn)cuinterpose_lookup_real_symbol("cuMemHostRegister_v2");
+  host_unregister_fn unregister_host = (host_unregister_fn)cuinterpose_lookup_real_symbol("cuMemHostUnregister");
+  copy_dtoh_async_fn copy = (copy_dtoh_async_fn)cuinterpose_lookup_real_symbol("cuMemcpyDtoHAsync_v2");
+  stream_create_fn stream_create = (stream_create_fn)cuinterpose_lookup_real_symbol("cuStreamCreate");
+  stream_synchronize_fn stream_synchronize =
+      (stream_synchronize_fn)cuinterpose_lookup_real_symbol("cuStreamSynchronize");
+  stream_destroy_fn stream_destroy = (stream_destroy_fn)cuinterpose_lookup_real_symbol("cuStreamDestroy_v2");
+  struct allocation_list list = {NULL, 0};
+  struct cuinterpose_context_scope scope;
+  struct staging_range range = {0, 0};
+  CUmemGenericAllocationHandle* handles = NULL;
+  CUstream stream = NULL;
+  void* base = MAP_FAILED;
+  uint64_t total = 0;
+  size_t placed = 0;
+  size_t begin;
+  size_t end;
+  size_t index;
+  double copy_time = 0.0;
+  bool entered = false;
+  bool registered = false;
+  int result = -1;
+
+  *bytes = 0;
+  *copy_us = 0;
+  *error = "host carrier symbols are unavailable";
+  if (register_host == NULL || unregister_host == NULL || copy == NULL || stream_create == NULL ||
+      stream_synchronize == NULL || stream_destroy == NULL)
+    return -1;
+  *error = "cannot allocate";
+  if (collect_carriers(wants_saving, &list, &total) != 0)
+    return -1;
+  for (index = 0; index < list.count; index++) {
+    if (list.items[index]->driver == 0) {
+      *error = "creator allocation has no carrier handle";
+      goto done;
+    }
+  }
+  if (list.count == 0) {
+    result = 0;
+    *error = NULL;
+    goto done;
+  }
+  if (arena.base != NULL) {
+    *error = "a host carrier arena already exists";
+    goto done;
+  }
+  handles = calloc(list.count, sizeof(*handles));
+  if (handles == NULL)
+    goto done;
+  /* Populate up front: the pages have to exist before they can be pinned, and
+   * faulting them in one call beats faulting them one by one while pinning. */
+  base = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
+  if (base == MAP_FAILED) {
+    *error = "cannot allocate host carrier memory";
+    goto done;
+  }
+  for (begin = 0; begin < list.count; begin = end) {
+    struct timespec started;
+    struct timespec finished;
+    uint64_t batch_bytes;
+    size_t offset = 0;
+
+    end = context_batch_end(&list, begin, &batch_bytes);
+    if (enter_allocation_context(list.items[begin], &scope) != 0) {
+      *error = "cannot enter the allocation's CUDA context";
+      goto done;
+    }
+    entered = true;
+    if (!registered) {
+      /* Pinned once, as portable memory, so every context can copy from it. */
+      if (register_host(base, total, CU_MEMHOSTREGISTER_PORTABLE) != CUDA_SUCCESS) {
+        *error = "cannot pin host carrier memory";
+        goto done;
+      }
+      registered = true;
+      arena.context = list.items[begin]->context;
+      arena.device = list.items[begin]->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE
+                         ? (CUdevice)list.items[begin]->properties.location.id
+                         : CUINTERPOSE_NO_DEVICE;
+    }
+    for (index = begin; index < end; index++)
+      handles[index] = list.items[index]->driver;
+    if (map_staging_range(&list.items[begin], &handles[begin], end - begin, batch_bytes, &range) != CUDA_SUCCESS) {
+      *error = "cannot map creator allocations for the host copy";
+      goto done;
+    }
+    if (stream_create(&stream, CU_STREAM_NON_BLOCKING) != CUDA_SUCCESS) {
+      stream = NULL;
+      *error = "cannot create the carrier stream";
+      goto done;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &started);
+    for (index = begin; index < end; index++) {
+      struct allocation* allocation = list.items[index];
+      void* host = (char*)base + placed;
+
+      if (copy(host, range.base + offset, allocation->size, stream) != CUDA_SUCCESS) {
+        *error = "device-to-host copy failed";
+        goto done;
+      }
+      allocation->host_carrier = host;
+      placed += allocation->size;
+      offset += allocation->size;
+    }
+    if (stream_synchronize(stream) != CUDA_SUCCESS) {
+      *error = "device-to-host copies did not complete";
+      goto done;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &finished);
+    copy_time += elapsed_milliseconds(&started, &finished);
+    *bytes += batch_bytes;
+    unmap_staging_range(&range);
+    (void)stream_destroy(stream);
+    stream = NULL;
+    entered = false;
+    if (leave_context(&scope) != 0) {
+      *error = "cannot leave the allocation's CUDA context";
+      goto done;
+    }
+  }
+  for (index = 0; index < list.count; index++)
+    list.items[index]->host_checkpointed = true;
+  arena.base = base;
+  arena.size = total;
+  *copy_us = (uint32_t)(copy_time * 1e3 + 0.5);
+  result = 0;
+  *error = NULL;
+done:
+  unmap_staging_range(&range);
+  if (stream != NULL)
+    (void)stream_destroy(stream);
+  if (result != 0) {
+    /* Undo so a retry (or the failure path) sees a clean slate. */
+    if (registered) {
+      if (!entered && enter_allocation_context(list.items[0], &scope) == 0)
+        entered = true;
+      (void)unregister_host(base);
+      arena.context = NULL;
+    }
+    if (base != MAP_FAILED)
+      munmap(base, total);
+    for (index = 0; index < list.count; index++)
+      list.items[index]->host_carrier = NULL;
+  }
+  if (entered)
+    (void)leave_context(&scope);
+  free(handles);
+  free(list.items);
+  return result;
+}
+
+/*
+ * RESTORE_HOST_CARRIER: fresh device memory for every carried allocation,
+ * contents copied back from the arena. The arena itself is released by
+ * release_carrier_arena() once the reply is out; until then a failure here
+ * loses nothing.
+ */
+static int
+restore_host_carriers(uint64_t* bytes, uint32_t* copy_us, const char** error)
+{
+  create_fn create = (create_fn)cuinterpose_lookup_real_symbol("cuMemCreate");
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  host_register_fn register_host = (host_register_fn)cuinterpose_lookup_real_symbol("cuMemHostRegister_v2");
+  host_get_flags_fn host_flags = (host_get_flags_fn)cuinterpose_lookup_real_symbol("cuMemHostGetFlags");
+  copy_htod_async_fn copy = (copy_htod_async_fn)cuinterpose_lookup_real_symbol("cuMemcpyHtoDAsync_v2");
+  stream_create_fn stream_create = (stream_create_fn)cuinterpose_lookup_real_symbol("cuStreamCreate");
+  stream_synchronize_fn stream_synchronize =
+      (stream_synchronize_fn)cuinterpose_lookup_real_symbol("cuStreamSynchronize");
+  stream_destroy_fn stream_destroy = (stream_destroy_fn)cuinterpose_lookup_real_symbol("cuStreamDestroy_v2");
+  struct allocation_list list = {NULL, 0};
+  struct cuinterpose_context_scope scope;
+  struct staging_range range = {0, 0};
+  CUmemGenericAllocationHandle* fresh = NULL;
+  CUstream stream = NULL;
+  uint64_t total = 0;
+  size_t begin;
+  size_t end;
+  size_t index;
+  double copy_time = 0.0;
+  bool entered = false;
+  bool checked = false;
+  int result = -1;
+
+  *bytes = 0;
+  *copy_us = 0;
+  *error = "host carrier symbols are unavailable";
+  if (create == NULL || release == NULL || register_host == NULL || copy == NULL || stream_create == NULL ||
+      stream_synchronize == NULL || stream_destroy == NULL)
+    return -1;
+  *error = "cannot allocate";
+  if (collect_carriers(wants_restoring, &list, &total) != 0)
+    return -1;
+  if (list.count == 0) {
+    result = 0;
+    *error = NULL;
+    goto done;
+  }
+  if (arena.base == NULL) {
+    *error = "host carrier arena is missing";
+    goto done;
+  }
+  for (index = 0; index < list.count; index++) {
+    if (list.items[index]->host_carrier == NULL) {
+      *error = "host carrier is missing";
+      goto done;
+    }
+  }
+  fresh = calloc(list.count, sizeof(*fresh));
+  if (fresh == NULL)
+    goto done;
+  for (begin = 0; begin < list.count; begin = end) {
+    struct timespec started;
+    struct timespec finished;
+    uint64_t batch_bytes;
+    size_t offset = 0;
+
+    end = context_batch_end(&list, begin, &batch_bytes);
+    if (enter_allocation_context(list.items[begin], &scope) != 0) {
+      *error = "cannot enter the allocation's CUDA context";
+      goto done;
+    }
+    entered = true;
+    if (!checked) {
+      unsigned int flags = 0;
+
+      /* The arena should still be pinned after the native restore. If it is
+       * not, pin it again: a copy from pageable memory runs far below the
+       * link's speed, and this copy is in the restore hot path. */
+      if (host_flags == NULL || host_flags(&flags, arena.base) != CUDA_SUCCESS) {
+        if (register_host(arena.base, arena.size, CU_MEMHOSTREGISTER_PORTABLE) != CUDA_SUCCESS) {
+          *error = "cannot pin host carrier memory for the copy back";
+          goto done;
+        }
+        warn("host carrier registration did not survive restore; re-registered");
+      }
+      checked = true;
+      arena.context = list.items[begin]->context;
+      arena.device = list.items[begin]->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE
+                         ? (CUdevice)list.items[begin]->properties.location.id
+                         : CUINTERPOSE_NO_DEVICE;
+    }
+    for (index = begin; index < end; index++) {
+      if (create(&fresh[index], list.items[index]->size, &list.items[index]->properties, 0) != CUDA_SUCCESS) {
+        fresh[index] = 0;
+        *error = "cannot create fresh device memory for a creator allocation";
+        goto done;
+      }
+    }
+    if (map_staging_range(&list.items[begin], &fresh[begin], end - begin, batch_bytes, &range) != CUDA_SUCCESS) {
+      *error = "cannot map fresh device memory for the copy back";
+      goto done;
+    }
+    if (stream_create(&stream, CU_STREAM_NON_BLOCKING) != CUDA_SUCCESS) {
+      stream = NULL;
+      *error = "cannot create the carrier stream";
+      goto done;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &started);
+    for (index = begin; index < end; index++) {
+      const struct allocation* allocation = list.items[index];
+
+      if (copy(range.base + offset, allocation->host_carrier, allocation->size, stream) != CUDA_SUCCESS) {
+        *error = "host-to-device copy failed";
+        goto done;
+      }
+      offset += allocation->size;
+    }
+    if (stream_synchronize(stream) != CUDA_SUCCESS) {
+      *error = "host-to-device copies did not complete";
+      goto done;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &finished);
+    copy_time += elapsed_milliseconds(&started, &finished);
+    *bytes += batch_bytes;
+    unmap_staging_range(&range);
+    (void)stream_destroy(stream);
+    stream = NULL;
+    entered = false;
+    if (leave_context(&scope) != 0) {
+      *error = "cannot leave the allocation's CUDA context";
+      goto done;
+    }
+  }
+  /* Every copy landed: publish the fresh handles. */
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+
+    allocation->driver = fresh[index];
+    fresh[index] = 0;
+    allocation->host_carrier = NULL;
+    allocation->host_checkpointed = false;
+  }
+  *copy_us = (uint32_t)(copy_time * 1e3 + 0.5);
+  result = 0;
+  *error = NULL;
+done:
+  unmap_staging_range(&range);
+  if (stream != NULL)
+    (void)stream_destroy(stream);
+  if (result != 0 && fresh != NULL) {
+    for (index = 0; index < list.count; index++) {
+      if (fresh[index] != 0)
+        (void)release(fresh[index]);
+    }
+  }
+  if (entered)
+    (void)leave_context(&scope);
+  free(fresh);
+  free(list.items);
+  return result;
+}
+
+/*
+ * Unpins and frees the arena. Called after the RESTORE_HOST_CARRIER reply, so
+ * the coordinator (and the application behind it) does not wait for the
+ * unpinning of gigabytes of host memory. Runs without state_lock.
+ */
+static void
+release_carrier_arena(void)
+{
+  host_unregister_fn unregister_host = (host_unregister_fn)cuinterpose_lookup_real_symbol("cuMemHostUnregister");
+  struct cuinterpose_context_scope scope;
+  struct carrier_arena local;
+
+  pthread_mutex_lock(&state_lock);
+  local = arena;
+  memset(&arena, 0, sizeof(arena));
+  pthread_mutex_unlock(&state_lock);
+  if (local.base == NULL)
+    return;
+  if (unregister_host != NULL && cuinterpose_enter_context(local.context, local.device, &scope) == 0) {
+    (void)unregister_host(local.base);
+    (void)cuinterpose_leave_context(&scope);
+  }
+  munmap(local.base, local.size);
+}
+
+/* PREPARE: leave nothing shared mapped or held, so the native checkpoint sees
+ * only private memory. The records stay; restore rebuilds from them. */
+static int
+prepare(const char** error)
+{
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  struct allocation_list list;
+  size_t index;
+
+  if (release == NULL || unmap == NULL) {
+    *error = "driver symbols are unavailable";
+    return -1;
+  }
+  for (index = 0; index < mappings.count; index++) {
+    const struct mapping* mapping = mappings.items[index].value;
+    if (mapping->access_unknown) {
+      *error = "a mapping's access state is unknown after a failed cuMemSetAccess";
+      return -1;
+    }
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  /* Peers must not fetch descriptors that are about to be invalidated. */
+  cuinterpose_export_cache_quiesce();
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t range;
+
+    if (needs_host_carrier(allocation) && !allocation->host_checkpointed) {
+      free(list.items);
+      *error = "a creator allocation was not saved to its host carrier";
+      return -1;
+    }
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    for (range = 0; range < mappings.count; range++) {
+      struct mapping* mapping = mappings.items[range].value;
+      if (mapping->allocation != allocation || mapping->checkpointed)
+        continue;
+      if (unmap(mapping->address, mapping->size) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        free(list.items);
+        *error = "cuMemUnmap failed during prepare";
+        return -1;
+      }
+      mapping->checkpointed = true;
+    }
+    if (allocation->driver != 0) {
+      if (release(allocation->driver) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        free(list.items);
+        *error = "cuMemRelease failed during prepare";
+        return -1;
+      }
+      allocation->driver = 0;
+    }
+    allocation->checkpointed = true;
+    if (leave_context(&scope) != 0) {
+      free(list.items);
+      *error = "cannot leave the allocation's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* Map every checkpointed mapping of allocation back where it was. */
+static CUresult
+remap_allocation(struct allocation* allocation, const char** error)
+{
+  map_fn map = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  access_fn set_access = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  size_t index;
+
+  if (map == NULL || set_access == NULL) {
+    *error = "mapping symbols are unavailable";
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  for (index = 0; index < mappings.count; index++) {
+    struct mapping* mapping = mappings.items[index].value;
+    CUresult result;
+
+    if (mapping->allocation != allocation || !mapping->checkpointed)
+      continue;
+    result = map(mapping->address, mapping->size, mapping->offset, allocation->driver, 0);
+    if (result != CUDA_SUCCESS) {
+      *error = "cuMemMap failed during restore";
+      return result;
+    }
+    mapping->checkpointed = false;
+    if (mapping->access_count != 0) {
+      result = set_access(mapping->address, mapping->size, mapping->access, mapping->access_count);
+      if (result != CUDA_SUCCESS) {
+        *error = "cuMemSetAccess failed during restore";
+        return result;
+      }
+    }
+  }
+  return CUDA_SUCCESS;
+}
+
+/* Once an allocation is back, keep the driver handle only if the application
+ * still holds a logical handle; mappings keep the memory alive otherwise. */
+static int
+finish_restore(struct allocation* allocation, const char** error)
+{
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+
+  allocation->checkpointed = false;
+  if (allocation->live_handles == 0 && allocation->driver != 0) {
+    if (release == NULL || release(allocation->driver) != CUDA_SUCCESS) {
+      *error = "cuMemRelease failed during restore";
+      return -1;
+    }
+    allocation->driver = 0;
+  }
+  return 0;
+}
+
+/* RESTORE_CREATORS: creators remap and re-export. Every creator must be done
+ * before any importer asks, which the coordinator guarantees with a barrier. */
+static int
+restore_creators(const char** error)
+{
+  export_fn export_handle = (export_fn)cuinterpose_lookup_real_symbol("cuMemExportToShareableHandle");
+  struct allocation_list list;
+  size_t index;
+
+  if (export_handle == NULL) {
+    *error = "cuMemExportToShareableHandle is unavailable";
+    return -1;
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_context_scope scope;
+
+    if (!allocation->creator || !allocation->checkpointed)
+      continue;
+    if (allocation->driver == 0) {
+      free(list.items);
+      *error = "creator allocation has no device memory after restore";
+      return -1;
+    }
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    if (remap_allocation(allocation, error) != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      free(list.items);
+      return -1;
+    }
+    if (allocation->shared) {
+      int real_fd = -1;
+      if (export_handle(&real_fd, allocation->driver, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) != CUDA_SUCCESS ||
+          cuinterpose_export_cache_put(allocation->id, allocation->authorization, real_fd) != 0) {
+        if (real_fd >= 0)
+          close(real_fd);
+        (void)leave_context(&scope);
+        free(list.items);
+        *error = "cannot re-export a restored creator allocation";
+        return -1;
+      }
+    }
+    if (finish_restore(allocation, error) != 0 || leave_context(&scope) != 0) {
+      free(list.items);
+      if (*error == NULL)
+        *error = "cannot leave the allocation's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  /* Peers may fetch descriptors again. */
+  cuinterpose_export_cache_resume();
+  return 0;
+}
+
+/* RESTORE_IMPORTERS: importers fetch fresh descriptors and remap. */
+static int
+restore_importers(char* message, size_t message_size)
+{
+  import_fn import_handle = (import_fn)cuinterpose_lookup_real_symbol("cuMemImportFromShareableHandle");
+  struct allocation_list list;
+  size_t index;
+
+  if (import_handle == NULL) {
+    snprintf(message, message_size, "%s", "cuMemImportFromShareableHandle is unavailable");
+    return -1;
+  }
+  if (list_allocations(&list) != 0) {
+    snprintf(message, message_size, "%s", "cannot allocate");
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_posix_ticket ticket;
+    struct cuinterpose_context_scope scope;
+    const char* error = NULL;
+    char export_error[96];
+    int raw_fd = -1;
+    CUmemGenericAllocationHandle imported = 0;
+    CUresult result;
+
+    if (allocation->creator || !allocation->checkpointed)
+      continue;
+    memset(&ticket, 0, sizeof(ticket));
+    ticket.magic = CUINTERPOSE_POSIX_TICKET_MAGIC;
+    ticket.version = CUINTERPOSE_POSIX_TICKET_VERSION;
+    ticket.resource_kind = CUINTERPOSE_RESOURCE_UNICAST;
+    snprintf(ticket.creator_participant, sizeof(ticket.creator_participant), "%s", allocation->creator_participant);
+    memcpy(ticket.allocation_id, allocation->id, sizeof(ticket.allocation_id));
+    snprintf(ticket.creator_endpoint, sizeof(ticket.creator_endpoint), "%s", allocation->creator_endpoint);
+    memcpy(ticket.authorization, allocation->authorization, sizeof(ticket.authorization));
+    /* The creator's listener answers without any lock of its own that we hold,
+     * so the request can be made while holding state_lock. */
+    if (request_export(&ticket, &raw_fd, export_error, sizeof(export_error)) != 0) {
+      free(list.items);
+      snprintf(message, message_size, "creator export: %.70s", export_error);
+      return -1;
+    }
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      close(raw_fd);
+      free(list.items);
+      snprintf(message, message_size, "%s", "cannot enter the allocation's CUDA context");
+      return -1;
+    }
+    result = import_handle(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    close(raw_fd);
+    if (result != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      free(list.items);
+      snprintf(message, message_size, "cuMemImportFromShareableHandle failed: CUresult=%d", (int)result);
+      return -1;
+    }
+    allocation->driver = imported;
+    if (remap_allocation(allocation, &error) != CUDA_SUCCESS || finish_restore(allocation, &error) != 0 ||
+        leave_context(&scope) != 0) {
+      free(list.items);
+      snprintf(message, message_size, "%s", error != NULL ? error : "cannot leave the allocation's CUDA context");
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
 }
 
 static void
@@ -313,7 +1330,7 @@ serve(int client)
   response.live_raw_imports = atomic_load(&live_raw_imports);
   response.passthrough_creations = atomic_load(&passthrough_creations);
   response.phase = phase_code();
-  if (passed_fd >= 0 || request.payload_size != 0 || !cuinterpose_header_strings_terminated(&request) ||
+  if (passed_fd >= 0 || !cuinterpose_header_strings_terminated(&request) ||
       request.magic != CUINTERPOSE_MAGIC || request.version != CUINTERPOSE_VERSION || request.status != 0 ||
       request.count != 0 ||
       !((request.operation == CUINTERPOSE_IDENTIFY && request.participant_id[0] == '\0') ||
@@ -328,6 +1345,167 @@ serve(int client)
         cuinterpose_header_error(&response, failure);
       (void)cuinterpose_send_header(client, &response, -1);
       break;
+    case CUINTERPOSE_INSPECT: {
+      struct cuinterpose_record* records;
+      const char* error;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_ACTIVE) {
+        pthread_mutex_unlock(&state_lock);
+        cuinterpose_header_error(&response, "cuinterpose is not in the active phase");
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      records = inspect_records(&response.count, &error);
+      pthread_mutex_unlock(&state_lock);
+      if (records == NULL) {
+        cuinterpose_header_error(&response, error);
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      response.payload_size = (uint64_t)response.count * sizeof(struct cuinterpose_record);
+      if (cuinterpose_send_header(client, &response, -1) == 0 && response.payload_size != 0)
+        (void)cuinterpose_send_all(client, records, (size_t)response.payload_size);
+      free(records);
+      break;
+    }
+    case CUINTERPOSE_PREPARE_MULTICAST: {
+      const char* error = NULL;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_ACTIVE) {
+        error = "cuinterpose is not in the active phase";
+      } else if (create_carriers(&error) == 0) {
+        current_phase = PHASE_CARRIERS;
+      } else {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_SAVE_HOST_CARRIER: {
+      const char* error = NULL;
+      uint64_t bytes = 0;
+      uint32_t copy_us = 0;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_CARRIERS) {
+        error = "carriers were not created before the host copy";
+      } else if (save_host_carriers(&bytes, &copy_us, &error) != 0) {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      response.payload_size = bytes;
+      response.copy_us = copy_us;
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_PREPARE: {
+      const char* error = NULL;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_CARRIERS) {
+        error = "carriers were not created before prepare";
+      } else if (prepare(&error) == 0) {
+        current_phase = PHASE_PREPARED;
+      } else {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_RESTORE_HOST_CARRIER: {
+      const char* error = NULL;
+      uint64_t bytes = 0;
+      uint32_t copy_us = 0;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_PREPARED) {
+        error = "cuinterpose is not in the prepared phase";
+      } else if (restore_host_carriers(&bytes, &copy_us, &error) != 0) {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      response.payload_size = bytes;
+      response.copy_us = copy_us;
+      (void)cuinterpose_send_header(client, &response, -1);
+      /* Off the hot path: the coordinator has its answer and moves on. */
+      if (error == NULL)
+        release_carrier_arena();
+      break;
+    }
+    case CUINTERPOSE_RESTORE_CREATORS: {
+      const char* error = NULL;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_PREPARED) {
+        error = "cuinterpose is not in the prepared phase";
+      } else if (restore_creators(&error) == 0) {
+        current_phase = PHASE_CREATORS_RESTORED;
+      } else {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_RESTORE_IMPORTERS: {
+      char message[96] = {0};
+      bool failed = false;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_CREATORS_RESTORED) {
+        snprintf(message, sizeof(message), "%s", "creators were not restored before importers");
+        failed = true;
+      } else if (restore_importers(message, sizeof(message)) == 0) {
+        current_phase = PHASE_UNICAST_RESTORED;
+      } else {
+        set_failure(message);
+        failed = true;
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (failed)
+        cuinterpose_header_error(&response, message);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_RESTORE_MULTICAST_CREATORS:
+    case CUINTERPOSE_RESTORE_MULTICAST_IMPORTERS:
+    case CUINTERPOSE_RESTORE_MULTICAST_DEVICES:
+    case CUINTERPOSE_RESTORE_MULTICAST: {
+      /* No multicast state in this layer: each phase only advances. */
+      static const enum phase expected[] = {
+          PHASE_UNICAST_RESTORED, PHASE_MULTICAST_CREATED, PHASE_MULTICAST_IMPORTED, PHASE_MULTICAST_JOINED};
+      static const enum phase next[] = {
+          PHASE_MULTICAST_CREATED, PHASE_MULTICAST_IMPORTED, PHASE_MULTICAST_JOINED, PHASE_ACTIVE};
+      size_t step = request.operation - CUINTERPOSE_RESTORE_MULTICAST_CREATORS;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != expected[step]) {
+        pthread_mutex_unlock(&state_lock);
+        cuinterpose_header_error(&response, "multicast restore phase out of order");
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      current_phase = next[step];
+      if (current_phase == PHASE_ACTIVE)
+        failure[0] = '\0';
+      pthread_mutex_unlock(&state_lock);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
     case CUINTERPOSE_EXPORT: {
       /* A peer holding a ticket wants the real descriptor. Served from the
        * export cache only: no driver call, no state_lock. */
@@ -409,6 +1587,44 @@ control_agent(void* unused)
   }
 }
 
+/*
+ * A process that exits without running destructors (os._exit, a signal) leaves
+ * its socket behind, and CUDA workloads spawn many such helpers. Remove the
+ * sockets whose process no longer exists, so the control directory describes
+ * the processes that are actually there.
+ */
+static void
+remove_dead_sockets(void)
+{
+  DIR* directory = opendir(control_directory);
+  struct dirent* entry;
+
+  if (directory == NULL)
+    return;
+  while ((entry = readdir(directory)) != NULL) {
+    const char* name = entry->d_name;
+    const char* digits;
+    long pid = 0;
+
+    if (strncmp(name, CUINTERPOSE_SOCKET_PREFIX, strlen(CUINTERPOSE_SOCKET_PREFIX)) != 0)
+      continue;
+    /* Hand-rolled: strtol resolves to a glibc 2.38 symbol under C2x headers,
+     * and the shim must load on glibc 2.34. */
+    for (digits = name + strlen(CUINTERPOSE_SOCKET_PREFIX); *digits >= '0' && *digits <= '9' && pid < 100000000L;
+         digits++)
+      pid = pid * 10 + (*digits - '0');
+    if (pid <= 0 || strcmp(digits, ".sock") != 0 || pid == (long)getpid())
+      continue;
+    if (kill((pid_t)pid, 0) == -1 && errno == ESRCH) {
+      char path[sizeof(socket_path)];
+
+      if (snprintf(path, sizeof(path), "%s/%s", control_directory, name) < (int)sizeof(path))
+        unlink(path);
+    }
+  }
+  closedir(directory);
+}
+
 static int
 start_control_endpoint(void)
 {
@@ -416,6 +1632,7 @@ start_control_endpoint(void)
   pthread_t thread;
   int count;
 
+  remove_dead_sockets();
   count = snprintf(
       socket_path, sizeof(socket_path), "%s/%s%ld.sock", control_directory, CUINTERPOSE_SOCKET_PREFIX,
       (long)getpid());
@@ -506,6 +1723,9 @@ fork_child(void)
   next_logical_handle = 1;
   current_phase = PHASE_ACTIVE;
   failure[0] = '\0';
+  if (arena.base != NULL)
+    munmap(arena.base, arena.size);
+  memset(&arena, 0, sizeof(arena));
   cuinterpose_export_cache_fork_child();
   pthread_mutex_init(&state_lock, NULL);
 }
@@ -645,10 +1865,16 @@ cuMemCreate(
     return result;
   allocation = calloc(1, sizeof(*allocation));
   pthread_mutex_lock(&state_lock);
-  if (allocation == NULL || current_phase != PHASE_ACTIVE ||
-      cuinterpose_random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
+  if (current_phase != PHASE_ACTIVE) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+    pthread_mutex_unlock(&state_lock);
+    if (release != NULL)
+      (void)release(driver);
+    free(allocation);
+    return CUDA_ERROR_NOT_READY;
+  }
+  if (allocation == NULL || cuinterpose_random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
       cuinterpose_random_bytes(allocation->authorization, sizeof(allocation->authorization)) != 0 ||
-      current_context(&allocation->context) != 0 ||
       cuinterpose_table_put(&allocations, cuinterpose_key_bytes(allocation->id), allocation) != 0) {
     release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
     pthread_mutex_unlock(&state_lock);
@@ -661,6 +1887,7 @@ cuMemCreate(
   allocation->properties = *properties;
   allocation->driver = driver;
   allocation->creator = true;
+  cuinterpose_capture_context(&allocation->context);
   snprintf(allocation->creator_participant, sizeof(allocation->creator_participant), "%s", participant_id);
   snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", socket_path);
   if (add_handle(allocation, &logical) != 0) {
@@ -831,6 +2058,7 @@ cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocation
   mapping->offset = offset;
   mapping->allocation = handle->allocation;
   handle->allocation->live_mappings++;
+  adopt_context(handle->allocation);
   pthread_mutex_unlock(&state_lock);
   return CUDA_SUCCESS;
 }
@@ -1029,6 +2257,7 @@ cuMemExportToShareableHandle(
     return CUDA_ERROR_NOT_READY;
   }
   allocation = handle->allocation;
+  adopt_context(allocation);
   if (allocation->creator && !cuinterpose_export_cache_has(allocation->id)) {
     /*
      * The one real export for this allocation in this process. The descriptor
@@ -1136,7 +2365,6 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
   if (allocation == NULL) {
     allocation = calloc(1, sizeof(*allocation));
     if (allocation == NULL || get_properties(&allocation->properties, imported) != CUDA_SUCCESS ||
-        current_context(&allocation->context) != 0 ||
         cuinterpose_table_put(&allocations, cuinterpose_key_bytes(ticket.allocation_id), allocation) != 0) {
       pthread_mutex_unlock(&state_lock);
       (void)release(imported);
@@ -1150,6 +2378,7 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
     snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", ticket.creator_endpoint);
     allocation->creator = false;
     allocation->driver = imported;
+    cuinterpose_capture_context(&allocation->context);
   } else if (allocation->driver != 0) {
     /* Already imported here: alias the existing driver handle. */
     if (release(imported) != CUDA_SUCCESS) {

--- a/agent/cmd/cuinterpose/tests/coordinator_test.cc
+++ b/agent/cmd/cuinterpose/tests/coordinator_test.cc
@@ -23,6 +23,7 @@
 #include <functional>
 #include <mutex>
 #include <sstream>
+#include <filesystem>
 #include <string>
 #include <thread>
 #include <vector>
@@ -185,7 +186,8 @@ class Coordinator : public ::testing::Test {
     ASSERT_EQ(mkdir(checkpoint.c_str(), 0700), 0);
   }
   void TearDown() override {
-    if (std::system(("rm -rf " + dir).c_str()) != 0) ADD_FAILURE() << "cleanup failed";
+    std::error_code ignored;
+    std::filesystem::remove_all(dir, ignored);
   }
 
   std::vector<std::string> args(const char* mode, std::initializer_list<int> pids) {

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -25,6 +25,26 @@ CUresult CUDAAPI fakeCuGetProcAddress(const char*, void**, int, cuuint64_t);
 
 static struct fake_last_call last;
 
+#define FAKE_MAX_HOST 256
+
+struct fake_host_range {
+  int used;
+  void* address;
+  size_t size;
+};
+
+static struct fake_host_range host_ranges[FAKE_MAX_HOST];
+static uint64_t copied_to_host;
+static uint64_t copied_to_device;
+static CUcontext current_context = (CUcontext)(uintptr_t)1;
+/* Primary contexts: one per device, handed out by cuDevicePrimaryCtxRetain. */
+static int primary_retain_calls;
+static int primary_contexts_held;
+static char fail_next[64];
+static CUdeviceptr next_reservation = 0x7f0000000000ULL;
+
+static int should_fail(const char* function);
+
 void
 fakeReset(void)
 {
@@ -96,12 +116,19 @@ fakeEnableTrackedBehavior(void)
 void
 fakeResetModel(void)
 {
+  current_context = (CUcontext)(uintptr_t)1;
+  primary_retain_calls = 0;
+  primary_contexts_held = 0;
   pthread_mutex_lock(&model_lock);
   memset(allocations, 0, sizeof(allocations));
   memset(handles, 0, sizeof(handles));
   memset(mappings, 0, sizeof(mappings));
+  memset(host_ranges, 0, sizeof(host_ranges));
   export_calls = 0;
   access_calls = 0;
+  copied_to_host = 0;
+  copied_to_device = 0;
+  fail_next[0] = '\0';
   pthread_mutex_unlock(&model_lock);
 }
 
@@ -234,6 +261,8 @@ fakeCuMemCreate(
     last.handle_type = properties != NULL ? (int)properties->requestedHandleTypes : -1;
     if (output == NULL)
       return CUDA_ERROR_INVALID_VALUE;
+    if (should_fail("cuMemCreate"))
+      return CUDA_ERROR_UNKNOWN;
     pthread_mutex_lock(&model_lock);
     allocation = new_allocation(size, properties);
     if (allocation >= 0)
@@ -702,11 +731,260 @@ cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_
   return fakeCuMulticastUnbind(multicast, device, offset, size);
 }
 
+
+/* ---------------------------------------------------------------------- */
+/* Tracked mode: staging, host carriers, streams, contexts.                 */
+/* ---------------------------------------------------------------------- */
+
+
+void
+fakeFailNext(const char* function)
+{
+  snprintf(fail_next, sizeof(fail_next), "%s", function);
+}
+
+/* True (and consumed) when this call was armed to fail. */
+static int
+should_fail(const char* function)
+{
+  if (fail_next[0] != '\0' && strcmp(fail_next, function) == 0) {
+    fail_next[0] = '\0';
+    return 1;
+  }
+  return 0;
+}
+
+uint64_t
+fakeCopiedToHost(void)
+{
+  return copied_to_host;
+}
+
+uint64_t
+fakeCopiedToDevice(void)
+{
+  return copied_to_device;
+}
+
+int
+fakeRegisteredHostRanges(void)
+{
+  int index;
+  int count = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++)
+    count += host_ranges[index].used;
+  pthread_mutex_unlock(&model_lock);
+  return count;
+}
+
+void
+fakeForgetHostRegistrations(void)
+{
+  pthread_mutex_lock(&model_lock);
+  memset(host_ranges, 0, sizeof(host_ranges));
+  pthread_mutex_unlock(&model_lock);
+}
+
+CUcontext
+fakeCurrentContext(void)
+{
+  return current_context;
+}
+
+CUresult CUDAAPI
+cuCtxSetCurrent(CUcontext context)
+{
+  current_context = context;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemAddressReserve(CUdeviceptr* address, size_t size, size_t alignment, CUdeviceptr fixed, unsigned long long flags)
+{
+  (void)alignment;
+  (void)fixed;
+  (void)flags;
+  if (should_fail("cuMemAddressReserve"))
+    return CUDA_ERROR_UNKNOWN;
+  pthread_mutex_lock(&model_lock);
+  *address = next_reservation;
+  next_reservation += (size + 0xfffff) & ~(CUdeviceptr)0xfffff;
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemAddressFree(CUdeviceptr address, size_t size)
+{
+  (void)address;
+  (void)size;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemHostRegister_v2(void* address, size_t size, unsigned int flags)
+{
+  int index;
+
+  (void)flags;
+  if (should_fail("cuMemHostRegister_v2"))
+    return CUDA_ERROR_UNKNOWN;
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++) {
+    if (!host_ranges[index].used) {
+      host_ranges[index].used = 1;
+      host_ranges[index].address = address;
+      host_ranges[index].size = size;
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_SUCCESS;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_ERROR_OUT_OF_MEMORY;
+}
+
+CUresult CUDAAPI
+cuMemHostUnregister(void* address)
+{
+  int index;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++) {
+    if (host_ranges[index].used && host_ranges[index].address == address) {
+      host_ranges[index].used = 0;
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_SUCCESS;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED;
+}
+
+CUresult CUDAAPI
+cuMemHostGetFlags(unsigned int* flags, void* address)
+{
+  int index;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++) {
+    if (host_ranges[index].used && host_ranges[index].address == address) {
+      pthread_mutex_unlock(&model_lock);
+      *flags = 0;
+      return CUDA_SUCCESS;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_ERROR_INVALID_VALUE;
+}
+
+/* The fake has no device memory: copies only count bytes. A staging mapping
+ * must exist for the device address, as the driver would require. */
+static int
+staged(CUdeviceptr address, size_t size)
+{
+  int index;
+  int ok = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_MAPPINGS; index++) {
+    if (mappings[index].used && address >= mappings[index].address &&
+        address + size <= mappings[index].address + mappings[index].size)
+      ok = 1;
+  }
+  pthread_mutex_unlock(&model_lock);
+  return ok;
+}
+
+CUresult CUDAAPI
+cuMemcpyDtoHAsync_v2(void* host, CUdeviceptr device, size_t size, CUstream stream)
+{
+  (void)host;
+  (void)stream;
+  if (should_fail("cuMemcpyDtoHAsync_v2"))
+    return CUDA_ERROR_UNKNOWN;
+  if (!staged(device, size))
+    return CUDA_ERROR_INVALID_VALUE;
+  copied_to_host += size;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemcpyHtoDAsync_v2(CUdeviceptr device, const void* host, size_t size, CUstream stream)
+{
+  (void)host;
+  (void)stream;
+  if (should_fail("cuMemcpyHtoDAsync_v2"))
+    return CUDA_ERROR_UNKNOWN;
+  if (!staged(device, size))
+    return CUDA_ERROR_INVALID_VALUE;
+  copied_to_device += size;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuStreamCreate(CUstream* stream, unsigned int flags)
+{
+  (void)flags;
+  *stream = (CUstream)(uintptr_t)0x5eed;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuStreamSynchronize(CUstream stream)
+{
+  (void)stream;
+  return should_fail("cuStreamSynchronize") ? CUDA_ERROR_UNKNOWN : CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuStreamDestroy_v2(CUstream stream)
+{
+  (void)stream;
+  return CUDA_SUCCESS;
+}
+
 CUresult CUDAAPI
 cuCtxGetCurrent(CUcontext* context)
 {
-  *context = (CUcontext)(uintptr_t)1;
+  *context = current_context;
   return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuDevicePrimaryCtxRetain(CUcontext* context, CUdevice device)
+{
+  if (should_fail("cuDevicePrimaryCtxRetain"))
+    return CUDA_ERROR_UNKNOWN;
+  *context = (CUcontext)(uintptr_t)(0x100 + device);
+  pthread_mutex_lock(&model_lock);
+  primary_retain_calls++;
+  primary_contexts_held++;
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuDevicePrimaryCtxRelease_v2(CUdevice device)
+{
+  (void)device;
+  pthread_mutex_lock(&model_lock);
+  primary_contexts_held--;
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_SUCCESS;
+}
+
+int
+fakePrimaryContextRetainCalls(void)
+{
+  return primary_retain_calls;
+}
+
+int
+fakePrimaryContextsHeld(void)
+{
+  return primary_contexts_held;
 }
 
 /*

--- a/agent/cmd/cuinterpose/tests/fake_cuda.h
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.h
@@ -82,6 +82,21 @@ int fakeAllocationRefs(CUmemGenericAllocationHandle handle);
 int fakeSameAllocation(CUmemGenericAllocationHandle a, CUmemGenericAllocationHandle b);
 int fakeExportCalls(void);
 int fakeMappedCount(void);
+/* Bytes moved by cuMemcpyDtoHAsync / cuMemcpyHtoDAsync since the last model reset. */
+uint64_t fakeCopiedToHost(void);
+uint64_t fakeCopiedToDevice(void);
+/* Host ranges currently registered with cuMemHostRegister. */
+int fakeRegisteredHostRanges(void);
+/* Make cuMemHostGetFlags report every range as unregistered (simulates a
+ * registration that did not survive restore). */
+void fakeForgetHostRegistrations(void);
+/* Fail the next call to the named entry point once, with CUDA_ERROR_UNKNOWN. */
+void fakeFailNext(const char* function);
+/* The fake's notion of the current context, changed by cuCtxSetCurrent. */
+CUcontext fakeCurrentContext(void);
+/* cuDevicePrimaryCtxRetain calls since the last model reset, and retains not yet released. */
+int fakePrimaryContextRetainCalls(void);
+int fakePrimaryContextsHeld(void);
 /* Number of cuMemSetAccess calls since the last reset. */
 int fakeAccessCalls(void);
 /* The fake's own implementation of `symbol`, bypassing any interposer. */

--- a/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
@@ -1,0 +1,345 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// End-to-end checkpoint and restore of shared allocations with the shim
+// LD_PRELOADed over the fake driver: this process creates and shares memory, a
+// forked child imports it, and the real cuinterpose-coordinator binary drives
+// both through prepare and restore exactly as the agent would. Requires
+// SNAPSHOT_CONTROL_DIR (writable) and CUINTERPOSE_COORDINATOR (binary path).
+
+#include <cuda.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "../export.h"
+#include "../protocol.h"
+#include "fake_cuda.h"
+
+namespace {
+
+struct cuinterpose_debug_stats stats() {
+  using fn = void (*)(struct cuinterpose_debug_stats*);
+  static fn get = reinterpret_cast<fn>(dlsym(RTLD_DEFAULT, "cuinterpose_debug_stats"));
+  struct cuinterpose_debug_stats s{};
+  get(&s);
+  return s;
+}
+
+CUmemAllocationProp posix_props() {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+// Runs the coordinator against the given namespace PIDs (== observed PIDs here,
+// since there is no PID namespace) and returns its exit status and output.
+struct Outcome {
+  int status;
+  std::string out;
+  std::string err;
+};
+
+Outcome coordinate(const char* mode, const std::string& checkpoint, const std::vector<pid_t>& pids) {
+  const char* binary = getenv("CUINTERPOSE_COORDINATOR");
+  const char* control = getenv("SNAPSHOT_CONTROL_DIR");
+  int out_pipe[2], err_pipe[2];
+  if (pipe(out_pipe) != 0 || pipe(err_pipe) != 0) abort();
+  pid_t child = fork();
+  if (child == 0) {
+    dup2(out_pipe[1], STDOUT_FILENO);
+    dup2(err_pipe[1], STDERR_FILENO);
+    std::vector<std::string> args = {binary, mode, "--proc-root", "", "--checkpoint-dir", checkpoint,
+                                     "--control-dir", control};
+    for (pid_t pid : pids) {
+      args.push_back("--process");
+      args.push_back(std::to_string(pid));
+      args.push_back(std::to_string(pid));
+    }
+    std::vector<char*> argv;
+    for (auto& a : args) argv.push_back(const_cast<char*>(a.c_str()));
+    argv.push_back(nullptr);
+    // The coordinator must not itself be interposed.
+    unsetenv("LD_PRELOAD");
+    execv(binary, argv.data());
+    perror("execv cuinterpose-coordinator");
+    _exit(127);
+  }
+  close(out_pipe[1]);
+  close(err_pipe[1]);
+  auto drain = [](int fd) {
+    std::string s;
+    char buffer[4096];
+    ssize_t n;
+    while ((n = read(fd, buffer, sizeof(buffer))) > 0) s.append(buffer, n);
+    close(fd);
+    return s;
+  };
+  Outcome outcome;
+  outcome.out = drain(out_pipe[0]);
+  outcome.err = drain(err_pipe[0]);
+  int status = 0;
+  waitpid(child, &status, 0);
+  outcome.status = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+  return outcome;
+}
+
+// Commands the parent sends the importer child over a pipe.
+enum Command : int { kImport = 1, kCheckRestored = 2, kRelease = 3, kQuit = 4 };
+
+class Lifecycle : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { fakeEnableTrackedBehavior(); }
+  void SetUp() override {
+    ASSERT_NE(getenv("CUINTERPOSE_COORDINATOR"), nullptr) << "set CUINTERPOSE_COORDINATOR";
+    fakeResetModel();
+    char tmpl[] = "/tmp/cuinterpose-lifecycle-XXXXXX";
+    ASSERT_NE(mkdtemp(tmpl), nullptr);
+    checkpoint = tmpl;
+  }
+  void TearDown() override {
+    // Not std::system(): a shell child would inherit the sanitized LD_PRELOAD,
+    // and the base image's /bin/sh runs a profile script whose helpers then
+    // report their own tiny leaks.
+    std::error_code ignored;
+    std::filesystem::remove_all(checkpoint, ignored);
+  }
+  std::string checkpoint;
+};
+
+// Creator (this process) and importer (child) share one 1 MiB allocation and
+// a second, never-exported allocation that must still travel through the host
+// carrier. The coordinator prepares both, then restores both; the fake driver
+// counts bytes copied out and back in, and the child confirms its imported
+// mapping came back.
+TEST_F(Lifecycle, PrepareAndRestoreAcrossTwoProcesses) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle shared = 0, private_alloc = 0;
+  ASSERT_EQ(cuMemCreate(&shared, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemCreate(&private_alloc, 1 << 19, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x10000000, 1 << 20, 0, shared, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x20000000, 1 << 19, 0, private_alloc, 0), CUDA_SUCCESS);
+  CUmemAccessDesc access{};
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  ASSERT_EQ(cuMemSetAccess(0x10000000, 1 << 20, &access, 1), CUDA_SUCCESS);
+  int ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket, shared, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+
+  int to_child[2], from_child[2];
+  ASSERT_EQ(pipe(to_child), 0);
+  ASSERT_EQ(pipe(from_child), 0);
+  pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(to_child[1]);
+    close(from_child[0]);
+    // A real fork child has no usable CUDA state; the fake model starts empty too.
+    fakeResetModel();
+    CUmemGenericAllocationHandle imported = 0;
+    for (;;) {
+      int command = 0;
+      if (read(to_child[0], &command, sizeof(command)) != static_cast<ssize_t>(sizeof(command))) _exit(2);
+      int result = 0;
+      switch (command) {
+        case kImport:
+          if (cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                             CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS)
+            result |= 1;
+          if (cuMemMap(0x30000000, 1 << 20, 0, imported, 0) != CUDA_SUCCESS) result |= 2;
+          if (cuMemSetAccess(0x30000000, 1 << 20, &access, 1) != CUDA_SUCCESS) result |= 4;
+          break;
+        case kCheckRestored: {
+          struct cuinterpose_debug_stats s = stats();
+          if (s.phase != CUINTERPOSE_PHASE_ACTIVE) result |= 1;
+          if (s.allocations != 1 || s.handles != 1 || s.mappings != 1) result |= 2;
+          if (fakeMappedCount() != 1) result |= 4;  // the importer's mapping is back in the driver
+          // The logical handle still works after restore.
+          CUmemAllocationProp got{};
+          if (cuMemGetAllocationPropertiesFromHandle(&got, imported) != CUDA_SUCCESS) result |= 8;
+          break;
+        }
+        case kRelease:
+          if (cuMemUnmap(0x30000000, 1 << 20) != CUDA_SUCCESS) result |= 1;
+          if (cuMemRelease(imported) != CUDA_SUCCESS) result |= 2;
+          if (stats().allocations != 0) result |= 4;
+          break;
+        case kQuit:
+          _exit(0);
+      }
+      if (write(from_child[1], &result, sizeof(result)) != static_cast<ssize_t>(sizeof(result))) _exit(3);
+    }
+  }
+  close(to_child[0]);
+  close(from_child[1]);
+  auto tell = [&](int command) {
+    int result = -1;
+    EXPECT_EQ(write(to_child[1], &command, sizeof(command)), static_cast<ssize_t>(sizeof(command)));
+    EXPECT_EQ(read(from_child[0], &result, sizeof(result)), static_cast<ssize_t>(sizeof(result)));
+    return result;
+  };
+
+  EXPECT_EQ(tell(kImport), 0) << "child import failed";
+  EXPECT_EQ(fakeExportCalls(), 1);
+
+  // Checkpoint.
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid(), child});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_EQ(fakeRegisteredHostRanges(), 1) << "one pinned arena holds every host carrier while checkpointed";
+  struct stat st{};
+  EXPECT_EQ(stat((checkpoint + "/" + CUINTERPOSE_STATE_FILENAME).c_str(), &st), 0);
+  EXPECT_EQ(fakeCopiedToHost(), static_cast<uint64_t>((1 << 20) + (1 << 19)))
+      << "both creator allocations, the never-exported one included, were copied to the host";
+  EXPECT_NE(prepare.out.find("carrier_count=2 carrier_bytes=1572864"), std::string::npos) << prepare.out;
+  EXPECT_EQ(fakeMappedCount(), 0) << "nothing shared stays mapped in the parent for the native checkpoint";
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_PREPARED));
+  EXPECT_EQ(stats().cached_exports, 0u) << "the export cache is closed while checkpointed";
+  // While prepared, the application's handles answer "not ready".
+  EXPECT_EQ(cuMemRelease(shared), CUDA_ERROR_NOT_READY);
+  EXPECT_EQ(cuMemMap(0x40000000, 4096, 0, shared, 0), CUDA_ERROR_NOT_READY);
+
+  // Simulate what a native restore leaves behind: the host pages lost their
+  // registration in one process, so the shim must pin them again.
+  fakeForgetHostRegistrations();
+  EXPECT_EQ(fakeRegisteredHostRanges(), 0);
+
+  // Restore.
+  Outcome restore = coordinate("--restore", checkpoint, {getpid(), child});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeCopiedToDevice(), static_cast<uint64_t>((1 << 20) + (1 << 19)));
+  EXPECT_NE(restore.out.find("phase=restore_host_carrier status=ok"), std::string::npos) << restore.out;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+  EXPECT_EQ(stats().mappings, 2u);
+  EXPECT_EQ(fakeMappedCount(), 2) << "both creator mappings are back";
+  EXPECT_EQ(fakeExportCalls(), 2) << "the shared allocation was exported again for the export cache";
+  EXPECT_EQ(stats().cached_exports, 1u);
+  // The arena is unpinned after the reply, off the coordinator's critical path.
+  for (int attempt = 0; attempt < 200 && fakeRegisteredHostRanges() != 0; attempt++) usleep(10000);
+  EXPECT_EQ(fakeRegisteredHostRanges(), 0) << "the host carrier arena is released after the copy back";
+  EXPECT_EQ(tell(kCheckRestored), 0) << "child did not see its mapping restored";
+
+  // Normal operation resumes: a fresh import of the old ticket still works.
+  CUmemGenericAllocationHandle again = 0;
+  EXPECT_EQ(cuMemImportFromShareableHandle(&again, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(again), CUDA_SUCCESS);
+
+  EXPECT_EQ(tell(kRelease), 0);
+  int quit = kQuit;  // no reply: the child exits
+  EXPECT_EQ(write(to_child[1], &quit, sizeof(quit)), static_cast<ssize_t>(sizeof(quit)));
+  int status = 0;
+  waitpid(child, &status, 0);
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "child status " << status << (WIFSIGNALED(status) ? " signal " + std::to_string(WTERMSIG(status)) : "");
+
+  close(ticket);
+  EXPECT_EQ(cuMemUnmap(0x10000000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemUnmap(0x20000000, 1 << 19), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(shared), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(private_alloc), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+TEST_F(Lifecycle, PrepareIsRefusedWhileARawImportIsAlive) {
+  int foreign = memfd_create("foreign", MFD_CLOEXEC);
+  ASSERT_EQ(write(foreign, "x", 1), 1);
+  CUmemGenericAllocationHandle raw = 0;
+  ASSERT_EQ(cuMemImportFromShareableHandle(&raw, reinterpret_cast<void*>(static_cast<intptr_t>(foreign)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  close(foreign);
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_NE(prepare.status, 0);
+  EXPECT_NE(prepare.err.find("live raw imports"), std::string::npos) << prepare.err;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE)) << "nothing was torn down";
+  EXPECT_EQ(cuMemRelease(raw), CUDA_SUCCESS);
+  // With the raw import gone, prepare succeeds (on an empty topology).
+  Outcome again = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_EQ(again.status, 0) << again.err;
+  // Bring the shim back to ACTIVE for the next test.
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  EXPECT_EQ(restore.status, 0) << restore.err;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+}
+
+// The driver needs no current context for cuMemCreate, and some workloads
+// allocate before they initialize one. Such an allocation adopts the context
+// current at its first map or export; one that never gets a context is still
+// carried through checkpoint and restore in its device's primary context.
+TEST_F(Lifecycle, AllocationsCreatedWithoutAContextAreCarried) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle mapped_later = 0, never_mapped = 0;
+  ASSERT_EQ(cuCtxSetCurrent(nullptr), CUDA_SUCCESS);  // not interposed: goes to the fake
+  ASSERT_EQ(cuMemCreate(&mapped_later, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemCreate(&never_mapped, 1 << 19, &prop, 0), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 2u) << "allocations made without a context are tracked";
+
+  CUcontext application = reinterpret_cast<CUcontext>(static_cast<uintptr_t>(7));
+  ASSERT_EQ(cuCtxSetCurrent(application), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x50000000, 1 << 20, 0, mapped_later, 0), CUDA_SUCCESS);
+
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_EQ(fakeCopiedToHost(), static_cast<uint64_t>((1 << 20) + (1 << 19)))
+      << "both allocations were copied out, the never-mapped one in its primary context";
+  EXPECT_GT(fakePrimaryContextRetainCalls(), 0) << "the primary context was used for the context-less allocation";
+  EXPECT_EQ(fakePrimaryContextsHeld(), 0) << "every retained primary context was released";
+  EXPECT_EQ(fakeCurrentContext(), application) << "the application's context is current again";
+
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeCopiedToDevice(), static_cast<uint64_t>((1 << 20) + (1 << 19)));
+  EXPECT_EQ(fakePrimaryContextsHeld(), 0);
+  EXPECT_EQ(fakeCurrentContext(), application);
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+
+  // The allocation that never had a context is still usable afterwards.
+  EXPECT_EQ(cuMemMap(0x60000000, 1 << 19, 0, never_mapped, 0), CUDA_SUCCESS);
+  EXPECT_EQ(fakeMappedCount(), 2);
+
+  EXPECT_EQ(cuMemUnmap(0x50000000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemUnmap(0x60000000, 1 << 19), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(mapped_later), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(never_mapped), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+TEST_F(Lifecycle, FailedHostCopyLeavesTheWorkloadIntactAndFailsClosed) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle handle = 0;
+  ASSERT_EQ(cuMemCreate(&handle, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x10000000, 1 << 20, 0, handle, 0), CUDA_SUCCESS);
+  fakeFailNext("cuMemcpyDtoHAsync_v2");
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_NE(prepare.status, 0);
+  EXPECT_NE(prepare.err.find("host carrier save"), std::string::npos) << prepare.err;
+  struct stat st{};
+  EXPECT_NE(stat((checkpoint + "/" + CUINTERPOSE_STATE_FILENAME).c_str(), &st), 0) << "no state file on failure";
+  EXPECT_EQ(fakeRegisteredHostRanges(), 0) << "partial host carriers were released";
+  EXPECT_EQ(fakeMappedCount(), 1) << "the mapping was never touched";
+  // The shim is in the failed phase: IDENTIFY reports it, and the application
+  // cannot continue with VMM calls. This is the documented fail-stop behavior.
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_FAILED));
+  EXPECT_EQ(cuMemUnmap(0x10000000, 1 << 20), CUDA_ERROR_NOT_READY);
+  // The process is unusable for the rest of this test binary, so run this
+  // test last (gtest runs tests in definition order within a binary).
+}
+
+}  // namespace


### PR DESCRIPTION

## Summary

The lifecycle: the shim answers INSPECT, PREPARE_MULTICAST (unicast part), SAVE_HOST_CARRIER, PREPARE, RESTORE_HOST_CARRIER, RESTORE_CREATORS, RESTORE_IMPORTERS, and the coordinator gains its per-participant carrier requests. From here an annotated Pod checkpoints and restores. Doc: `docs/reference/cuinterpose.md` §3.2, §3.3, §4, §7, and the first pitfall in §8.

- Every tracked creator allocation is carried through pinned host memory (the r615 driver attaches fabric state at creation and does not rebuild it on restore, so a natively restored allocation cannot be exported again). One pinned arena per process, one staging range per CUDA context, all copies on one stream with one wait, the arena unpinned after the restore reply; the shim reports the copy time (`copy_us`) and the coordinator prints `gb_per_s` (phase) and `copy_gb_per_s` (transfer). On B200 the restore phase went from 17 to 30 GB/s aggregate over two GPUs with per-allocation pinning to 87 to 108 GB/s with the arena.
- Allocations created or imported without a current CUDA context are tracked (the driver needs none); they adopt a context at first map or export or fall back to the device's primary context (`context.c`).
- Sockets of processes that exited without running destructors are removed when a new endpoint starts.
- Tests: `lifecycle_preload_test` (two processes with the real coordinator, carriers for exported and never-exported allocations, lost host registration, raw import refusal, context-less allocations, failed host copy fail-stop).

## Origin

Re-cut of the lifecycle parts of #152 and of #165 (host carrier) and #163 (closed; its external-allocation preservation is covered by the carrier and the raw-import refusal).

<details><summary>#165 fix(agent): recreate large shared allocations on restore (verbatim, bot blocks removed)</summary>

> ## Summary
>
> - preserve large shared POSIX-exportable device allocations in anonymous pinned host memory owned by the workload process before CUDA checkpoint
> - release the original exportable device backing before native CUDA checkpoint
> - let CRIU capture the pinned host carrier as ordinary process memory; no carrier sidecar files are created
> - after restore, create fresh exportable device backing, restore bytes with H2D, then unregister and unmap the host carrier
> - transfer creator ranks in parallel and use bounded control timeouts
> - force the path in `test_cucheckpoint.py` without changing the production threshold, and assert that no carrier files appear
>
> This is a transparent r615 workaround for large shared allocations whose bytes restore but whose original post-restore POSIX export state is stale. It does not change the driver, disable FLA/FABRIC, require GMS, or retain a second device allocation. Small, non-shared, non-POSIX-exportable, and non-device allocations remain on the native CUDA checkpoint path.
>
> ## Validation
>
> - exact 578 MiB two-GPU symmetric-memory A/B:
>   - PR #133 without this workaround fails during coordinator restore when creator re-export returns `CUDA_ERROR_INVALID_VALUE`
>   - this patch restores successfully and verifies CUDA-graph output and allocation bytes
> - native CUDA checkpoint test builds the shim with `HOST_CARRIER_THRESHOLD=1`, exercises the carrier path, and rejects any `cuinterposer-host-*.bin` artifact
> - GLM 5.2 / DeepSeek-V4-Flash-NVFP4 SGLang TP8/EP8 on eight B200 GPUs, context length 32768, with warm compile/JIT/FlashInfer caches:
>   - source startup: 87.02 s
>   - checkpoint: 290.891 s total; CRIU dump 262.580 s; CUDA checkpoint 27.632 s
>   - active restore: 37.410 s total; CRIU 12.914 s; CUDA 24.291 s
>   - standby restore: 40.165 s total; CRIU 12.921 s; CUDA 27.033 s
>   - aggregate CRIU process artifact: about 100 GiB; no separate carrier artifact
>   - coherent post-restore and post-promotion inference both returned `17 * 23 = 391`
> - clean CUDA-image build with `-Wall -Wextra -Werror`
> - `git diff --check`
> - `python3 -m py_compile agent/cmd/cuinterpose/tests/test_cucheckpoint.py`

</details>

<details><summary>#163 fix(agent): preserve external CUDA allocations across restore (verbatim, bot blocks removed)</summary>

> ## Summary
>
> - preserve creator-owned external CUDA VMM allocations across native restore
> - re-export the restored multicast carrier so every rank imports the same physical allocation without a D2D copy
> - pass the retained broker FD through restore and make coordinator export available during restore preparation
> - add focused CUDA interposer coverage for post-restore multicast collectives and graph replay
> - retain the restored allocation broker for repeatable restore while handling agent restart/replay safely
>
> This PR is intentionally based on #133 and should be reviewed/merged after it.
>
> ## Validation
>
> - `go test ./internal/cuda ./internal/executor -count=1` in `agent/`
> - `go test ./podcontract -count=1` in `api/`
> - strict native build with `-Wall -Wextra -Werror`
> - focused FlashInfer/PyTorch multicast A/B:
>   - before: first uncaptured post-restore collective hung in `cuCtxSynchronize`
>   - after: post-restore collective and captured graph replay passed
> - full interposer test file: `2 passed in 15.66s`
> - GLM-5.2-NVFP4 SGLang TP8/EP8:
>   - warm startup: 152.53s
>   - checkpoint captured successfully
>   - CUDA/interposer restore: 29.68s; external restore total: 39.75s
>   - restored deployment Ready and `/health` returned 200
>   - post-restore OpenAI chat completion returned coherent final content:
>     `The sky appears blue because Earth's atmosphere scatters the sun's shorter blue wavelengths of light more than other colors.`

</details>

## Review threads carried

No review threads on #152, #165, or #163.

## Validation

- Fake-driver suites (GoogleTest, AddressSanitizer + UndefinedBehaviorSanitizer) run in the agent image build against CUDA 13.1 headers at every layer of the stack; at the top: proto 22, table 3, forward 12, coordinator 12, state 14, lifecycle 4, multicast 6, no sanitizer reports.
- `go test ./...` in `api`, `operator`, `agent`; `make lint`, `make helm-lint`, `make verify-license-headers`.
- Agent image built from the top of the stack and deployed on nscale-dev (B200, kernel driver 595.58.03) with this chart.
- GPU tests (two B200s, `cuda-checkpoint --launch-job`): POSIX round trip with seeded 1 GiB carriers per rank, multicast round trip with PyTorch's multimem all-reduce and a `cuMulticastBindAddr` rebind, refusal while a raw import is alive: 3 passed. Host-carrier restore phase 87 to 108 GB/s aggregate over two GPUs (pinned-copy baseline 55 GB/s per GPU).
- End to end: vLLM 0.27.1 `AsyncLLM`, Qwen3-0.6B, tensor parallel 2, FlashInfer TRT-LLM attention and fused allreduce (`trtllm` backend), PodSnapshot of a Deployment shaped with `podcontract.ShapeCuinterposeCapture`, then restore: checkpoint 52 s (CRIU dump 49 s, cuinterpose prepare 0.43 s; 4 CUDA processes, 1052 records, 382 host carriers, 2.08 GB); restore 5.7 s (cuinterpose 0.35 s: carriers 0.05 s, unicast 0.09 s, multicast 0.18 s); the restored replica answers coherently ("The capital of Italy is Rome").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
