### PR TITLE
docs: cuinterpose design and limitations

### DIFF
--- a/agent/cmd/cuinterpose/README.md
+++ b/agent/cmd/cuinterpose/README.md
@@ -47,16 +47,15 @@ shaped it, and what is explicitly unsupported are in
 make -C agent/cmd/cuinterpose CUDA_HOME=/usr/local/cuda-13.1
 ```
 
-Only headers are used from `CUDA_HOME`; the shim never links libcuda. Every C
-file in the directory is part of the shim except `coordinator.c`, which is the
-coordinator. The build asserts, on the produced `libcuinterpose.so`:
+Only headers are used from `CUDA_HOME`; the shim never links libcuda. The build
+asserts, on the produced `libcuinterpose.so`:
 
 - no `NEEDED` entry for libcuda or libcudart;
 - no glibc symbol newer than `GLIBC_2.34` (the shim must load into Ubuntu
   22.04 images);
 - the real `dlsym` is obtained through `dlvsym(..., "GLIBC_2.34")`;
 - the exported symbol set is exactly the CUDA entry points it replaces,
-  `dlsym`, and `cuinterpose_*` (everything else is hidden, because an
+  `dlsym`, and `cuinterpose_build_info` (everything else is hidden, because an
   `LD_PRELOAD` library is first in the symbol search order of the whole
   process);
 - the CUDA headers are 13.1 or newer (`ALLOW_OLD_CUDA_HEADERS=1` overrides).
@@ -73,11 +72,68 @@ container's mount namespace regardless of that image's C library.
 make -C agent/cmd/cuinterpose CUDA_HOME=/usr/local/cuda-13.1 test
 ```
 
-GoogleTest suites, no GPU needed, found by file name under `tests/`:
-`<name>_unit_test.cc` links the shim's CUDA-free objects and runs on its own;
-`<name>_preload_test.cc` runs with a sanitizer-instrumented build of the shim
-`LD_PRELOAD`ed over a fake `libcuda.so.1` / `libcudart.so.13` that record what
-they were called with; `coordinator_test.cc` runs the sanitizer-instrumented
-coordinator against fake participants. All are built with AddressSanitizer and
-UndefinedBehaviorSanitizer (`SANITIZE=` disables). The agent image build runs
-them; a failing test fails the image. GPU tests live under `tests/gpu`.
+GoogleTest suites, no GPU needed, found by file name under `tests/` (`<name>_unit_test.cc` links the shim's CUDA-free objects; `<name>_preload_test.cc` runs with the sanitized shim `LD_PRELOAD`ed over the fake driver; `coordinator_test.cc` drives the sanitized coordinator):
+
+- `proto_unit_test`: the ticket format and control-socket helpers (`util.c`,
+  `posix.c`), including descriptor passing and the paths that must not leak a
+  descriptor on a malformed message, and the export cache, including a drop
+  racing in-flight requests; `table_unit_test`: the tables and range index.
+- `state_preload_test`: allocation tracking end to end against the fake driver's
+  tracked mode: alias collapse, range unmap, access merging, tickets, imports
+  in the same process and from a forked child through the listener, raw import
+  counting, a churn test that leaves the tables empty, and descriptor
+  exhaustion.
+- `forward_preload_test`: runs with `LD_PRELOAD` of a sanitizer-instrumented shim
+  against fake `libcuda.so.1` / `libcudart.so.13` that record their arguments,
+  and checks all four resolution paths above.
+- `coordinator_test`: runs the coordinator binary against fake participants
+  (small servers speaking the control protocol) and checks phase ordering, the
+  multicast phase barrier, topology validation, refusal on live raw imports,
+  the state file format, and every restore precondition.
+- `lifecycle_preload_test`: the real coordinator drives this process and a forked
+  importer child through prepare and restore over the fake driver: host
+  carriers for exported and never-exported allocations, the re-pin after a lost
+  host registration, the refusal while a raw import is alive, allocations
+  created before any CUDA context existed, and a failed host copy leaving the
+  workload untouched.
+- `multicast_preload_test`: the same two-process flow for a multicast group (bind by
+  handle in one rank, by address with the device-explicit ABI in the other),
+  the effective extent beyond the requested size, unbinding and rebinding by
+  address, pass-through of non-POSIX objects, refusal of untracked members,
+  and the order in which PREPARE_MULTICAST closes the cached descriptor and
+  releases the object.
+
+All are built with AddressSanitizer and UndefinedBehaviorSanitizer
+(`SANITIZE=` disables). The agent image build runs them; a failing test fails
+the image. The test helpers never shell out: a child of a sanitized process
+inherits its `LD_PRELOAD`, and the base image's `/bin/sh` runs a profile script
+whose helpers would then report leaks of their own.
+
+### GPU tests
+
+`tests/gpu/` holds pytest tests that need two GPUs, a CUDA 13 driver with
+checkpoint support, and `cuda-checkpoint`:
+
+```bash
+cuda-checkpoint --launch-job uv run --project agent/cmd/cuinterpose/tests/gpu \
+    pytest agent/cmd/cuinterpose/tests/gpu -v -m gpu
+```
+
+The test process starts one interposed parent that forks two PyTorch workers.
+Each creates POSIX-shareable allocations of its own (one of them before any
+CUDA context exists, one large one filled with seeded random bytes), imports a
+descriptor from the uninterposed test process, shares a symmetric-memory buffer
+with the other rank, and captures a collective into a CUDA graph. The test then
+runs the coordinator, the native checkpoint sequence through `cuda.bindings`,
+and the coordinator again, and checks: the state file exists and nothing else
+was written; the coordinator's summary line reports at least the workers' own
+allocations as carried; the host-to-device copy on restore reached 80% of a
+plain pinned copy measured on the same machine
+(`CUINTERPOSE_TEST_MIN_H2D_FRACTION`); every byte survived; the graph replays
+with the right result; a fresh raw import works. A second test holds a raw
+import across `--prepare` and checks the refusal names it and that the workload
+keeps working. `test_multicast.py` (marker `multicast`, skipped without NVLink)
+runs the same flow with PyTorch's multimem all-reduce, one rank rebinding its
+slice with `cuMulticastBindAddr`. `CUINTERPOSE_BUILD_DIR` points the tests at prebuilt binaries
+(for example copied out of the agent image); otherwise they build the shim with
+`CUDA_HOME`. The seed is printed and can be replayed with `CUINTERPOSE_TEST_SEED`.

--- a/agent/cmd/cuinterpose/tests/gpu/conftest.py
+++ b/agent/cmd/cuinterpose/tests/gpu/conftest.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures for the GPU tests.
+
+Everything here skips rather than fails when the machine cannot run the tests:
+no torch or cuda-bindings, fewer than two GPUs, not started through
+``cuda-checkpoint --launch-job``, or no CUDA headers to build the shim with.
+Set ``CUINTERPOSE_BUILD_DIR`` to a directory holding ``libcuinterpose.so`` and
+``cuinterpose-coordinator`` to use prebuilt binaries (for example copied out of
+the agent image) instead of building them here.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BUILD_TIMEOUT_SECONDS = 300
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers", "gpu: needs two GPUs, a CUDA 13 driver, and cuda-checkpoint --launch-job"
+    )
+    config.addinivalue_line(
+        "markers", "multicast: additionally needs NVLink between the two GPUs"
+    )
+
+
+@pytest.fixture(scope="session")
+def tools(tmp_path_factory: pytest.TempPathFactory):
+    """The shim and coordinator under test, prebuilt or built once per session."""
+    from harness import Tools
+
+    prebuilt = os.environ.get("CUINTERPOSE_BUILD_DIR")
+    if prebuilt:
+        build_dir = Path(prebuilt)
+    else:
+        source_dir = Path(__file__).resolve().parents[2]
+        cuda_home = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda"))
+        compiler = os.environ.get("CC", "cc")
+        missing = [
+            requirement
+            for requirement, present in (
+                ("make on PATH", shutil.which("make") is not None),
+                ("readelf on PATH", shutil.which("readelf") is not None),
+                (f"{compiler} on PATH", shutil.which(compiler) is not None),
+                (f"{cuda_home}/include/cuda.h", (cuda_home / "include" / "cuda.h").is_file()),
+            )
+            if not present
+        ]
+        if missing:
+            pytest.skip(
+                "cannot build the shim: missing "
+                + ", ".join(missing)
+                + "; set CUDA_HOME, or CUINTERPOSE_BUILD_DIR to prebuilt binaries"
+            )
+        build_dir = tmp_path_factory.mktemp("cuinterpose-build")
+        result = subprocess.run(
+            ["make", "-C", str(source_dir), f"BUILD_DIR={build_dir}", f"CUDA_HOME={cuda_home}", "all"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=BUILD_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            pytest.fail(f"shim build failed ({result.returncode}):\n{result.stdout}{result.stderr}")
+    interposer = (build_dir / "libcuinterpose.so").resolve()
+    coordinator = (build_dir / "cuinterpose-coordinator").resolve()
+    if not interposer.is_file() or not coordinator.is_file():
+        pytest.fail(f"{build_dir} does not hold libcuinterpose.so and cuinterpose-coordinator")
+    return Tools(interposer, coordinator)
+
+
+@pytest.fixture(scope="session")
+def gpu_environment(tools):
+    pytest.importorskip("torch")
+    pytest.importorskip("cuda.bindings")
+    import harness
+
+    launch_job = harness.launch_job_fds()
+    if launch_job is None:
+        pytest.skip("run through cuda-checkpoint --launch-job (CUDA_CHECKPOINT_JOB_FILE is unset)")
+    gpus = harness.visible_gpus()
+    if gpus is None:
+        pytest.skip(f"needs {harness.WORLD_SIZE} distinct GPUs (CUDA_VISIBLE_DEVICES)")
+    return harness.Environment(tools, gpus, launch_job)
+
+
+@pytest.fixture(scope="session")
+def multicast_supported(gpu_environment):
+    """Skips unless both GPUs report multicast support (NVLink / NVSwitch)."""
+    import harness
+    from cuda.bindings import driver
+
+    harness.cuda_call(driver.cuInit, 0)
+    for ordinal in range(harness.WORLD_SIZE):
+        device = harness.cuda_call(driver.cuDeviceGet, ordinal)
+        supported = harness.cuda_call(
+            driver.cuDeviceGetAttribute,
+            driver.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
+            device,
+        )
+        if not int(supported):
+            pytest.skip(f"GPU {ordinal} does not support CUDA multicast")
+    return True
+
+
+@pytest.fixture
+def seed(record_property) -> int:
+    """Seed for the random buffer contents; set CUINTERPOSE_TEST_SEED to replay."""
+    value = int(os.environ.get("CUINTERPOSE_TEST_SEED") or random.getrandbits(32))
+    record_property("cuinterpose_test_seed", value)
+    print(f"\ncuinterpose test seed: {value} (CUINTERPOSE_TEST_SEED={value} to replay)")
+    return value

--- a/agent/cmd/cuinterpose/tests/gpu/harness.py
+++ b/agent/cmd/cuinterpose/tests/gpu/harness.py
@@ -1,0 +1,682 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared pieces of the GPU tests.
+
+The test process never loads the shim. It launches one interposed *parent*
+Python process (``worker.py``) that forks ``WORLD_SIZE`` CUDA workers, and then
+drives a checkpoint from the outside exactly as the snapshot agent would:
+``cuinterpose-coordinator --prepare``, the native ``cuCheckpointProcess*``
+sequence, ``cuinterpose-coordinator --restore``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import queue
+import re
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from multiprocessing.reduction import send_handle
+from pathlib import Path
+from typing import NamedTuple
+
+from cuda.bindings import driver
+
+WORLD_SIZE = 2
+COMMAND_TIMEOUT_SECONDS = 60
+CHECKPOINT_TIMEOUT_SECONDS = 120
+WORKER_TIMEOUT_SECONDS = 240
+
+# Names pinned to protocol.h.
+SOCKET_PREFIX = "cuinterpose-"
+STATE_FILENAME = "cuinterpose.state"
+CONTROL_DIR_ENV = "SNAPSHOT_CONTROL_DIR"
+PARTICIPANT_ID_ENV = "SNAPSHOT_PARTICIPANT_ID"
+# 32 lowercase hex digits; the shim accepts it as the parent's identity.
+PARENT_PARTICIPANT_ID = "a" * 32
+
+# Logical handles carry this tag in the top 16 bits (interpose.c).
+LOGICAL_HANDLE_TAG = 0xD94D000000000000
+LOGICAL_HANDLE_TAG_MASK = 0xFFFF000000000000
+
+POSIX_FD_HANDLE_TYPE = (
+    driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+)
+
+PHASE_LINE = re.compile(
+    r"^cuinterpose-coordinator phase=(?P<phase>\S+) status=(?P<status>\S+)"
+    r"(?P<rest>(?: \S+=\S+)*)$"
+)
+
+
+class Tools(NamedTuple):
+    interposer: Path
+    coordinator: Path
+
+
+class Environment(NamedTuple):
+    tools: Tools
+    gpus: tuple[str, str]
+    launch_job_fds: tuple[int, ...]
+
+
+# --- thin wrappers over cuda.bindings -----------------------------------------
+
+
+def cuda_call(function, *arguments):
+    status, *outputs = function(*arguments)
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"{function.__name__} failed: {status.name} ({int(status)})")
+    if not outputs:
+        return None
+    if len(outputs) == 1:
+        return outputs[0]
+    return tuple(outputs)
+
+
+def assert_no_current_context(process: str) -> None:
+    status, context = driver.cuCtxGetCurrent()
+    if status == driver.CUresult.CUDA_ERROR_NOT_INITIALIZED:
+        return
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuCtxGetCurrent failed: {status.name} ({int(status)})")
+    if int(context) != 0:
+        raise AssertionError(f"{process} has a current CUDA context")
+
+
+def allocation_properties(device) -> driver.CUmemAllocationProp:
+    properties = driver.CUmemAllocationProp()
+    properties.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    properties.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    properties.location.id = int(device)
+    properties.requestedHandleTypes = POSIX_FD_HANDLE_TYPE
+    return properties
+
+
+def allocation_granularity(properties: driver.CUmemAllocationProp) -> int:
+    return int(
+        cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+        )
+    )
+
+
+def round_up(size: int, granularity: int) -> int:
+    return (size + granularity - 1) // granularity * granularity
+
+
+def assert_handle_namespace(handle, logical: bool, stage: str) -> None:
+    tagged = int(handle) & LOGICAL_HANDLE_TAG_MASK == LOGICAL_HANDLE_TAG
+    if tagged != logical:
+        expected = "logical" if logical else "raw"
+        raise AssertionError(f"{stage}: handle {int(handle):#x} is not {expected}")
+
+
+def map_allocation(handle, size: int, device) -> int:
+    address = int(cuda_call(driver.cuMemAddressReserve, size, size, 0, 0))
+    mapped = False
+    try:
+        cuda_call(driver.cuMemMap, address, size, 0, handle, 0)
+        mapped = True
+        access = driver.CUmemAccessDesc()
+        access.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        access.location.id = int(device)
+        access.flags = driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+        cuda_call(driver.cuMemSetAccess, address, size, [access], 1)
+    except Exception:
+        if mapped:
+            cuda_call(driver.cuMemUnmap, address, size)
+        cuda_call(driver.cuMemAddressFree, address, size)
+        raise
+    return address
+
+
+def write_bytes(address: int, expected: bytes) -> None:
+    source = ctypes.create_string_buffer(expected)
+    cuda_call(driver.cuMemcpyHtoD, address, ctypes.addressof(source), len(expected))
+
+
+def assert_bytes(address: int, expected: bytes, stage: str) -> None:
+    actual = ctypes.create_string_buffer(len(expected))
+    cuda_call(driver.cuMemcpyDtoH, ctypes.addressof(actual), address, len(expected))
+    if actual.raw != expected:
+        raise AssertionError(f"{stage}: got {actual.raw!r}, expected {expected!r}")
+
+
+def destroy_mapped_allocation(address: int, size: int, handle) -> None:
+    cuda_call(driver.cuMemUnmap, address, size)
+    cuda_call(driver.cuMemAddressFree, address, size)
+    cuda_call(driver.cuMemRelease, handle)
+
+
+# --- allocations made outside the shim ----------------------------------------
+
+
+class ExternalAllocation(NamedTuple):
+    """A POSIX-shareable allocation owned by the (uninterposed) test process.
+
+    Workers import its descriptor raw, which is exactly the "untracked import"
+    the coordinator must refuse to checkpoint while it is alive.
+    """
+
+    device: driver.CUdevice
+    context: driver.CUcontext
+    address: int
+    size: int
+    handle: driver.CUmemGenericAllocationHandle
+    fd: int
+
+
+def create_external_allocations(byte_base: int) -> list[ExternalAllocation]:
+    cuda_call(driver.cuInit, 0)
+    allocations: list[ExternalAllocation] = []
+    try:
+        for rank in range(WORLD_SIZE):
+            allocations.append(_create_external_allocation(rank, byte_base))
+    except Exception:
+        destroy_external_allocations(allocations)
+        raise
+    return allocations
+
+
+def _create_external_allocation(rank: int, byte_base: int) -> ExternalAllocation:
+    device = cuda_call(driver.cuDeviceGet, rank)
+    context = cuda_call(driver.cuDevicePrimaryCtxRetain, device)
+    handle = None
+    address = 0
+    try:
+        cuda_call(driver.cuCtxPushCurrent, context)
+        try:
+            properties = allocation_properties(device)
+            size = allocation_granularity(properties)
+            handle = cuda_call(driver.cuMemCreate, size, properties, 0)
+            address = map_allocation(handle, size, device)
+            write_bytes(address, bytes([byte_base + rank]) * 32)
+            fd = int(
+                cuda_call(
+                    driver.cuMemExportToShareableHandle, handle, POSIX_FD_HANDLE_TYPE, 0
+                )
+            )
+        except Exception:
+            if address:
+                destroy_mapped_allocation(address, size, handle)
+            elif handle is not None:
+                cuda_call(driver.cuMemRelease, handle)
+            raise
+        finally:
+            cuda_call(driver.cuCtxPopCurrent)
+    except Exception:
+        cuda_call(driver.cuDevicePrimaryCtxRelease, device)
+        raise
+    return ExternalAllocation(device, context, address, size, handle, fd)
+
+
+def destroy_external_allocations(allocations: list[ExternalAllocation]) -> None:
+    while allocations:
+        allocation = allocations.pop()
+        os.close(allocation.fd)
+        cuda_call(driver.cuCtxPushCurrent, allocation.context)
+        try:
+            destroy_mapped_allocation(allocation.address, allocation.size, allocation.handle)
+        finally:
+            cuda_call(driver.cuCtxPopCurrent)
+            cuda_call(driver.cuDevicePrimaryCtxRelease, allocation.device)
+
+
+# --- environment --------------------------------------------------------------
+
+
+def launch_job_fds() -> tuple[int, ...] | None:
+    """Descriptors of the cuda-checkpoint launch-job file, or None when the
+    process was not started through ``cuda-checkpoint --launch-job``."""
+    job_file = os.environ.get("CUDA_CHECKPOINT_JOB_FILE")
+    if not job_file or not Path(job_file).is_file():
+        return None
+    match = re.fullmatch(r"/proc/self/fd/([0-9]+)", job_file)
+    if match is None:
+        return ()
+    descriptor = int(match.group(1))
+    os.fstat(descriptor)
+    return (descriptor,)
+
+
+def require_launch_job() -> tuple[int, ...]:
+    fds = launch_job_fds()
+    if fds is None:
+        raise RuntimeError(
+            "CUDA_CHECKPOINT_JOB_FILE is missing; run through cuda-checkpoint --launch-job"
+        )
+    return fds
+
+
+def visible_gpus() -> tuple[str, str] | None:
+    """The two GPU ordinals the workers use, or None when fewer are available."""
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is None:
+        cuda_call(driver.cuInit, 0)
+        if int(cuda_call(driver.cuDeviceGetCount)) < WORLD_SIZE:
+            return None
+        return "0", "1"
+    devices = [entry.strip() for entry in configured.split(",") if entry.strip()]
+    if len(devices) < WORLD_SIZE or devices[0] == devices[1]:
+        return None
+    return devices[0], devices[1]
+
+
+def measure_h2d_gbps(device_ordinal: int, nbytes: int, repeats: int = 3) -> float:
+    """Best of ``repeats`` synchronous pinned host-to-device copies, in GB/s
+    (10**9 bytes per second, the unit of the coordinator's ``gb_per_s``)."""
+    cuda_call(driver.cuInit, 0)
+    device = cuda_call(driver.cuDeviceGet, device_ordinal)
+    context = cuda_call(driver.cuDevicePrimaryCtxRetain, device)
+    cuda_call(driver.cuCtxPushCurrent, context)
+    try:
+        destination = cuda_call(driver.cuMemAlloc, nbytes)
+        source = cuda_call(driver.cuMemHostAlloc, nbytes, 0)
+        try:
+            best = 0.0
+            for attempt in range(repeats + 1):
+                start = time.perf_counter()
+                cuda_call(driver.cuMemcpyHtoD, destination, source, nbytes)
+                elapsed = time.perf_counter() - start
+                if attempt:  # the first copy warms up the link
+                    best = max(best, nbytes / 1e9 / elapsed)
+            return best
+        finally:
+            cuda_call(driver.cuMemFreeHost, source)
+            cuda_call(driver.cuMemFree, destination)
+    finally:
+        cuda_call(driver.cuCtxPopCurrent)
+        cuda_call(driver.cuDevicePrimaryCtxRelease, device)
+
+
+# --- the coordinator ----------------------------------------------------------
+
+
+@dataclass
+class CoordinatorRun:
+    status: int
+    out: str
+    err: str
+    phases: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    @property
+    def failed(self) -> str:
+        return f"coordinator exited {self.status}\nstdout:\n{self.out}\nstderr:\n{self.err}"
+
+
+def parse_phase_lines(stdout: str) -> dict[str, dict[str, str]]:
+    phases: dict[str, dict[str, str]] = {}
+    for line in stdout.splitlines():
+        match = PHASE_LINE.match(line.strip())
+        if match is None:
+            continue
+        fields = {"status": match.group("status")}
+        for pair in match.group("rest").split():
+            key, _, value = pair.partition("=")
+            fields[key] = value
+        phases[match.group("phase")] = fields
+    return phases
+
+
+def run_coordinator(
+    coordinator: Path,
+    operation: str,
+    checkpoint_dir: Path,
+    control_dir: Path,
+    process_ids: tuple[int, ...],
+) -> CoordinatorRun:
+    command = [
+        str(coordinator),
+        operation,
+        "--proc-root",
+        "",
+        "--checkpoint-dir",
+        str(checkpoint_dir),
+        "--control-dir",
+        str(control_dir),
+    ]
+    for process_id in process_ids:
+        command.extend(["--process", str(process_id), str(process_id)])
+    environment = os.environ.copy()
+    environment.pop("LD_PRELOAD", None)
+    result = subprocess.run(
+        command,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    return CoordinatorRun(
+        result.returncode, result.stdout, result.stderr, parse_phase_lines(result.stdout)
+    )
+
+
+# --- the native checkpoint ----------------------------------------------------
+
+
+def _expect_state(process_id: int, expected) -> None:
+    actual = cuda_call(driver.cuCheckpointProcessGetState, process_id)
+    if actual != expected:
+        raise AssertionError(
+            f"CUDA process {process_id} is {actual.name}, expected {expected.name}"
+        )
+
+
+def _native_checkpoint(process_ids: tuple[int, ...]) -> None:
+    cuda_call(driver.cuInit, 0)
+    running = driver.CUprocessState.CU_PROCESS_STATE_RUNNING
+    locked = driver.CUprocessState.CU_PROCESS_STATE_LOCKED
+    checkpointed = driver.CUprocessState.CU_PROCESS_STATE_CHECKPOINTED
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+    lock_arguments = driver.CUcheckpointLockArgs()
+    lock_arguments.timeoutMs = COMMAND_TIMEOUT_SECONDS * 1000
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessLock, process_id, lock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    checkpoint_arguments = driver.CUcheckpointCheckpointArgs()
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessCheckpoint, process_id, checkpoint_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, checkpointed)
+
+    restore_arguments = driver.CUcheckpointRestoreArgs()
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessRestore, process_id, restore_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    unlock_arguments = driver.CUcheckpointUnlockArgs()
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessUnlock, process_id, unlock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+
+def native_checkpoint(process_ids: tuple[int, ...]) -> None:
+    """Lock, checkpoint, restore, and unlock the workers through the driver's
+    checkpoint API, with a timeout so a wedged driver fails the test instead
+    of hanging it."""
+    outcomes: queue.Queue[Exception | None] = queue.Queue(maxsize=1)
+
+    def run() -> None:
+        try:
+            _native_checkpoint(process_ids)
+        except Exception as error:  # noqa: BLE001 -- forwarded to the test thread
+            outcomes.put(error)
+        else:
+            outcomes.put(None)
+
+    threading.Thread(target=run, daemon=True).start()
+    try:
+        outcome = outcomes.get(timeout=CHECKPOINT_TIMEOUT_SECONDS)
+    except queue.Empty as error:
+        raise TimeoutError(
+            f"native CUDA checkpoint exceeded {CHECKPOINT_TIMEOUT_SECONDS} seconds"
+        ) from error
+    if outcome is not None:
+        raise outcome
+
+
+# --- the interposed workload --------------------------------------------------
+
+
+class Workload:
+    """One interposed parent process with ``WORLD_SIZE`` forked CUDA workers.
+
+    Use as a context manager: on the way out it terminates the process group,
+    collects the parent's and workers' output, and attaches it to any error
+    that is propagating, so a failure shows what the workers saw.
+    """
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        environment: Environment,
+        *,
+        mode: str,
+        carrier_bytes: int,
+        seed: int,
+        hold_raw_import: bool = False,
+    ) -> None:
+        if mode not in {"unicast", "multicast"}:
+            raise ValueError(mode)
+        self.environment = environment
+        self.mode = mode
+        self.carrier_bytes = carrier_bytes
+        self.seed = seed
+        self.hold_raw_import = hold_raw_import
+        self.control_dir = tmp_path / "control"
+        self.checkpoint_dir = tmp_path / "checkpoint"
+        self.sync_dir = tmp_path / "sync"
+        self.store_path = tmp_path / "torch-distributed-store"
+        for directory in (self.control_dir, self.checkpoint_dir, self.sync_dir):
+            directory.mkdir()
+        self.parent: subprocess.Popen[str] | None = None
+        self.child_pids: tuple[int, ...] = ()
+        self.output: tuple[str, str] = ("", "")
+        self._output_collected = False
+        self._externals: list[ExternalAllocation] = []
+        self._restore_channels = [socket.socketpair() for _ in range(WORLD_SIZE)]
+
+    # -- lifecycle -------------------------------------------------------------
+
+    def __enter__(self) -> Workload:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            if self.parent is not None and (exc is not None or self.parent.poll() is None):
+                self._kill(signal.SIGTERM)
+            if self.parent is not None and not self._output_collected:
+                try:
+                    self.output = self.parent.communicate(timeout=10)
+                except subprocess.TimeoutExpired:
+                    self._kill(signal.SIGKILL)
+                    self.output = self.parent.communicate(timeout=10)
+                self._output_collected = True
+        finally:
+            destroy_external_allocations(self._externals)
+            for sender, receiver in self._restore_channels:
+                sender.close()
+                receiver.close()
+        if exc is not None:
+            exc.add_note(self.diagnostics())
+
+    def _kill(self, signum: int) -> None:
+        assert self.parent is not None
+        try:
+            os.killpg(self.parent.pid, signum)
+        except ProcessLookupError:
+            pass
+
+    def diagnostics(self) -> str:
+        parent_pid = self.parent.pid if self.parent is not None else "not started"
+        returncode = self.parent.returncode if self.parent is not None else "not started"
+        sockets = sorted(path.name for path in self.control_dir.glob("*.sock"))
+        return (
+            f"seed: {self.seed}\n"
+            f"parent PID/return code: {parent_pid}/{returncode}\n"
+            f"forked worker PIDs: {self.child_pids}\n"
+            f"control sockets: {sockets}\n"
+            f"parent and worker stdout:\n{self.output[0] or ''}\n"
+            f"parent and worker stderr:\n{self.output[1] or ''}"
+        )
+
+    # -- steps -----------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the parent, wait until every worker is ready, and check the shim
+        is loaded and listening in each of them."""
+        self._externals = create_external_allocations(1)
+        self.parent = self._start_parent(
+            tuple(allocation.fd for allocation in self._externals),
+            tuple(receiver.fileno() for _, receiver in self._restore_channels),
+        )
+        for _, receiver in self._restore_channels:
+            receiver.close()
+        self.child_pids = self._wait_for_child_pids()
+        self.wait_for_workers("ready")
+        # The workers have imported and released (or are holding) their raw
+        # imports; the creator side can go away either way.
+        destroy_external_allocations(self._externals)
+        for process_id in (self.parent.pid, *self.child_pids):
+            self.assert_worker_runtime(process_id)
+
+    def prepare(self) -> CoordinatorRun:
+        return run_coordinator(
+            self.environment.tools.coordinator,
+            "--prepare",
+            self.checkpoint_dir,
+            self.control_dir,
+            self.child_pids,
+        )
+
+    def restore(self) -> CoordinatorRun:
+        return run_coordinator(
+            self.environment.tools.coordinator,
+            "--restore",
+            self.checkpoint_dir,
+            self.control_dir,
+            self.child_pids,
+        )
+
+    def native_checkpoint(self) -> None:
+        native_checkpoint(self.child_pids)
+
+    def hand_fresh_imports(self) -> None:
+        """Give every worker a brand-new raw descriptor to import after restore."""
+        self._externals = create_external_allocations(0x40)
+        for rank, (sender, _) in enumerate(self._restore_channels):
+            send_handle(sender, self._externals[rank].fd, self.child_pids[rank])
+
+    def resume(self) -> None:
+        (self.sync_dir / "continue").touch()
+
+    def finish(self) -> None:
+        """Wait for the workers' done markers and a clean parent exit."""
+        assert self.parent is not None
+        self.wait_for_workers("done")
+        self.output = self.parent.communicate(timeout=COMMAND_TIMEOUT_SECONDS)
+        self._output_collected = True
+        if self.parent.returncode != 0:
+            raise RuntimeError(f"parent {self.parent.pid} exited with {self.parent.returncode}")
+
+    def worker_carriers(self) -> tuple[int, int]:
+        """Count and bytes of the tracked creator allocations the workers made
+        themselves (not counting PyTorch's), summed over ranks."""
+        count = 0
+        total = 0
+        for rank in range(WORLD_SIZE):
+            fields = (self.sync_dir / f"carrier-{rank}").read_text().split()
+            count += int(fields[0])
+            total += int(fields[1])
+        return count, total
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _start_parent(
+        self, raw_fds: tuple[int, ...], restore_fds: tuple[int, ...]
+    ) -> subprocess.Popen[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CUDA_VISIBLE_DEVICES": ",".join(self.environment.gpus),
+                PARTICIPANT_ID_ENV: PARENT_PARTICIPANT_ID,
+                CONTROL_DIR_ENV: str(self.control_dir),
+                "LD_PRELOAD": str(self.environment.tools.interposer),
+                "PYTHONFAULTHANDLER": "1",
+                "PYTHONUNBUFFERED": "1",
+                "TORCH_SYMMEM_IMPLICIT_POOL": "0",
+            }
+        )
+        if self.mode == "multicast":
+            environment.pop("TORCH_SYMM_MEM_DISABLE_MULTICAST", None)
+        else:
+            environment["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"
+        return subprocess.Popen(
+            [
+                sys.executable,
+                "-X",
+                "faulthandler",
+                "-u",
+                str(Path(__file__).with_name("worker.py")),
+                *(str(fd) for fd in raw_fds),
+                *(str(fd) for fd in restore_fds),
+                str(self.sync_dir),
+                str(self.store_path),
+                self.mode,
+                str(self.carrier_bytes),
+                str(self.seed),
+                "hold-raw-import" if self.hold_raw_import else "release-raw-import",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+            pass_fds=raw_fds + restore_fds + self.environment.launch_job_fds,
+        )
+
+    def _wait_for_child_pids(self) -> tuple[int, ...]:
+        assert self.parent is not None
+        paths = [self.sync_dir / f"pid-{rank}" for rank in range(WORLD_SIZE)]
+        deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+        while True:
+            try:
+                pids = tuple(int(path.read_text()) for path in paths)
+            except (FileNotFoundError, ValueError):
+                pids = ()
+            if len(pids) == WORLD_SIZE:
+                if len(set(pids)) != WORLD_SIZE:
+                    raise AssertionError(f"forked worker PIDs are not unique: {pids}")
+                return pids
+            if self.parent.poll() is not None:
+                raise RuntimeError(
+                    f"parent {self.parent.pid} exited before publishing child PIDs "
+                    f"with {self.parent.returncode}"
+                )
+            if time.monotonic() >= deadline:
+                raise TimeoutError("timed out waiting for forked worker PIDs")
+            time.sleep(0.05)
+
+    def wait_for_workers(self, marker: str) -> None:
+        assert self.parent is not None
+        expected = [self.sync_dir / f"{marker}-{rank}" for rank in range(WORLD_SIZE)]
+        deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+        while not all(path.exists() for path in expected):
+            if self.parent.poll() is not None:
+                raise RuntimeError(
+                    f"parent {self.parent.pid} exited before workers reached {marker} "
+                    f"with {self.parent.returncode}"
+                )
+            if time.monotonic() >= deadline:
+                missing = [str(path) for path in expected if not path.exists()]
+                raise TimeoutError(f"timed out waiting for {marker}: {', '.join(missing)}")
+            time.sleep(0.05)
+
+    def assert_worker_runtime(self, process_id: int) -> None:
+        interposer = self.environment.tools.interposer
+        maps = Path(f"/proc/{process_id}/maps").read_text().splitlines()
+        mapped_paths = {
+            fields[5] for line in maps if len(fields := line.split(maxsplit=5)) == 6
+        }
+        if str(interposer) not in mapped_paths:
+            raise AssertionError(f"{interposer} is not loaded in process {process_id}")
+        endpoint = self.control_dir / f"{SOCKET_PREFIX}{process_id}.sock"
+        if not endpoint.is_socket():
+            raise AssertionError(f"shim endpoint does not exist: {endpoint}")

--- a/agent/cmd/cuinterpose/tests/gpu/pyproject.toml
+++ b/agent/cmd/cuinterpose/tests/gpu/pyproject.toml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "cuinterpose-gpu-tests"
+version = "0.0.0"
+description = "GPU integration tests for the cuinterpose shim and coordinator"
+requires-python = ">=3.12"
+# Pinned to the versions the suite was run with (torch from the cu130 index
+# below). Bump deliberately.
+dependencies = [
+  "cuda-bindings==13.3.1",
+  "pytest==8.4.2",
+  "torch==2.11.0",
+]
+
+[tool.uv]
+package = false
+
+# CUDA 13 wheels: the tests exercise a CUDA 13 driver and cuda-bindings 13.
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-cu130" }
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+markers = [
+  "gpu: needs two GPUs, a CUDA 13 driver, and cuda-checkpoint --launch-job",
+  "multicast: additionally needs NVLink between the two GPUs",
+]

--- a/agent/cmd/cuinterpose/tests/gpu/test_multicast.py
+++ b/agent/cmd/cuinterpose/tests/gpu/test_multicast.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint and restore of a CUDA multicast group on real GPUs.
+
+Same flow as test_posix.py, but the two workers share their symmetric-memory
+buffer through a multicast object (PyTorch's multimem all-reduce), and one rank
+rebinds its slice with cuMulticastBindAddr so both bind entry points are
+exercised. Needs NVLink between the two GPUs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("cuda.bindings")
+
+import harness  # noqa: E402
+from harness import Workload  # noqa: E402
+
+from test_posix import CARRIER_MIB  # noqa: E402
+
+
+@pytest.mark.gpu
+@pytest.mark.multicast
+def test_checkpoint_restores_multicast_group(gpu_environment, multicast_supported, tmp_path, seed) -> None:
+    with Workload(
+        tmp_path, gpu_environment, mode="multicast", carrier_bytes=CARRIER_MIB << 20, seed=seed
+    ) as workload:
+        workload.start()
+
+        prepare = workload.prepare()
+        assert prepare.status == 0, prepare.failed
+        assert (workload.checkpoint_dir / harness.STATE_FILENAME).is_file()
+        expected_count, expected_bytes = workload.worker_carriers()
+        saved = prepare.phases["save_host_carrier"]
+        assert int(saved["carrier_count"]) >= expected_count, prepare.out
+        assert int(saved["carrier_bytes"]) >= expected_bytes, prepare.out
+        # The multicast phases ran on both sides.
+        assert prepare.phases["prepare_multicast"]["status"] == "ok", prepare.out
+
+        workload.native_checkpoint()
+
+        restore = workload.restore()
+        assert restore.status == 0, restore.failed
+        assert restore.phases["restore_multicast"]["status"] == "ok", restore.out
+
+        workload.hand_fresh_imports()
+        workload.resume()
+        workload.finish()

--- a/agent/cmd/cuinterpose/tests/gpu/test_posix.py
+++ b/agent/cmd/cuinterpose/tests/gpu/test_posix.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint and restore of POSIX-shared CUDA memory on real GPUs.
+
+Run through the launch-job wrapper so the workers are checkpointable:
+
+    cuda-checkpoint --launch-job uv run --project agent/cmd/cuinterpose/tests/gpu \\
+        pytest agent/cmd/cuinterpose/tests/gpu -v -m gpu
+
+Knobs: ``CUINTERPOSE_TEST_CARRIER_MIB`` (size of the large per-rank allocation,
+default 256), ``CUINTERPOSE_TEST_MIN_H2D_FRACTION`` (how close the host carrier
+restore must come to a plain pinned copy, default 0.8), ``CUINTERPOSE_TEST_SEED``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("cuda.bindings")
+
+import harness  # noqa: E402
+from harness import Workload  # noqa: E402
+
+CARRIER_MIB = int(os.environ.get("CUINTERPOSE_TEST_CARRIER_MIB", "256"))
+MIN_H2D_FRACTION = float(os.environ.get("CUINTERPOSE_TEST_MIN_H2D_FRACTION", "0.8"))
+
+
+@pytest.fixture(scope="session")
+def h2d_baseline_gbps(gpu_environment) -> float:
+    """A plain pinned host-to-device copy of one rank's large allocation on the
+    first GPU: the speed the carrier restore is held to."""
+    return harness.measure_h2d_gbps(0, CARRIER_MIB << 20)
+
+
+@pytest.mark.gpu
+def test_checkpoint_restores_shared_posix_memory(
+    gpu_environment, tmp_path, seed, h2d_baseline_gbps
+) -> None:
+    with Workload(
+        tmp_path, gpu_environment, mode="unicast", carrier_bytes=CARRIER_MIB << 20, seed=seed
+    ) as workload:
+        workload.start()
+
+        prepare = workload.prepare()
+        assert prepare.status == 0, prepare.failed
+        state = workload.checkpoint_dir / harness.STATE_FILENAME
+        assert state.is_file() and state.stat().st_size > 0, "coordinator wrote no state file"
+        stray = [path.name for path in workload.checkpoint_dir.iterdir() if path != state]
+        assert not stray, f"host carriers must stay in process memory, found {stray}"
+
+        # Every tracked creator allocation travels through the host carrier: at
+        # least the two each worker made itself (PyTorch's buffers may add more).
+        expected_count, expected_bytes = workload.worker_carriers()
+        saved = prepare.phases["save_host_carrier"]
+        assert int(saved["carrier_count"]) >= expected_count, prepare.out
+        assert int(saved["carrier_bytes"]) >= expected_bytes, prepare.out
+
+        workload.native_checkpoint()
+
+        restore = workload.restore()
+        assert restore.status == 0, restore.failed
+        restored = restore.phases["restore_host_carrier"]
+        assert restored["carrier_count"] == saved["carrier_count"], restore.out
+        assert restored["carrier_bytes"] == saved["carrier_bytes"], restore.out
+        # The phase figure includes creating and mapping the fresh device memory
+        # and the socket round trip; the copy figure is the transfer alone, and
+        # that is what must run at the link's speed.
+        phase = float(restored["gb_per_s"])
+        copied = float(restored["copy_gb_per_s"])
+        print(
+            f"\nhost carrier restore: copies {copied:.2f} GB/s, whole phase {phase:.2f} GB/s over "
+            f"{restored['carrier_bytes']} bytes; pinned copy baseline {h2d_baseline_gbps:.2f} GB/s"
+        )
+        assert copied >= MIN_H2D_FRACTION * h2d_baseline_gbps, (
+            f"host carrier copies reached {copied:.2f} GB/s, below "
+            f"{MIN_H2D_FRACTION:.0%} of the {h2d_baseline_gbps:.2f} GB/s pinned copy baseline"
+        )
+
+        workload.hand_fresh_imports()
+        workload.resume()
+        workload.finish()
+
+
+@pytest.mark.gpu
+def test_prepare_is_refused_while_a_raw_import_is_alive(gpu_environment, tmp_path, seed) -> None:
+    """An import of a descriptor from a process without the shim cannot be
+    repaired after restore, so the coordinator refuses to checkpoint while one
+    is alive, and the workload keeps running untouched."""
+    with Workload(
+        tmp_path,
+        gpu_environment,
+        mode="unicast",
+        carrier_bytes=1 << 20,
+        seed=seed,
+        hold_raw_import=True,
+    ) as workload:
+        workload.start()
+
+        prepare = workload.prepare()
+        assert prepare.status != 0, "prepare must be refused while a raw import is alive"
+        assert "live raw imports" in prepare.err, prepare.err
+        assert not (workload.checkpoint_dir / harness.STATE_FILENAME).exists()
+
+        workload.resume()
+        workload.finish()

--- a/agent/cmd/cuinterpose/tests/gpu/worker.py
+++ b/agent/cmd/cuinterpose/tests/gpu/worker.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The interposed workload for the GPU tests.
+
+Started by ``harness.Workload`` with ``LD_PRELOAD=libcuinterpose.so``. The
+parent forks ``WORLD_SIZE`` workers before touching CUDA (a fork after CUDA
+state exists is unsupported); each worker then behaves like one rank of a
+tensor-parallel server:
+
+* creates two POSIX-shareable allocations of its own, one small one *before*
+  any CUDA context exists (the driver allows that) and one large one whose
+  contents must travel through the host carrier, both filled with seeded
+  random bytes;
+* imports a descriptor from a process without the shim (a raw import) and
+  releases it again, or keeps it alive in ``hold-raw-import`` mode so the
+  coordinator has something to refuse;
+* shares a PyTorch symmetric-memory buffer with the other rank and captures a
+  collective into a CUDA graph;
+* signals ``ready``, waits for ``continue``, and after the checkpoint round
+  trip verifies every byte and replays the graph.
+
+Progress and results are communicated to the test through marker files in the
+sync directory; failures print a traceback and exit non-zero.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import sys
+import time
+import traceback
+from multiprocessing.reduction import recv_handle
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cuda.bindings import driver
+
+import harness
+from harness import POSIX_FD_HANDLE_TYPE, WORLD_SIZE, WORKER_TIMEOUT_SECONDS, cuda_call
+
+NUMEL = 2048
+
+
+class Options:
+    def __init__(self, argv: list[str]) -> None:
+        if len(argv) != 11:
+            raise SystemExit(
+                "usage: worker.py RAW_FD_0 RAW_FD_1 RESTORE_FD_0 RESTORE_FD_1 SYNC_DIR "
+                "STORE_PATH (unicast|multicast) CARRIER_BYTES SEED "
+                "(hold-raw-import|release-raw-import)"
+            )
+        self.raw_fds = (int(argv[1]), int(argv[2]))
+        self.restore_fds = (int(argv[3]), int(argv[4]))
+        self.sync_dir = Path(argv[5])
+        self.store_path = Path(argv[6])
+        if argv[7] not in {"unicast", "multicast"}:
+            raise SystemExit("mode must be unicast or multicast")
+        self.multicast = argv[7] == "multicast"
+        self.carrier_bytes = int(argv[8])
+        self.seed = int(argv[9])
+        if argv[10] not in {"hold-raw-import", "release-raw-import"}:
+            raise SystemExit("raw import handling must be hold-raw-import or release-raw-import")
+        self.hold_raw_import = argv[10] == "hold-raw-import"
+
+
+# --- seeded contents ----------------------------------------------------------
+
+
+def _pattern(nbytes: int, seed: int, device_index: int) -> torch.Tensor:
+    generator = torch.Generator(device=f"cuda:{device_index}")
+    generator.manual_seed(seed)
+    return torch.randint(
+        0, 256, (nbytes,), dtype=torch.uint8, device=f"cuda:{device_index}", generator=generator
+    )
+
+
+def _fill(address: int, nbytes: int, seed: int, device_index: int) -> None:
+    pattern = _pattern(nbytes, seed, device_index)
+    cuda_call(driver.cuMemcpyDtoD, address, pattern.data_ptr(), nbytes)
+    torch.cuda.synchronize()
+
+
+def _verify(address: int, nbytes: int, seed: int, device_index: int, stage: str) -> None:
+    expected = _pattern(nbytes, seed, device_index)
+    actual = torch.empty(nbytes, dtype=torch.uint8, device=f"cuda:{device_index}")
+    cuda_call(driver.cuMemcpyDtoD, actual.data_ptr(), address, nbytes)
+    torch.cuda.synchronize()
+    if not torch.equal(actual, expected):
+        mismatches = actual != expected
+        first = int(torch.nonzero(mismatches)[0].item())
+        raise AssertionError(
+            f"{stage}: {int(mismatches.sum().item())} of {nbytes} bytes differ, "
+            f"first at offset {first} (seed {seed})"
+        )
+
+
+# --- the worker ---------------------------------------------------------------
+
+
+def _wait_for_continue(sync_dir: Path) -> None:
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while not (sync_dir / "continue").exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for the test to continue")
+        time.sleep(0.05)
+
+
+def _import_raw(fd: int, size: int, device, expected: bytes, stage: str) -> tuple[object, int]:
+    """Import a descriptor from an uninterposed process, map it, and check its
+    contents. Returns the (raw) handle and the mapped address."""
+    try:
+        handle = cuda_call(driver.cuMemImportFromShareableHandle, fd, POSIX_FD_HANDLE_TYPE)
+        harness.assert_handle_namespace(handle, False, stage)
+    finally:
+        os.close(fd)
+    try:
+        address = harness.map_allocation(handle, size, device)
+    except Exception:
+        cuda_call(driver.cuMemRelease, handle)
+        raise
+    try:
+        harness.assert_bytes(address, expected, stage)
+    except Exception:
+        harness.destroy_mapped_allocation(address, size, handle)
+        raise
+    return handle, address
+
+
+def _worker(rank: int, options: Options) -> None:
+    harness.require_launch_job()
+    cuda_call(driver.cuInit, 0)
+    device = cuda_call(driver.cuDeviceGet, rank)
+    properties = harness.allocation_properties(device)
+    granularity = harness.allocation_granularity(properties)
+    private_size = granularity
+    bulk_size = harness.round_up(options.carrier_bytes, granularity)
+    private_seed = options.seed + 2 * rank
+    bulk_seed = options.seed + 2 * rank + 1
+
+    # The driver does not need a context for cuMemCreate, so neither may the shim.
+    harness.assert_no_current_context("worker before the first cuMemCreate")
+    private_handle = cuda_call(driver.cuMemCreate, private_size, properties, 0)
+    harness.assert_handle_namespace(private_handle, True, "tracked cuMemCreate")
+
+    torch.cuda.set_device(rank)
+    for other_rank, fd in enumerate(options.raw_fds):
+        if other_rank != rank:
+            os.close(fd)
+    for other_rank, fd in enumerate(options.restore_fds):
+        if other_rank != rank:
+            os.close(fd)
+    restore_socket = socket.socket(fileno=options.restore_fds[rank])
+
+    raw_handle, raw_address = _import_raw(
+        options.raw_fds[rank], granularity, device, bytes([rank + 1]) * 32, "raw import"
+    )
+    if not options.hold_raw_import:
+        harness.destroy_mapped_allocation(raw_address, granularity, raw_handle)
+
+    private_address = harness.map_allocation(private_handle, private_size, device)
+    retained_handle = cuda_call(driver.cuMemRetainAllocationHandle, private_address)
+    harness.assert_handle_namespace(retained_handle, True, "tracked retain")
+    cuda_call(driver.cuMemRelease, retained_handle)
+    _fill(private_address, private_size, private_seed, rank)
+
+    bulk_handle = cuda_call(driver.cuMemCreate, bulk_size, properties, 0)
+    harness.assert_handle_namespace(bulk_handle, True, "tracked bulk cuMemCreate")
+    bulk_address = harness.map_allocation(bulk_handle, bulk_size, device)
+    _fill(bulk_address, bulk_size, bulk_seed, rank)
+    (options.sync_dir / f"carrier-{rank}").write_text(f"2 {private_size + bulk_size}\n")
+
+    if options.hold_raw_import:
+        # Nothing to restore in this mode: the test only checks that prepare is
+        # refused and that the workload keeps working afterwards.
+        restore_socket.close()
+        (options.sync_dir / f"ready-{rank}").touch()
+        _wait_for_continue(options.sync_dir)
+        harness.destroy_mapped_allocation(raw_address, granularity, raw_handle)
+        probe = cuda_call(driver.cuMemCreate, granularity, properties, 0)
+        harness.assert_handle_namespace(probe, True, "cuMemCreate after a refused prepare")
+        cuda_call(driver.cuMemRelease, probe)
+        _verify(private_address, private_size, private_seed, rank, "private after refused prepare")
+        _verify(bulk_address, bulk_size, bulk_seed, rank, "bulk after refused prepare")
+        (options.sync_dir / f"done-{rank}").touch()
+        harness.destroy_mapped_allocation(bulk_address, bulk_size, bulk_handle)
+        harness.destroy_mapped_allocation(private_address, private_size, private_handle)
+        return
+
+    dist.init_process_group(
+        "gloo", init_method=f"file://{options.store_path}", rank=rank, world_size=WORLD_SIZE
+    )
+    group_name = dist.group.WORLD.group_name
+    input_tensor = symm_mem.empty(NUMEL, dtype=torch.float32, device="cuda")
+    input_tensor.fill_(rank + 1)
+    symm_handle = symm_mem.rendezvous(input_tensor, group=group_name)
+    if options.multicast:
+        if not symm_handle.has_multicast_support:
+            raise AssertionError("PyTorch silently fell back from CUDA multicast")
+        if int(symm_handle.multicast_ptr) == 0:
+            raise AssertionError("PyTorch selected multicast without a multicast VA")
+        _replace_local_binding_with_address(rank, input_tensor, symm_handle, properties)
+        dist.barrier()
+    output = torch.empty_like(input_tensor)
+
+    _collective(input_tensor, group_name, output, options.multicast)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _collective(input_tensor, group_name, output, options.multicast)
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "before checkpoint")
+    (options.sync_dir / f"ready-{rank}").touch()
+
+    _wait_for_continue(options.sync_dir)
+
+    # A raw import made after restore must work like before.
+    fresh_fd = recv_handle(restore_socket)
+    restore_socket.close()
+    fresh_handle, fresh_address = _import_raw(
+        fresh_fd, granularity, device, bytes([0x40 + rank]) * 32, "raw import after restore"
+    )
+    harness.destroy_mapped_allocation(fresh_address, granularity, fresh_handle)
+
+    _verify(private_address, private_size, private_seed, rank, "private allocation after restore")
+    _verify(bulk_address, bulk_size, bulk_seed, rank, "bulk allocation after restore")
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "after restore")
+    (options.sync_dir / f"done-{rank}").touch()
+
+    dist.barrier()
+    del graph, output, symm_handle, input_tensor
+    torch.cuda.empty_cache()
+    dist.destroy_process_group()
+    harness.destroy_mapped_allocation(bulk_address, bulk_size, bulk_handle)
+    harness.destroy_mapped_allocation(private_address, private_size, private_handle)
+
+
+def _collective(
+    input_tensor: torch.Tensor, group_name: str, output: torch.Tensor, multicast: bool
+) -> None:
+    operation = (
+        torch.ops.symm_mem.multimem_one_shot_all_reduce_out
+        if multicast
+        else torch.ops.symm_mem.one_shot_all_reduce_out
+    )
+    operation(input_tensor, "sum", group_name, output)
+
+
+def _replace_local_binding_with_address(
+    rank: int, input_tensor: torch.Tensor, symm_handle, properties: driver.CUmemAllocationProp
+) -> None:
+    """Rebind this rank's slice of the multicast object through
+    cuMulticastBindAddr, so both bind entry points are exercised."""
+    granularity = int(
+        cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+        )
+    )
+    buffer_size = input_tensor.numel() * input_tensor.element_size()
+    signal_offset = (buffer_size + 15) // 16 * 16
+    unrounded_size = signal_offset + symm_mem.get_signal_pad_size()
+    block_size = harness.round_up(unrounded_size, granularity)
+    multicast_handle = cuda_call(
+        driver.cuMemRetainAllocationHandle, int(symm_handle.multicast_ptr)
+    )
+    harness.assert_handle_namespace(multicast_handle, True, "retained multicast handle")
+    device = cuda_call(driver.cuDeviceGet, rank)
+    try:
+        cuda_call(driver.cuMulticastUnbind, multicast_handle, device, 0, block_size)
+        cuda_call(
+            driver.cuMulticastBindAddr,
+            multicast_handle,
+            0,
+            int(symm_handle.buffer_ptrs[rank]),
+            block_size,
+            0,
+        )
+    finally:
+        cuda_call(driver.cuMemRelease, multicast_handle)
+
+
+def _assert_exact_result(output: torch.Tensor, stage: str) -> None:
+    expected = torch.full((NUMEL,), 3.0, dtype=torch.float32)
+    actual = output.cpu()
+    if not torch.equal(actual, expected):
+        mismatch = torch.nonzero(actual != expected)[0].item()
+        raise AssertionError(
+            f"{stage}: output[{mismatch}] is {actual[mismatch].item()}, expected 3.0"
+        )
+
+
+# --- the parent ---------------------------------------------------------------
+
+
+def _fork_workers(options: Options) -> None:
+    if torch.cuda.is_initialized():
+        raise RuntimeError("parent initialized CUDA before forking workers")
+    harness.assert_no_current_context("parent before forking workers")
+
+    children = []
+    for rank in range(WORLD_SIZE):
+        child = os.fork()
+        if child == 0:
+            try:
+                _worker(rank, options)
+            except BaseException:  # noqa: BLE001 -- report child failures to the parent
+                traceback.print_exc()
+                os._exit(1)
+            os._exit(0)
+        children.append((rank, child))
+        (options.sync_dir / f"pid-{rank}").write_text(f"{child}\n")
+
+    for fd in options.raw_fds + options.restore_fds:
+        os.close(fd)
+
+    remaining = dict(children)
+    while remaining:
+        failures = []
+        for rank, child in tuple(remaining.items()):
+            waited, status = os.waitpid(child, os.WNOHANG)
+            if waited == 0:
+                continue
+            del remaining[rank]
+            exit_code = os.waitstatus_to_exitcode(status)
+            if not os.WIFEXITED(status) or exit_code != 0:
+                failures.append(f"rank {rank} PID {child}: {exit_code}")
+        if failures:
+            for child in remaining.values():
+                try:
+                    os.kill(child, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            for child in remaining.values():
+                os.waitpid(child, 0)
+            raise RuntimeError(f"forked workers failed: {', '.join(failures)}")
+        time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    _fork_workers(Options(sys.argv))

--- a/docs/guides/vllm.md
+++ b/docs/guides/vllm.md
@@ -117,9 +117,29 @@ source and restored containers.
 > [!NOTE]
 > This example runs vLLM directly through `AsyncLLM` rather than `vllm serve`, so
 > the standard `vllm serve` command-line arguments do not apply. The model is
-> selected with `SNAPSHOT_MODEL`, and other runtime settings are supplied through
-> vLLM's [environment variables](https://docs.vllm.ai/en/v0.27.1/configuration/env_vars/)
+> selected with `SNAPSHOT_MODEL`; further engine arguments go in
+> `SNAPSHOT_ENGINE_ARGS` as a JSON object (for example
+> `{"tensor_parallel_size": 2, "kv_cache_memory_bytes": 2147483648}`), and
+> other runtime settings are supplied through vLLM's
+> [environment variables](https://docs.vllm.ai/en/v0.27.1/configuration/env_vars/)
 > set in the Deployment's Pod template.
+
+### Tensor parallelism
+
+A tensor-parallel replica shares GPU memory between its worker processes.
+Snapshot needs the CUDA interposer for that: add the annotation
+`nvidia.com/cuinterpose: enabled` to the Pod template, set
+`tensor_parallel_size` in `SNAPSHOT_ENGINE_ARGS`, request the matching number
+of GPUs, and give the container an explicit `command` (the launch-job wrapper
+needs one). With a `SnapshotJob`, the operator shapes the Pod itself. With a
+`PodSnapshot` of a Deployment you manage, shape the Pod template with
+`podcontract.ShapeCuinterposeCapture` from `api/podcontract` (it adds the init
+container that copies the shim out of the agent image, `LD_PRELOAD`, and the
+`cuda-checkpoint --launch-job` wrapper). Keep allocators on POSIX descriptors:
+`VLLM_ALLREDUCE_USE_FLASHINFER=1` with `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm`
+uses them for its unicast and multicast workspace, whereas the `mnnvl` backend
+and PyTorch symmetric memory prefer fabric handles on nodes that offer them,
+which the interposer does not track (see [limitations](../limitations.md)).
 
 Deploy the edited manifest:
 

--- a/docs/guides/vllm/app.py
+++ b/docs/guides/vllm/app.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 import os
 from pathlib import Path
 from uuid import uuid4
@@ -16,6 +17,24 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 CONTROL_DIR = Path(os.environ.get("SNAPSHOT_CONTROL_DIR", "/snapshot-control"))
 MODEL = os.environ["SNAPSHOT_MODEL"]
+# Extra AsyncEngineArgs fields as a JSON object, for example
+# {"tensor_parallel_size": 2, "kv_cache_memory_bytes": 2147483648,
+#  "attention_config": {"backend": "FLASHINFER", "use_trtllm_attention": true}}.
+ENGINE_ARGS = json.loads(os.environ.get("SNAPSHOT_ENGINE_ARGS", "{}"))
+
+
+def engine_args() -> dict:
+    """Nested configs arrive as JSON objects; hand vLLM the dataclasses it expects."""
+    args = dict(ENGINE_ARGS)
+    if isinstance(args.get("attention_config"), dict):
+        from vllm.config import AttentionConfig
+
+        args["attention_config"] = AttentionConfig(**args["attention_config"])
+    if isinstance(args.get("compilation_config"), dict):
+        from vllm.config import CompilationConfig
+
+        args["compilation_config"] = CompilationConfig(**args["compilation_config"])
+    return args
 
 
 class GenerateRequest(BaseModel):
@@ -86,6 +105,7 @@ async def main() -> None:
         AsyncEngineArgs(
             model=MODEL,
             enable_sleep_mode=True,
+            **engine_args(),
         ),
         usage_context=UsageContext.LLM_CLASS,
     )

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -15,3 +15,41 @@ roadmap.
   that will be snapshotted.
 
 Multi-GPU and Arm support are on the roadmap.
+
+## Shared CUDA memory (cuinterpose)
+
+Pods that opt in with the `nvidia.com/cuinterpose: enabled` annotation can be
+checkpointed while their processes share GPU memory through the CUDA virtual
+memory API and CUDA multicast (tensor-parallel workers, NCCL, FlashInfer,
+PyTorch symmetric memory). The design and its reasoning are in
+[the cuinterpose reference](reference/cuinterpose.md). What it does not cover:
+
+- **Memory shared with a process that does not carry the shim.** An import of a
+  descriptor that did not come from the shim (a raw `cuMemImportFromShareableHandle`)
+  cannot be repaired after restore, so the checkpoint is refused while such an
+  import is alive. A descriptor duplicated or passed around outside the shim's
+  view is the same case.
+- **Fabric handles.** Allocations and multicast objects created with the
+  `CU_MEM_HANDLE_TYPE_FABRIC` handle type (or any handle type other than exactly
+  the POSIX file descriptor) pass through untracked; their sharing does not
+  survive a checkpoint. PyTorch, vLLM, and SGLang allocators prefer fabric
+  handles on nodes where the driver offers them; configure them for POSIX
+  descriptors (for example FlashInfer's `trtllm` allreduce backend rather than
+  `mnnvl`).
+- **Legacy CUDA IPC** (`cudaIpcGetMemHandle`), multi-node (IMEX) multicast, and
+  another `dlsym` interposer in the same process.
+- **Forking a process after it holds tracked memory.** The child gets a fresh
+  identity and no records; the parent's sharing is unaffected.
+- **A checkpoint while communicators are being set up.** The workload must be
+  quiescent from the moment the checkpoint starts until the restore-complete
+  sentinel: no CUDA calls, no new shares, no new processes.
+- **Topology changes between checkpoint and restore:** a different GPU count,
+  multicast group, or per-rank `CUDA_VISIBLE_DEVICES` (the coordinator identifies
+  devices by their process-local ordinal).
+- **Rollback.** Once the shim has taken the sharing apart for a checkpoint there
+  is no way back; a checkpoint that fails afterwards ends the source.
+- **Limits:** at most 32 access descriptors per mapping and 4096 records per
+  process; `cuMemUnmap` and `cuMemSetAccess` over part of a tracked mapping are
+  refused.
+- **State files from earlier builds** are not read; source and restore nodes
+  must run the same agent image.

--- a/docs/reference/cuinterpose.md
+++ b/docs/reference/cuinterpose.md
@@ -1,0 +1,488 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# cuinterpose: checkpointing CUDA memory that processes share
+
+> For someone reviewing the pull requests that add cuinterpose, who wants to
+> understand what the pieces do and why. Not a specification: the code is the
+> specification, and each section names the files that implement it.
+
+## 1. The problem in one page
+
+Snapshot checkpoints a container with CRIU for the CPU side and NVIDIA's
+`cuda-checkpoint` for the GPU side. `cuda-checkpoint` saves each process's GPU
+memory and restores it into a fresh allocation later. That works for memory a
+process uses alone.
+
+Inference servers do not use GPU memory alone. Tensor-parallel workers share
+buffers between processes on the same node: one process allocates a buffer
+with the CUDA virtual memory management API (`cuMemCreate`), exports it as a
+file descriptor (`cuMemExportToShareableHandle`), passes the descriptor to a
+sibling over a socket, and the sibling imports it (`cuMemImportFromShareableHandle`)
+and maps it into its own address space. NCCL, FlashInfer, and PyTorch's
+symmetric memory all do this. Multicast objects (`cuMulticastCreate`) go one
+step further: several GPUs write one buffer through NVLink.
+
+Two things break when such a process tree is checkpointed and restored:
+
+1. **The restored copies are private.** `cuda-checkpoint` restores each
+   process's memory as new allocations owned by that process. The importer's
+   view of the creator's buffer becomes a separate buffer with a stale copy of
+   the bytes. Nothing fails; the processes just stop seeing each other's
+   writes.
+2. **Exports of restored memory fail.** On the r615 driver, large device
+   allocations carry a fabric linear address (FLA) handle from the moment they
+   are created. That handle is not rebuilt on restore, so the next
+   `cuMemExportToShareableHandle` on a restored allocation fails with
+   `CUDA_ERROR_INVALID_VALUE`, and a multicast rebuild after restore cannot
+   proceed.
+
+cuinterpose fixes both by standing between the application and the driver.
+It watches the sharing happen, takes the sharing apart just before the native
+checkpoint so the driver only sees plain memory, and puts it back together just
+after the native restore, in every process, in the right order.
+
+## 2. The cast
+
+| Piece | What it is | Where |
+| --- | --- | --- |
+| **Workload process** | vLLM, SGLang, or any CUDA program. Unchanged. | the source Pod |
+| **Shim** (`libcuinterpose.so`) | A library loaded first via `LD_PRELOAD` into every container process. It replaces the CUDA driver functions that create, export, import, map, and bind shared memory, forwards each call to the real driver, and records what happened. | `agent/cmd/cuinterpose/interpose.c`, `multicast.c`, `symbols.c` |
+| **Listener** | One thread the shim starts per process, serving a Unix socket at `/snapshot-control/cuinterpose-<pid>.sock` (pid as seen inside the container). Peers ask it for real file descriptors; the coordinator asks it to describe, tear down, and rebuild. Each request gets its own short-lived thread. | `interpose.c` |
+| **Ticket** | What the application gets instead of a real exported descriptor: a sealed in-memory file (memfd) naming the creator process, the allocation, and a random authorization token. Applications pass tickets around exactly as they would pass descriptors. | `posix.c` |
+| **Export cache** | The creator's real exported descriptor, kept open while the allocation is live so the listener can hand out copies without calling the driver or taking the shim's lock. | `export_cache.c` |
+| **Tables** | Open-addressing hash tables (logical handle → record, allocation id → record) and a sorted range index (address → mapping) that shrink as well as grow, so a server that maps and unmaps all day does not slow down. | `table.c` |
+| **Context helpers** | Remember which CUDA context an allocation belongs to and switch to it for the lifecycle work, falling back to the device's primary context for memory that never had one. | `context.c` |
+| **Coordinator** (`cuinterpose-coordinator`) | A static program the agent runs once before checkpoint and once after restore. It talks to every listener, validates that the processes agree about what is shared, and drives them through the steps in order. It never touches the GPU. | `coordinator.c` |
+| **snapshot-agent** | Decides *when*: detects the shim by its sockets, runs the coordinator, records what happened in the checkpoint manifest, mounts the shim at restore. | `agent/internal/cuda/cuinterpose.go`, `agent/internal/executor` |
+| **Operator / podcontract** | Puts the shim into an opted-in Pod: an init container copies `libcuinterpose.so` and `cuda-checkpoint` from the agent image into an emptyDir, mounts it at `/tmp/cuinterpose`, sets `LD_PRELOAD`, and wraps the command with `cuda-checkpoint --launch-job`. | `api/podcontract/cuinterpose.go` |
+| **cuda-checkpoint** | NVIDIA's tool. Saves and restores a process's GPU state natively. Sees only plain memory because the shim has taken the sharing apart first. | agent bundle |
+| **CRIU** | Saves and restores the processes themselves, including the shim's own bookkeeping, which is ordinary process memory. | agent bundle |
+
+The shim's bookkeeping surviving CRIU is the trick that makes restore possible:
+after CRIU, every process still remembers exactly which allocations it created
+or imported, at which addresses they were mapped, and with what access. Only
+the driver-side objects behind those records are gone, and the coordinator's
+job is to have each process recreate them.
+
+## 3. Flows
+
+### 3.1 Sharing an allocation while the workload runs
+
+```mermaid
+sequenceDiagram
+    participant AppC as Creator process
+    participant ShimC as Creator shim
+    participant LisC as Creator listener
+    participant AppI as Importer process
+    participant ShimI as Importer shim
+    AppC->>ShimC: cuMemCreate(POSIX fd handle type)
+    ShimC->>ShimC: real cuMemCreate; record allocation; return a logical handle
+    AppC->>ShimC: cuMemExportToShareableHandle
+    ShimC->>ShimC: first export: real driver export, keep the fd (export cache)
+    ShimC-->>AppC: ticket (sealed memfd)
+    AppC->>AppI: ticket fd over the app's own channel (NCCL socket etc.)
+    AppI->>ShimI: cuMemImportFromShareableHandle(ticket)
+    ShimI->>LisC: connect to creator's socket, EXPORT{allocation, authorization}
+    LisC-->>ShimI: copy of the cached fd (SCM_RIGHTS); no driver call, no shared lock
+    ShimI->>ShimI: real cuMemImport; close fd; record importer entry
+    ShimI-->>AppI: logical handle
+```
+
+Why a ticket and not the real fd: the shim must learn that a share happened
+and who the two sides are. Handing out the real descriptor would make the
+import invisible. Handing out a ticket makes the importer come back to the
+creator, and that round trip is where the shim records the pair.
+
+Why the listener never calls the driver: the creator's application
+threads may be inside a long collective driver call holding the shim's lock.
+An earlier version did the real export at request time, under that lock, and
+peers timed out waiting. Exporting once at ticket time and serving copies
+removes the dependency.
+
+### 3.2 Checkpoint
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Coord as Coordinator
+    participant P as Every CUDA process (shim listener)
+    participant cc as cuda-checkpoint
+    Agent->>Agent: requested := Pod annotation; sockets := detect
+    Agent->>Coord: --prepare --proc-root /host/proc ...
+    Coord->>P: IDENTIFY, INSPECT (records + live raw import count)
+    Coord->>Coord: validate: one creator per allocation, mappings in bounds,<br/>multicast groups complete; refuse if any raw import is live
+    Coord->>P: PREPARE_MULTICAST (all at once): unbind, unmap, release multicast objects
+    Coord->>P: SAVE_HOST_CARRIER (creators, all at once): copy every creator allocation into one pinned host arena, free the device copies
+    Coord->>P: PREPARE (all at once): unmap shared mappings, drop importer handles
+    Coord->>Coord: write cuinterpose.state (rename + fsync)
+    Agent->>Agent: manifest.cuinterpose.prepared = true
+    Agent->>cc: lock + native checkpoint (sees only private memory)
+    Agent->>Agent: CRIU dump (the host copies are ordinary process pages)
+```
+
+Order matters twice. Multicast bindings sit on top of unicast allocations, so
+every process must finish multicast teardown before any process unmaps unicast
+memory. And the state file is written last, so a state file's existence means
+prepare completed everywhere.
+
+### 3.3 Restore
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant CRIU
+    participant cc as cuda-checkpoint
+    participant Coord as Coordinator
+    participant P as Every CUDA process (shim listener)
+    participant App as Application threads
+    Agent->>Agent: mount the shim at /tmp/cuinterpose (manifest.requested)
+    Agent->>Agent: delete stale cuinterpose-*.sock in /snapshot-control
+    Agent->>Agent: open the coordinator binary (fd survives the mount namespace change)
+    Agent->>CRIU: restore the process tree (app parked in its restore-complete poll loop)
+    Agent->>cc: native restore + unlock
+    Note over Agent: manifest.prepared but no cuinterpose.state → refuse
+    Agent->>Coord: --restore --proc-root "" ...
+    Coord->>P: IDENTIFY; participants must equal the checkpointed set
+    Coord->>P: RESTORE_HOST_CARRIER (creators, all at once): new device allocations, copy back from the arena; the arena is unpinned after the reply
+    Coord->>P: RESTORE_CREATORS (all at once): remap at the saved addresses, restore access, re-export
+    Coord->>P: RESTORE_IMPORTERS (all at once): ask creators for fresh fds, import, remap
+    Coord->>P: multicast: CREATE → IMPORT → ADD_DEVICE ⟂ BIND+MAP, barrier after each
+    Coord->>P: INSPECT again; must equal the checkpointed topology
+    Agent->>App: write restore-complete → application resumes
+```
+
+The barrier between ADD_DEVICE and BIND is not a design choice. The r615 driver
+makes `cuMulticastBindMem` spin until every device in the team has been
+attached, so a bind issued before every process finished attaching would wait
+forever.
+
+### 3.4 Other flows
+
+**Fork.** The shim registers `pthread_atfork` handlers. The child of a fork
+inherits none of the parent's records, descriptors, or socket: CUDA contexts do
+not survive `fork()`, so nothing the parent tracked is usable in the child. The
+child mints a new participant identity and starts its own listener on its first
+CUDA activity (any interposed call or any driver symbol resolution). vLLM and
+PyTorch fork their workers before touching CUDA, which is the supported shape;
+forking a process that already holds tracked memory leaves the parent intact
+and the child with a clean slate.
+
+**Processes that come and go.** A CUDA server spawns thousands of short-lived
+helpers (compilation workers, `nvidia-smi`, shells), and every one of them loads
+the shim through `LD_PRELOAD` and gets a socket. A process that exits without
+running destructors leaves its socket file behind; the next process to start an
+endpoint in the same control directory removes the sockets whose owner is gone.
+
+**Agent restart during restore.** The restore path is idempotent up to the
+coordinator: the agent deletes stale `cuinterpose-*.sock` files before CRIU,
+because CRIU would fail to `bind()` onto a path that exists. A restore that is
+interrupted after the native restore but before the coordinator finished leaves
+the shims in an intermediate phase, in which every VMM call answers
+`CUDA_ERROR_NOT_READY`; the application, parked in its poll loop, notices
+nothing until the sentinel is written, and the sentinel is written only after
+the coordinator succeeded.
+
+**Failed prepare.** A failure in INSPECT or validation is free: nothing was torn
+down, the shims stay active, the checkpoint is reported failed. A failure in
+PREPARE_MULTICAST, SAVE_HOST_CARRIER, or PREPARE is not: the shim that failed
+moves to the *failed* phase and the others may already have torn down their
+sharing. There is no rollback; the checkpoint fails and the source Pod is
+terminated by the agent as it would be for any failed checkpoint.
+
+**Failed restore.** The coordinator stops at the first failing phase, prints
+which participant refused and why, and exits non-zero; the agent fails the
+restore and the Pod. Restoring the same checkpoint again into a fresh Pod is
+allowed: the state file is read-only.
+
+## 4. Lifecycle phases
+
+Each shim moves through these phases; the coordinator's requests are refused
+out of order, so a stray or repeated request cannot corrupt the state.
+
+```mermaid
+stateDiagram-v2
+    [*] --> active
+    active --> carriers: PREPARE_MULTICAST (multicast torn down, creator handles pinned)
+    carriers --> prepared: PREPARE (after SAVE_HOST_CARRIER)
+    prepared --> creators_restored: RESTORE_CREATORS (after RESTORE_HOST_CARRIER)
+    creators_restored --> unicast_restored: RESTORE_IMPORTERS
+    unicast_restored --> multicast_created: RESTORE_MULTICAST_CREATORS
+    multicast_created --> multicast_imported: RESTORE_MULTICAST_IMPORTERS
+    multicast_imported --> multicast_joined: RESTORE_MULTICAST_DEVICES
+    multicast_joined --> active: RESTORE_MULTICAST
+    active --> failed: any lifecycle step fails
+    carriers --> failed
+    prepared --> failed
+    creators_restored --> failed
+    unicast_restored --> failed
+    multicast_created --> failed
+    multicast_imported --> failed
+    multicast_joined --> failed
+```
+
+What the application sees, by phase:
+
+| Call on a tracked object | active | any other phase |
+| --- | --- | --- |
+| `cuMemCreate`, `cuMulticastCreate` with the POSIX handle type | tracked, logical handle returned | `CUDA_ERROR_NOT_READY` |
+| map, unmap, set access, export, import, retain, release, bind, unbind | forwarded and recorded | `CUDA_ERROR_NOT_READY` |
+| the same calls on untracked memory (other handle types, raw descriptors) | forwarded | forwarded |
+| import of a ticket by a peer (listener EXPORT request) | served from the export cache | refused ("not accepting exports") |
+
+`IDENTIFY` and `INSPECT` report the phase, so a coordinator that finds a shim
+in the wrong phase can say so.
+
+## 5. Formats
+
+**Ticket** (`posix.h`): 256 bytes in a sealed memfd (`F_SEAL_WRITE`, `SHRINK`,
+`GROW`, `SEAL`), which is how the shim tells a ticket apart from a real driver
+descriptor (a character device, on which `F_GET_SEALS` fails). Fields: magic
+and version; the creator's participant id (32 hex digits) and socket path; the
+16-byte allocation id; a 32-byte random authorization token; the resource kind
+(unicast allocation or multicast object); for multicast objects the requested
+size, handle type, flags, and device count, which the importer checks against
+an object it already knows.
+
+**Control message** (`protocol.h`): one 256-byte header each way, optionally
+followed by `count` records and optionally carrying one descriptor as
+`SCM_RIGHTS`. The header names the operation, the participant, a status and
+message, the allocation id and authorization for EXPORT, the live raw import
+and pass-through creation counts and the phase in IDENTIFY/INSPECT replies,
+`payload_size` (bytes copied) and `copy_us` (how long the copies took) in
+carrier replies.
+
+**Record** (`protocol.h`): 688 bytes describing one allocation, mapping,
+multicast object, attached device, binding, or multicast mapping, with up to 32
+access descriptors. Records sort so that an object precedes what depends on
+it.
+
+**State file** (`cuinterpose.state`, written by the coordinator): text. The
+first line is `cuinterpose-state-v2`; then, for each participant in sorted
+order, `participant <id> <count>` followed by `count` records, each one line of
+hex. Written to a temporary name, fsynced, renamed, and the directory fsynced,
+so a state file that exists is complete. Restore refuses to run without it when
+the manifest says prepare ran.
+
+**Manifest** (`agent/internal/types/manifest.go`): `cuinterpose.requested`
+(the source Pod opted in; restore mounts the shim) and `cuinterpose.prepared`
+(prepare wrote the state file; restore runs the coordinator, and a missing
+state file is a hard failure).
+
+## 6. Invariants
+
+- **Creator anchor.** The process that created a shared allocation must still
+  hold a handle to it or a mapping of it at checkpoint time. It is the only
+  process that can re-export the memory after restore; without it the
+  importers have nothing to import. The coordinator refuses a checkpoint that
+  violates this.
+- **Tickets live as long as the creator's local references.** When the creator
+  releases its last handle and unmaps its last mapping, the allocation is
+  gone from the shim's tables and any ticket for it is dead. This matches what
+  the application asked for: freeing memory frees it.
+- **One backing driver reference per allocation per process.** Several logical
+  handles (from repeated imports or `cuMemRetainAllocationHandle`) share one
+  driver handle; releasing the last logical handle releases the driver's.
+- **Access is merged per location.** `cuMemSetAccess` may be called once per
+  GPU; the shim keeps the union and replays it on restore.
+- **Multicast phase barrier.** Every process finishes attaching devices before
+  any process binds memory (see 3.3).
+- **Quiescence.** From the moment the agent starts detecting until the source
+  is terminated after checkpoint, and from CRIU restore until the
+  restore-complete sentinel, the workload issues no CUDA calls and no shares.
+  Dynamo workloads park in a poll loop for exactly this reason. The shim's
+  "not ready" answers during that window are safe only because nothing is
+  asking.
+- **Prepare is one-way.** After prepare has torn down the sharing there is no
+  rollback; a checkpoint that fails afterwards leaves the source unusable and
+  the agent terminates it.
+- **One real export per allocation or object per process while active.** The
+  descriptor lives in the export cache and is closed by PREPARE (unicast) or
+  PREPARE_MULTICAST (multicast, before the object is released, because the
+  descriptor is itself a reference to the object); restore exports again.
+- **Every tracked creator allocation is carried through the host.** Not just
+  the exported ones: a never-exported allocation may be exported for the first
+  time after restore, and the sticky fabric state would make that fail.
+- **Lock order.** The shim's state lock is taken before the export cache's
+  lock, never the other way; the listener takes only the cache lock. Team
+  collectives (`cuMulticastCreate`, `AddDevice`, bind, map) run without the
+  state lock and re-look up their object afterwards.
+
+## 7. Performance
+
+Measured on the nscale-dev cluster (B200, kernel driver 595.58.03) with the
+vLLM guide's `app.py`, Qwen3-0.6B, tensor parallel 2, FlashInfer TRT-LLM
+attention and fused allreduce, four CUDA processes:
+
+| Step | Time | Notes |
+| --- | --- | --- |
+| checkpoint, total | 52 s | |
+| of which CRIU dump | 48.9 s | process memory including the host arena and vLLM's CPU-offloaded weights |
+| of which native `cuda-checkpoint` | 2.3 s | |
+| of which cuinterpose prepare | 0.43 s | 1052 records, 382 carriers, 2.08 GB |
+| restore, total | 5.7 s | Pod ready 13 s after the Deployment was applied |
+| of which CRIU restore | 2.5 s | |
+| of which native CUDA restore | 2.1 s | |
+| of which cuinterpose restore | 0.35 s | host carriers 0.05 s (2.08 GB at 43 GB/s for the phase, 105 GB/s for the copies), unicast 0.09 s, multicast 0.18 s |
+
+The host carrier copies are the part that scales with the workload, and the
+version reviewed here changed how they are done. With one pinned buffer and
+one staging mapping per allocation, the restore phase reached 17 to 30 GB/s
+aggregate over two GPUs (256 MiB to 8 GiB per rank), against a pinned-copy
+baseline of 55 GB/s per GPU: pinning, mapping, and unpinning each of vLLM's
+hundreds of 2 MiB pieces cost more than moving the bytes. With one pinned
+arena per process, one staging range per context, and the unpinning moved
+after the reply, the same phase runs at 87 to 108 GB/s aggregate, and the
+copies alone at 82 GB/s aggregate on the checkpoint side. The coordinator
+prints both figures (`gb_per_s` for the phase, `copy_gb_per_s` for the
+transfer) so a regression in either is visible in the agent log.
+
+The remaining cost of the save phase (0.34 s for 2 GB, of which the copies are
+25 ms) is populating and pinning the arena's pages; it happens before the
+native checkpoint, off the restore hot path, and a `MAP_POPULATE` mapping is
+already the cheapest way to get pinned pages the driver accepts.
+
+## 8. Pitfalls we hit and fixed
+
+- **Sticky fabric state (r615).** `cuMemCreate` attaches a fabric linear
+  address to large allocations at creation and native restore does not rebuild
+  it, so a restored allocation cannot be exported again and peer NVLink access
+  fails. Fix: every creator allocation goes through a fresh allocation at
+  restore, with its contents carried through pinned host memory.
+- **Multicast capacity rounding (r615).** The driver gives a multicast object
+  more capacity than requested (512 MiB granularity) and NCCL binds and maps
+  into it. Fix: the shim reports the largest extent actually used, the
+  coordinator checks bounds against the largest extent any participant
+  reported, and restore replays the requested size.
+- **Bind waits for the team.** `cuMulticastBindMem` spins until every device is
+  attached. Fix: a coordinator barrier between the add-device and bind phases,
+  and no shim lock held across the collective calls.
+- **Listener starvation.** An earlier version exported on request, under the
+  shim's lock, while application threads sat in long collective driver calls;
+  peers timed out. Fix: export once at ticket time, serve copies from a cache
+  the listener can read without the lock.
+- **Per-allocation host pinning.** See section 7.
+- **`cuMemCreate` without a current context.** The driver allows it; the first
+  version of the shim refused it. Fix: adopt the context at the first map or
+  export, fall back to the device's primary context in the lifecycle.
+- **Stale sockets.** Short-lived helper processes left hundreds of socket files
+  behind. Fix: sockets of dead processes are removed when an endpoint starts;
+  the agent removes them before CRIU restore as well, since a stale path makes
+  CRIU's `bind()` fail.
+- **`strtol` under glibc 2.38 headers** resolves to `__isoc23_strtol@GLIBC_2.38`,
+  and the shim must load on glibc 2.34 images. The build asserts the newest
+  glibc symbol version; number parsing is done by hand.
+- **Sanitized tests shelling out.** A child of a sanitizer-instrumented test
+  inherits `LD_PRELOAD`, and the CUDA base image's `/bin/sh` runs a profile
+  script whose helpers then report their own leaks. The tests never shell out.
+- **Access granularity.** `cuMemSetAccess` is applied per location by the
+  driver, so PyTorch's one-call-per-GPU pattern must be merged, not replaced;
+  and eight GPUs plus host NUMA nodes overflow an eight-entry record. Records
+  hold 32 access descriptors and the shim refuses a call that would exceed them
+  before the driver sees it.
+- **Duplicate driver references.** Repeated imports and
+  `cuMemRetainAllocationHandle` each cost a driver reference and leaked memory.
+  One driver handle per allocation per process; logical handles alias it.
+- **Listener refusing multicast requests.** Left over from the layer that did
+  not yet know multicast; caught by the two-rank fake-driver test.
+
+## 9. Explicitly unsupported
+
+The list in [`docs/limitations.md`](../limitations.md) is the user-facing one.
+For a reviewer, the reasons:
+
+- Raw imports (descriptors not produced by the shim), descriptors duplicated or
+  passed outside the shim's view: native restore gives that process a private
+  copy with no error, so the checkpoint is refused instead.
+- Fabric handle types: untracked by decision; the allocators that prefer them
+  can be steered to POSIX descriptors.
+- Legacy CUDA IPC, multi-node multicast, a second `dlsym` interposer.
+- Forking after tracked state exists; a checkpoint during communicator setup;
+  any change of GPU count, multicast group, or per-rank `CUDA_VISIBLE_DEVICES`
+  between checkpoint and restore.
+- Partial-range unmap or access changes over tracked mappings; more than 32
+  access locations per mapping; more than 4096 records per process.
+- Rollback after prepare; state files from other builds; a restore node whose
+  agent image differs from the checkpoint node's (fails inside CRIU's file
+  validation with an unhelpful message; deferred).
+
+## 10. Accepted risks
+
+- Fabric pass-through makes fabric-capable allocator pools invisible to the
+  shim; documented, and the coordinator's `passthrough_creations` count makes
+  it visible in the agent log.
+- Host staging is pool-sized: a workload that keeps its whole KV cache in
+  tracked allocations carries it through pinned host memory and the CRIU image.
+  vLLM's sleep mode makes this small in practice.
+- One `/dev/nvidiactl` descriptor per exported allocation stays open in the
+  creator while it is shared.
+- The fake-driver tests run in the agent image build, not on pull requests.
+- Fail-stop lifecycle: a failed prepare ends the source.
+- Same-UID trust on the control sockets: file mode 0600 keeps other users out,
+  and any process of the same user in the container could talk to a shim.
+- Artifacts from before this stack are not restorable (state version 2).
+
+## 11. Knobs, timeouts, and log lines
+
+Environment, read by the shim and the coordinator: `SNAPSHOT_CONTROL_DIR`
+(default `/snapshot-control`), `SNAPSHOT_PARTICIPANT_ID` (tests only),
+`SNAPSHOT_CONTROL_TIMEOUT_SECONDS` (default 10) for every exchange except the
+two that copy allocation contents, which use `SNAPSHOT_CARRIER_TIMEOUT_SECONDS`
+(default 3600).
+
+Chart: `cuinterpose.imagePullSecrets`; the agent image itself is `image.agent`.
+
+Coordinator arguments: `--prepare|--restore --proc-root PATH --checkpoint-dir
+PATH --control-dir PATH --process OBSERVED_PID NAMESPACE_PID...`.
+
+Log lines an operator will see in the agent log:
+
+- `cuinterpose coordinator phase` with `phase=`, `status=`, `elapsed_ms=`,
+  `participants=`; INSPECT adds `records=`, `live_raw_imports=`,
+  `passthrough_creations=`; the carrier phases add `carrier_count=`,
+  `carrier_bytes=`, `gb_per_s=`, `copy_gb_per_s=`.
+- `prepare refused: participant ... holds N live raw imports` when a checkpoint
+  is refused.
+- Timing summaries with `cuinterpose_prepare` and `cuinterpose_restore`
+  phases.
+- In the workload's own stderr: `cuinterpose: an allocation with the FABRIC
+  handle type passed through untracked` (once per process), `cuinterpose: host
+  carrier registration did not survive restore; re-registered`.
+
+## 12. Test matrix
+
+| Suite | Where it runs | Covers |
+| --- | --- | --- |
+| `proto_unit_test`, `table_unit_test` | agent image build | tickets, control messages, descriptor passing, tables, range index, export cache |
+| `forward_preload_test` | agent image build | all four symbol resolution paths, argument forwarding, bind ABI selection |
+| `coordinator_test` | agent image build | phase ordering, barriers, topology validation, raw import refusal, state file, restore preconditions |
+| `state_preload_test` | agent image build | tracking: alias collapse, range unmap, access merging, tickets, cross-process import, churn |
+| `lifecycle_preload_test` | agent image build | prepare and restore across two processes with the real coordinator, carriers, lost pinning, context-less allocations, fail-stop |
+| `multicast_preload_test` | agent image build | two-rank multicast group round trip, effective extent, rebind by address, pass-through, refusal of untracked members, descriptor-before-object teardown |
+| `tests/gpu` | manual, two GPUs, launch job | real driver: POSIX and multicast round trips with PyTorch, seeded contents, copy throughput against a pinned baseline, raw import refusal |
+| cluster e2e | manual, nscale-dev | vLLM TP2 with FlashInfer TRT-LLM kernels through PodSnapshot and restore, coherent inference afterwards |
+
+## 13. Reviewer's guide
+
+1. **Delivery, orchestration, packaging** (`api/podcontract`, operator,
+   chart, `agent/internal`, Dockerfile, the Makefile, `protocol.h`): the only
+   PR that touches Go. Read section 2's operator and snapshot-agent rows,
+   3.2 and 3.3 for what the agent does around the coordinator, and 5 for the
+   manifest fields and the state file. The shim and coordinator here are
+   placeholders; an annotated Pod is refused until PR 5.
+2. **Symbol resolution and forwarding** (`symbols.c`, the `dlsym`
+   replacement, `posix.c`): read 3.1 for what tickets are;
+   `forward_preload_test` is the contract.
+3. **Coordinator** (`coordinator.c`): read 3.2, 3.3, 5, and 6 (barriers).
+4. **Tracking** (`interpose.c` without the lifecycle, `table.c`,
+   `export_cache.c`): read 3.1 and 6 (creator anchor, one driver reference,
+   access merging, lock order).
+5. **Lifecycle** (`interpose.c` lifecycle, `context.c`, the coordinator's
+   carrier phases): read 3.2, 3.3, 4, 7, and the first pitfall in 8.
+6. **Multicast** (`multicast.c`): read 3.3's multicast phases, 6's barrier and
+   export invariants, and the second and third pitfalls in 8.
+7. **GPU tests** (`tests/gpu`): read 12; the harness mirrors the agent's
+   sequence with the real driver.
+8. **Docs**: this document, `docs/limitations.md`, the vLLM guide.


### PR DESCRIPTION

## Summary

`docs/reference/cuinterpose.md`: the design for reviewers (problem, cast, flows as sequence diagrams, lifecycle phases, formats, invariants, measured performance, pitfalls, unsupported cases, accepted risks, knobs and log lines, test matrix, per-PR reading guide). `docs/limitations.md`: what checkpointing shared CUDA memory does not cover. The vLLM guide gains `SNAPSHOT_ENGINE_ARGS` and a tensor-parallel section (annotation, explicit command, PodSnapshot versus SnapshotJob shaping, keeping FlashInfer's allreduce on POSIX descriptors). The shim README shrinks to usage, build, and tests.

## Validation

`make verify-license-headers`, `make helm-lint`; the vLLM guide's `app.py` is the one used in the end-to-end run described in the other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
