### PR TITLE
test(agent): cuinterpose GPU tests

### DIFF
--- a/agent/cmd/cuinterpose/tests/gpu/conftest.py
+++ b/agent/cmd/cuinterpose/tests/gpu/conftest.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures for the GPU tests.
+
+Everything here skips rather than fails when the machine cannot run the tests:
+no torch or cuda-bindings, fewer than two GPUs, not started through
+``cuda-checkpoint --launch-job``, or no CUDA headers to build the shim with.
+Set ``CUINTERPOSE_BUILD_DIR`` to a directory holding ``libcuinterpose.so`` and
+``cuinterpose-coordinator`` to use prebuilt binaries (for example copied out of
+the agent image) instead of building them here.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BUILD_TIMEOUT_SECONDS = 300
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers", "gpu: needs two GPUs, a CUDA 13 driver, and cuda-checkpoint --launch-job"
+    )
+    config.addinivalue_line(
+        "markers", "multicast: additionally needs NVLink between the two GPUs"
+    )
+
+
+@pytest.fixture(scope="session")
+def tools(tmp_path_factory: pytest.TempPathFactory):
+    """The shim and coordinator under test, prebuilt or built once per session."""
+    from harness import Tools
+
+    prebuilt = os.environ.get("CUINTERPOSE_BUILD_DIR")
+    if prebuilt:
+        build_dir = Path(prebuilt)
+    else:
+        source_dir = Path(__file__).resolve().parents[2]
+        cuda_home = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda"))
+        compiler = os.environ.get("CC", "cc")
+        missing = [
+            requirement
+            for requirement, present in (
+                ("make on PATH", shutil.which("make") is not None),
+                ("readelf on PATH", shutil.which("readelf") is not None),
+                (f"{compiler} on PATH", shutil.which(compiler) is not None),
+                (f"{cuda_home}/include/cuda.h", (cuda_home / "include" / "cuda.h").is_file()),
+            )
+            if not present
+        ]
+        if missing:
+            pytest.skip(
+                "cannot build the shim: missing "
+                + ", ".join(missing)
+                + "; set CUDA_HOME, or CUINTERPOSE_BUILD_DIR to prebuilt binaries"
+            )
+        build_dir = tmp_path_factory.mktemp("cuinterpose-build")
+        result = subprocess.run(
+            ["make", "-C", str(source_dir), f"BUILD_DIR={build_dir}", f"CUDA_HOME={cuda_home}", "all"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=BUILD_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            pytest.fail(f"shim build failed ({result.returncode}):\n{result.stdout}{result.stderr}")
+    interposer = (build_dir / "libcuinterpose.so").resolve()
+    coordinator = (build_dir / "cuinterpose-coordinator").resolve()
+    if not interposer.is_file() or not coordinator.is_file():
+        pytest.fail(f"{build_dir} does not hold libcuinterpose.so and cuinterpose-coordinator")
+    return Tools(interposer, coordinator)
+
+
+@pytest.fixture(scope="session")
+def gpu_environment(tools):
+    pytest.importorskip("torch")
+    pytest.importorskip("cuda.bindings")
+    import harness
+
+    launch_job = harness.launch_job_fds()
+    if launch_job is None:
+        pytest.skip("run through cuda-checkpoint --launch-job (CUDA_CHECKPOINT_JOB_FILE is unset)")
+    gpus = harness.visible_gpus()
+    if gpus is None:
+        pytest.skip(f"needs {harness.WORLD_SIZE} distinct GPUs (CUDA_VISIBLE_DEVICES)")
+    return harness.Environment(tools, gpus, launch_job)
+
+
+@pytest.fixture(scope="session")
+def multicast_supported(gpu_environment):
+    """Skips unless both GPUs report multicast support (NVLink / NVSwitch)."""
+    import harness
+    from cuda.bindings import driver
+
+    harness.cuda_call(driver.cuInit, 0)
+    for ordinal in range(harness.WORLD_SIZE):
+        device = harness.cuda_call(driver.cuDeviceGet, ordinal)
+        supported = harness.cuda_call(
+            driver.cuDeviceGetAttribute,
+            driver.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
+            device,
+        )
+        if not int(supported):
+            pytest.skip(f"GPU {ordinal} does not support CUDA multicast")
+    return True
+
+
+@pytest.fixture
+def seed(record_property) -> int:
+    """Seed for the random buffer contents; set CUINTERPOSE_TEST_SEED to replay."""
+    value = int(os.environ.get("CUINTERPOSE_TEST_SEED") or random.getrandbits(32))
+    record_property("cuinterpose_test_seed", value)
+    print(f"\ncuinterpose test seed: {value} (CUINTERPOSE_TEST_SEED={value} to replay)")
+    return value

--- a/agent/cmd/cuinterpose/tests/gpu/harness.py
+++ b/agent/cmd/cuinterpose/tests/gpu/harness.py
@@ -1,0 +1,682 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared pieces of the GPU tests.
+
+The test process never loads the shim. It launches one interposed *parent*
+Python process (``worker.py``) that forks ``WORLD_SIZE`` CUDA workers, and then
+drives a checkpoint from the outside exactly as the snapshot agent would:
+``cuinterpose-coordinator --prepare``, the native ``cuCheckpointProcess*``
+sequence, ``cuinterpose-coordinator --restore``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import queue
+import re
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from multiprocessing.reduction import send_handle
+from pathlib import Path
+from typing import NamedTuple
+
+from cuda.bindings import driver
+
+WORLD_SIZE = 2
+COMMAND_TIMEOUT_SECONDS = 60
+CHECKPOINT_TIMEOUT_SECONDS = 120
+WORKER_TIMEOUT_SECONDS = 240
+
+# Names pinned to protocol.h.
+SOCKET_PREFIX = "cuinterpose-"
+STATE_FILENAME = "cuinterpose.state"
+CONTROL_DIR_ENV = "SNAPSHOT_CONTROL_DIR"
+PARTICIPANT_ID_ENV = "SNAPSHOT_PARTICIPANT_ID"
+# 32 lowercase hex digits; the shim accepts it as the parent's identity.
+PARENT_PARTICIPANT_ID = "a" * 32
+
+# Logical handles carry this tag in the top 16 bits (interpose.c).
+LOGICAL_HANDLE_TAG = 0xD94D000000000000
+LOGICAL_HANDLE_TAG_MASK = 0xFFFF000000000000
+
+POSIX_FD_HANDLE_TYPE = (
+    driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+)
+
+PHASE_LINE = re.compile(
+    r"^cuinterpose-coordinator phase=(?P<phase>\S+) status=(?P<status>\S+)"
+    r"(?P<rest>(?: \S+=\S+)*)$"
+)
+
+
+class Tools(NamedTuple):
+    interposer: Path
+    coordinator: Path
+
+
+class Environment(NamedTuple):
+    tools: Tools
+    gpus: tuple[str, str]
+    launch_job_fds: tuple[int, ...]
+
+
+# --- thin wrappers over cuda.bindings -----------------------------------------
+
+
+def cuda_call(function, *arguments):
+    status, *outputs = function(*arguments)
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"{function.__name__} failed: {status.name} ({int(status)})")
+    if not outputs:
+        return None
+    if len(outputs) == 1:
+        return outputs[0]
+    return tuple(outputs)
+
+
+def assert_no_current_context(process: str) -> None:
+    status, context = driver.cuCtxGetCurrent()
+    if status == driver.CUresult.CUDA_ERROR_NOT_INITIALIZED:
+        return
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuCtxGetCurrent failed: {status.name} ({int(status)})")
+    if int(context) != 0:
+        raise AssertionError(f"{process} has a current CUDA context")
+
+
+def allocation_properties(device) -> driver.CUmemAllocationProp:
+    properties = driver.CUmemAllocationProp()
+    properties.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    properties.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    properties.location.id = int(device)
+    properties.requestedHandleTypes = POSIX_FD_HANDLE_TYPE
+    return properties
+
+
+def allocation_granularity(properties: driver.CUmemAllocationProp) -> int:
+    return int(
+        cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+        )
+    )
+
+
+def round_up(size: int, granularity: int) -> int:
+    return (size + granularity - 1) // granularity * granularity
+
+
+def assert_handle_namespace(handle, logical: bool, stage: str) -> None:
+    tagged = int(handle) & LOGICAL_HANDLE_TAG_MASK == LOGICAL_HANDLE_TAG
+    if tagged != logical:
+        expected = "logical" if logical else "raw"
+        raise AssertionError(f"{stage}: handle {int(handle):#x} is not {expected}")
+
+
+def map_allocation(handle, size: int, device) -> int:
+    address = int(cuda_call(driver.cuMemAddressReserve, size, size, 0, 0))
+    mapped = False
+    try:
+        cuda_call(driver.cuMemMap, address, size, 0, handle, 0)
+        mapped = True
+        access = driver.CUmemAccessDesc()
+        access.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        access.location.id = int(device)
+        access.flags = driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+        cuda_call(driver.cuMemSetAccess, address, size, [access], 1)
+    except Exception:
+        if mapped:
+            cuda_call(driver.cuMemUnmap, address, size)
+        cuda_call(driver.cuMemAddressFree, address, size)
+        raise
+    return address
+
+
+def write_bytes(address: int, expected: bytes) -> None:
+    source = ctypes.create_string_buffer(expected)
+    cuda_call(driver.cuMemcpyHtoD, address, ctypes.addressof(source), len(expected))
+
+
+def assert_bytes(address: int, expected: bytes, stage: str) -> None:
+    actual = ctypes.create_string_buffer(len(expected))
+    cuda_call(driver.cuMemcpyDtoH, ctypes.addressof(actual), address, len(expected))
+    if actual.raw != expected:
+        raise AssertionError(f"{stage}: got {actual.raw!r}, expected {expected!r}")
+
+
+def destroy_mapped_allocation(address: int, size: int, handle) -> None:
+    cuda_call(driver.cuMemUnmap, address, size)
+    cuda_call(driver.cuMemAddressFree, address, size)
+    cuda_call(driver.cuMemRelease, handle)
+
+
+# --- allocations made outside the shim ----------------------------------------
+
+
+class ExternalAllocation(NamedTuple):
+    """A POSIX-shareable allocation owned by the (uninterposed) test process.
+
+    Workers import its descriptor raw, which is exactly the "untracked import"
+    the coordinator must refuse to checkpoint while it is alive.
+    """
+
+    device: driver.CUdevice
+    context: driver.CUcontext
+    address: int
+    size: int
+    handle: driver.CUmemGenericAllocationHandle
+    fd: int
+
+
+def create_external_allocations(byte_base: int) -> list[ExternalAllocation]:
+    cuda_call(driver.cuInit, 0)
+    allocations: list[ExternalAllocation] = []
+    try:
+        for rank in range(WORLD_SIZE):
+            allocations.append(_create_external_allocation(rank, byte_base))
+    except Exception:
+        destroy_external_allocations(allocations)
+        raise
+    return allocations
+
+
+def _create_external_allocation(rank: int, byte_base: int) -> ExternalAllocation:
+    device = cuda_call(driver.cuDeviceGet, rank)
+    context = cuda_call(driver.cuDevicePrimaryCtxRetain, device)
+    handle = None
+    address = 0
+    try:
+        cuda_call(driver.cuCtxPushCurrent, context)
+        try:
+            properties = allocation_properties(device)
+            size = allocation_granularity(properties)
+            handle = cuda_call(driver.cuMemCreate, size, properties, 0)
+            address = map_allocation(handle, size, device)
+            write_bytes(address, bytes([byte_base + rank]) * 32)
+            fd = int(
+                cuda_call(
+                    driver.cuMemExportToShareableHandle, handle, POSIX_FD_HANDLE_TYPE, 0
+                )
+            )
+        except Exception:
+            if address:
+                destroy_mapped_allocation(address, size, handle)
+            elif handle is not None:
+                cuda_call(driver.cuMemRelease, handle)
+            raise
+        finally:
+            cuda_call(driver.cuCtxPopCurrent)
+    except Exception:
+        cuda_call(driver.cuDevicePrimaryCtxRelease, device)
+        raise
+    return ExternalAllocation(device, context, address, size, handle, fd)
+
+
+def destroy_external_allocations(allocations: list[ExternalAllocation]) -> None:
+    while allocations:
+        allocation = allocations.pop()
+        os.close(allocation.fd)
+        cuda_call(driver.cuCtxPushCurrent, allocation.context)
+        try:
+            destroy_mapped_allocation(allocation.address, allocation.size, allocation.handle)
+        finally:
+            cuda_call(driver.cuCtxPopCurrent)
+            cuda_call(driver.cuDevicePrimaryCtxRelease, allocation.device)
+
+
+# --- environment --------------------------------------------------------------
+
+
+def launch_job_fds() -> tuple[int, ...] | None:
+    """Descriptors of the cuda-checkpoint launch-job file, or None when the
+    process was not started through ``cuda-checkpoint --launch-job``."""
+    job_file = os.environ.get("CUDA_CHECKPOINT_JOB_FILE")
+    if not job_file or not Path(job_file).is_file():
+        return None
+    match = re.fullmatch(r"/proc/self/fd/([0-9]+)", job_file)
+    if match is None:
+        return ()
+    descriptor = int(match.group(1))
+    os.fstat(descriptor)
+    return (descriptor,)
+
+
+def require_launch_job() -> tuple[int, ...]:
+    fds = launch_job_fds()
+    if fds is None:
+        raise RuntimeError(
+            "CUDA_CHECKPOINT_JOB_FILE is missing; run through cuda-checkpoint --launch-job"
+        )
+    return fds
+
+
+def visible_gpus() -> tuple[str, str] | None:
+    """The two GPU ordinals the workers use, or None when fewer are available."""
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is None:
+        cuda_call(driver.cuInit, 0)
+        if int(cuda_call(driver.cuDeviceGetCount)) < WORLD_SIZE:
+            return None
+        return "0", "1"
+    devices = [entry.strip() for entry in configured.split(",") if entry.strip()]
+    if len(devices) < WORLD_SIZE or devices[0] == devices[1]:
+        return None
+    return devices[0], devices[1]
+
+
+def measure_h2d_gbps(device_ordinal: int, nbytes: int, repeats: int = 3) -> float:
+    """Best of ``repeats`` synchronous pinned host-to-device copies, in GB/s
+    (10**9 bytes per second, the unit of the coordinator's ``gb_per_s``)."""
+    cuda_call(driver.cuInit, 0)
+    device = cuda_call(driver.cuDeviceGet, device_ordinal)
+    context = cuda_call(driver.cuDevicePrimaryCtxRetain, device)
+    cuda_call(driver.cuCtxPushCurrent, context)
+    try:
+        destination = cuda_call(driver.cuMemAlloc, nbytes)
+        source = cuda_call(driver.cuMemHostAlloc, nbytes, 0)
+        try:
+            best = 0.0
+            for attempt in range(repeats + 1):
+                start = time.perf_counter()
+                cuda_call(driver.cuMemcpyHtoD, destination, source, nbytes)
+                elapsed = time.perf_counter() - start
+                if attempt:  # the first copy warms up the link
+                    best = max(best, nbytes / 1e9 / elapsed)
+            return best
+        finally:
+            cuda_call(driver.cuMemFreeHost, source)
+            cuda_call(driver.cuMemFree, destination)
+    finally:
+        cuda_call(driver.cuCtxPopCurrent)
+        cuda_call(driver.cuDevicePrimaryCtxRelease, device)
+
+
+# --- the coordinator ----------------------------------------------------------
+
+
+@dataclass
+class CoordinatorRun:
+    status: int
+    out: str
+    err: str
+    phases: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    @property
+    def failed(self) -> str:
+        return f"coordinator exited {self.status}\nstdout:\n{self.out}\nstderr:\n{self.err}"
+
+
+def parse_phase_lines(stdout: str) -> dict[str, dict[str, str]]:
+    phases: dict[str, dict[str, str]] = {}
+    for line in stdout.splitlines():
+        match = PHASE_LINE.match(line.strip())
+        if match is None:
+            continue
+        fields = {"status": match.group("status")}
+        for pair in match.group("rest").split():
+            key, _, value = pair.partition("=")
+            fields[key] = value
+        phases[match.group("phase")] = fields
+    return phases
+
+
+def run_coordinator(
+    coordinator: Path,
+    operation: str,
+    checkpoint_dir: Path,
+    control_dir: Path,
+    process_ids: tuple[int, ...],
+) -> CoordinatorRun:
+    command = [
+        str(coordinator),
+        operation,
+        "--proc-root",
+        "",
+        "--checkpoint-dir",
+        str(checkpoint_dir),
+        "--control-dir",
+        str(control_dir),
+    ]
+    for process_id in process_ids:
+        command.extend(["--process", str(process_id), str(process_id)])
+    environment = os.environ.copy()
+    environment.pop("LD_PRELOAD", None)
+    result = subprocess.run(
+        command,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    return CoordinatorRun(
+        result.returncode, result.stdout, result.stderr, parse_phase_lines(result.stdout)
+    )
+
+
+# --- the native checkpoint ----------------------------------------------------
+
+
+def _expect_state(process_id: int, expected) -> None:
+    actual = cuda_call(driver.cuCheckpointProcessGetState, process_id)
+    if actual != expected:
+        raise AssertionError(
+            f"CUDA process {process_id} is {actual.name}, expected {expected.name}"
+        )
+
+
+def _native_checkpoint(process_ids: tuple[int, ...]) -> None:
+    cuda_call(driver.cuInit, 0)
+    running = driver.CUprocessState.CU_PROCESS_STATE_RUNNING
+    locked = driver.CUprocessState.CU_PROCESS_STATE_LOCKED
+    checkpointed = driver.CUprocessState.CU_PROCESS_STATE_CHECKPOINTED
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+    lock_arguments = driver.CUcheckpointLockArgs()
+    lock_arguments.timeoutMs = COMMAND_TIMEOUT_SECONDS * 1000
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessLock, process_id, lock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    checkpoint_arguments = driver.CUcheckpointCheckpointArgs()
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessCheckpoint, process_id, checkpoint_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, checkpointed)
+
+    restore_arguments = driver.CUcheckpointRestoreArgs()
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessRestore, process_id, restore_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    unlock_arguments = driver.CUcheckpointUnlockArgs()
+    for process_id in process_ids:
+        cuda_call(driver.cuCheckpointProcessUnlock, process_id, unlock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+
+def native_checkpoint(process_ids: tuple[int, ...]) -> None:
+    """Lock, checkpoint, restore, and unlock the workers through the driver's
+    checkpoint API, with a timeout so a wedged driver fails the test instead
+    of hanging it."""
+    outcomes: queue.Queue[Exception | None] = queue.Queue(maxsize=1)
+
+    def run() -> None:
+        try:
+            _native_checkpoint(process_ids)
+        except Exception as error:  # noqa: BLE001 -- forwarded to the test thread
+            outcomes.put(error)
+        else:
+            outcomes.put(None)
+
+    threading.Thread(target=run, daemon=True).start()
+    try:
+        outcome = outcomes.get(timeout=CHECKPOINT_TIMEOUT_SECONDS)
+    except queue.Empty as error:
+        raise TimeoutError(
+            f"native CUDA checkpoint exceeded {CHECKPOINT_TIMEOUT_SECONDS} seconds"
+        ) from error
+    if outcome is not None:
+        raise outcome
+
+
+# --- the interposed workload --------------------------------------------------
+
+
+class Workload:
+    """One interposed parent process with ``WORLD_SIZE`` forked CUDA workers.
+
+    Use as a context manager: on the way out it terminates the process group,
+    collects the parent's and workers' output, and attaches it to any error
+    that is propagating, so a failure shows what the workers saw.
+    """
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        environment: Environment,
+        *,
+        mode: str,
+        carrier_bytes: int,
+        seed: int,
+        hold_raw_import: bool = False,
+    ) -> None:
+        if mode not in {"unicast", "multicast"}:
+            raise ValueError(mode)
+        self.environment = environment
+        self.mode = mode
+        self.carrier_bytes = carrier_bytes
+        self.seed = seed
+        self.hold_raw_import = hold_raw_import
+        self.control_dir = tmp_path / "control"
+        self.checkpoint_dir = tmp_path / "checkpoint"
+        self.sync_dir = tmp_path / "sync"
+        self.store_path = tmp_path / "torch-distributed-store"
+        for directory in (self.control_dir, self.checkpoint_dir, self.sync_dir):
+            directory.mkdir()
+        self.parent: subprocess.Popen[str] | None = None
+        self.child_pids: tuple[int, ...] = ()
+        self.output: tuple[str, str] = ("", "")
+        self._output_collected = False
+        self._externals: list[ExternalAllocation] = []
+        self._restore_channels = [socket.socketpair() for _ in range(WORLD_SIZE)]
+
+    # -- lifecycle -------------------------------------------------------------
+
+    def __enter__(self) -> Workload:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            if self.parent is not None and (exc is not None or self.parent.poll() is None):
+                self._kill(signal.SIGTERM)
+            if self.parent is not None and not self._output_collected:
+                try:
+                    self.output = self.parent.communicate(timeout=10)
+                except subprocess.TimeoutExpired:
+                    self._kill(signal.SIGKILL)
+                    self.output = self.parent.communicate(timeout=10)
+                self._output_collected = True
+        finally:
+            destroy_external_allocations(self._externals)
+            for sender, receiver in self._restore_channels:
+                sender.close()
+                receiver.close()
+        if exc is not None:
+            exc.add_note(self.diagnostics())
+
+    def _kill(self, signum: int) -> None:
+        assert self.parent is not None
+        try:
+            os.killpg(self.parent.pid, signum)
+        except ProcessLookupError:
+            pass
+
+    def diagnostics(self) -> str:
+        parent_pid = self.parent.pid if self.parent is not None else "not started"
+        returncode = self.parent.returncode if self.parent is not None else "not started"
+        sockets = sorted(path.name for path in self.control_dir.glob("*.sock"))
+        return (
+            f"seed: {self.seed}\n"
+            f"parent PID/return code: {parent_pid}/{returncode}\n"
+            f"forked worker PIDs: {self.child_pids}\n"
+            f"control sockets: {sockets}\n"
+            f"parent and worker stdout:\n{self.output[0] or ''}\n"
+            f"parent and worker stderr:\n{self.output[1] or ''}"
+        )
+
+    # -- steps -----------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the parent, wait until every worker is ready, and check the shim
+        is loaded and listening in each of them."""
+        self._externals = create_external_allocations(1)
+        self.parent = self._start_parent(
+            tuple(allocation.fd for allocation in self._externals),
+            tuple(receiver.fileno() for _, receiver in self._restore_channels),
+        )
+        for _, receiver in self._restore_channels:
+            receiver.close()
+        self.child_pids = self._wait_for_child_pids()
+        self.wait_for_workers("ready")
+        # The workers have imported and released (or are holding) their raw
+        # imports; the creator side can go away either way.
+        destroy_external_allocations(self._externals)
+        for process_id in (self.parent.pid, *self.child_pids):
+            self.assert_worker_runtime(process_id)
+
+    def prepare(self) -> CoordinatorRun:
+        return run_coordinator(
+            self.environment.tools.coordinator,
+            "--prepare",
+            self.checkpoint_dir,
+            self.control_dir,
+            self.child_pids,
+        )
+
+    def restore(self) -> CoordinatorRun:
+        return run_coordinator(
+            self.environment.tools.coordinator,
+            "--restore",
+            self.checkpoint_dir,
+            self.control_dir,
+            self.child_pids,
+        )
+
+    def native_checkpoint(self) -> None:
+        native_checkpoint(self.child_pids)
+
+    def hand_fresh_imports(self) -> None:
+        """Give every worker a brand-new raw descriptor to import after restore."""
+        self._externals = create_external_allocations(0x40)
+        for rank, (sender, _) in enumerate(self._restore_channels):
+            send_handle(sender, self._externals[rank].fd, self.child_pids[rank])
+
+    def resume(self) -> None:
+        (self.sync_dir / "continue").touch()
+
+    def finish(self) -> None:
+        """Wait for the workers' done markers and a clean parent exit."""
+        assert self.parent is not None
+        self.wait_for_workers("done")
+        self.output = self.parent.communicate(timeout=COMMAND_TIMEOUT_SECONDS)
+        self._output_collected = True
+        if self.parent.returncode != 0:
+            raise RuntimeError(f"parent {self.parent.pid} exited with {self.parent.returncode}")
+
+    def worker_carriers(self) -> tuple[int, int]:
+        """Count and bytes of the tracked creator allocations the workers made
+        themselves (not counting PyTorch's), summed over ranks."""
+        count = 0
+        total = 0
+        for rank in range(WORLD_SIZE):
+            fields = (self.sync_dir / f"carrier-{rank}").read_text().split()
+            count += int(fields[0])
+            total += int(fields[1])
+        return count, total
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _start_parent(
+        self, raw_fds: tuple[int, ...], restore_fds: tuple[int, ...]
+    ) -> subprocess.Popen[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CUDA_VISIBLE_DEVICES": ",".join(self.environment.gpus),
+                PARTICIPANT_ID_ENV: PARENT_PARTICIPANT_ID,
+                CONTROL_DIR_ENV: str(self.control_dir),
+                "LD_PRELOAD": str(self.environment.tools.interposer),
+                "PYTHONFAULTHANDLER": "1",
+                "PYTHONUNBUFFERED": "1",
+                "TORCH_SYMMEM_IMPLICIT_POOL": "0",
+            }
+        )
+        if self.mode == "multicast":
+            environment.pop("TORCH_SYMM_MEM_DISABLE_MULTICAST", None)
+        else:
+            environment["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"
+        return subprocess.Popen(
+            [
+                sys.executable,
+                "-X",
+                "faulthandler",
+                "-u",
+                str(Path(__file__).with_name("worker.py")),
+                *(str(fd) for fd in raw_fds),
+                *(str(fd) for fd in restore_fds),
+                str(self.sync_dir),
+                str(self.store_path),
+                self.mode,
+                str(self.carrier_bytes),
+                str(self.seed),
+                "hold-raw-import" if self.hold_raw_import else "release-raw-import",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+            pass_fds=raw_fds + restore_fds + self.environment.launch_job_fds,
+        )
+
+    def _wait_for_child_pids(self) -> tuple[int, ...]:
+        assert self.parent is not None
+        paths = [self.sync_dir / f"pid-{rank}" for rank in range(WORLD_SIZE)]
+        deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+        while True:
+            try:
+                pids = tuple(int(path.read_text()) for path in paths)
+            except (FileNotFoundError, ValueError):
+                pids = ()
+            if len(pids) == WORLD_SIZE:
+                if len(set(pids)) != WORLD_SIZE:
+                    raise AssertionError(f"forked worker PIDs are not unique: {pids}")
+                return pids
+            if self.parent.poll() is not None:
+                raise RuntimeError(
+                    f"parent {self.parent.pid} exited before publishing child PIDs "
+                    f"with {self.parent.returncode}"
+                )
+            if time.monotonic() >= deadline:
+                raise TimeoutError("timed out waiting for forked worker PIDs")
+            time.sleep(0.05)
+
+    def wait_for_workers(self, marker: str) -> None:
+        assert self.parent is not None
+        expected = [self.sync_dir / f"{marker}-{rank}" for rank in range(WORLD_SIZE)]
+        deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+        while not all(path.exists() for path in expected):
+            if self.parent.poll() is not None:
+                raise RuntimeError(
+                    f"parent {self.parent.pid} exited before workers reached {marker} "
+                    f"with {self.parent.returncode}"
+                )
+            if time.monotonic() >= deadline:
+                missing = [str(path) for path in expected if not path.exists()]
+                raise TimeoutError(f"timed out waiting for {marker}: {', '.join(missing)}")
+            time.sleep(0.05)
+
+    def assert_worker_runtime(self, process_id: int) -> None:
+        interposer = self.environment.tools.interposer
+        maps = Path(f"/proc/{process_id}/maps").read_text().splitlines()
+        mapped_paths = {
+            fields[5] for line in maps if len(fields := line.split(maxsplit=5)) == 6
+        }
+        if str(interposer) not in mapped_paths:
+            raise AssertionError(f"{interposer} is not loaded in process {process_id}")
+        endpoint = self.control_dir / f"{SOCKET_PREFIX}{process_id}.sock"
+        if not endpoint.is_socket():
+            raise AssertionError(f"shim endpoint does not exist: {endpoint}")

--- a/agent/cmd/cuinterpose/tests/gpu/pyproject.toml
+++ b/agent/cmd/cuinterpose/tests/gpu/pyproject.toml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "cuinterpose-gpu-tests"
+version = "0.0.0"
+description = "GPU integration tests for the cuinterpose shim and coordinator"
+requires-python = ">=3.12"
+# Pinned to the versions the suite was run with (torch from the cu130 index
+# below). Bump deliberately.
+dependencies = [
+  "cuda-bindings==13.3.1",
+  "pytest==8.4.2",
+  "torch==2.11.0",
+]
+
+[tool.uv]
+package = false
+
+# CUDA 13 wheels: the tests exercise a CUDA 13 driver and cuda-bindings 13.
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-cu130" }
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+markers = [
+  "gpu: needs two GPUs, a CUDA 13 driver, and cuda-checkpoint --launch-job",
+  "multicast: additionally needs NVLink between the two GPUs",
+]

--- a/agent/cmd/cuinterpose/tests/gpu/test_multicast.py
+++ b/agent/cmd/cuinterpose/tests/gpu/test_multicast.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint and restore of a CUDA multicast group on real GPUs.
+
+Same flow as test_posix.py, but the two workers share their symmetric-memory
+buffer through a multicast object (PyTorch's multimem all-reduce), and one rank
+rebinds its slice with cuMulticastBindAddr so both bind entry points are
+exercised. Needs NVLink between the two GPUs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("cuda.bindings")
+
+import harness  # noqa: E402
+from harness import Workload  # noqa: E402
+
+from test_posix import CARRIER_MIB  # noqa: E402
+
+
+@pytest.mark.gpu
+@pytest.mark.multicast
+def test_checkpoint_restores_multicast_group(gpu_environment, multicast_supported, tmp_path, seed) -> None:
+    with Workload(
+        tmp_path, gpu_environment, mode="multicast", carrier_bytes=CARRIER_MIB << 20, seed=seed
+    ) as workload:
+        workload.start()
+
+        prepare = workload.prepare()
+        assert prepare.status == 0, prepare.failed
+        assert (workload.checkpoint_dir / harness.STATE_FILENAME).is_file()
+        expected_count, expected_bytes = workload.worker_carriers()
+        saved = prepare.phases["save_host_carrier"]
+        assert int(saved["carrier_count"]) >= expected_count, prepare.out
+        assert int(saved["carrier_bytes"]) >= expected_bytes, prepare.out
+        # The multicast phases ran on both sides.
+        assert prepare.phases["prepare_multicast"]["status"] == "ok", prepare.out
+
+        workload.native_checkpoint()
+
+        restore = workload.restore()
+        assert restore.status == 0, restore.failed
+        assert restore.phases["restore_multicast"]["status"] == "ok", restore.out
+
+        workload.hand_fresh_imports()
+        workload.resume()
+        workload.finish()

--- a/agent/cmd/cuinterpose/tests/gpu/test_posix.py
+++ b/agent/cmd/cuinterpose/tests/gpu/test_posix.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint and restore of POSIX-shared CUDA memory on real GPUs.
+
+Run through the launch-job wrapper so the workers are checkpointable:
+
+    cuda-checkpoint --launch-job uv run --project agent/cmd/cuinterpose/tests/gpu \\
+        pytest agent/cmd/cuinterpose/tests/gpu -v -m gpu
+
+Knobs: ``CUINTERPOSE_TEST_CARRIER_MIB`` (size of the large per-rank allocation,
+default 256), ``CUINTERPOSE_TEST_MIN_H2D_FRACTION`` (how close the host carrier
+restore must come to a plain pinned copy, default 0.8), ``CUINTERPOSE_TEST_SEED``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("cuda.bindings")
+
+import harness  # noqa: E402
+from harness import Workload  # noqa: E402
+
+CARRIER_MIB = int(os.environ.get("CUINTERPOSE_TEST_CARRIER_MIB", "256"))
+MIN_H2D_FRACTION = float(os.environ.get("CUINTERPOSE_TEST_MIN_H2D_FRACTION", "0.8"))
+
+
+@pytest.fixture(scope="session")
+def h2d_baseline_gbps(gpu_environment) -> float:
+    """A plain pinned host-to-device copy of one rank's large allocation on the
+    first GPU: the speed the carrier restore is held to."""
+    return harness.measure_h2d_gbps(0, CARRIER_MIB << 20)
+
+
+@pytest.mark.gpu
+def test_checkpoint_restores_shared_posix_memory(
+    gpu_environment, tmp_path, seed, h2d_baseline_gbps
+) -> None:
+    with Workload(
+        tmp_path, gpu_environment, mode="unicast", carrier_bytes=CARRIER_MIB << 20, seed=seed
+    ) as workload:
+        workload.start()
+
+        prepare = workload.prepare()
+        assert prepare.status == 0, prepare.failed
+        state = workload.checkpoint_dir / harness.STATE_FILENAME
+        assert state.is_file() and state.stat().st_size > 0, "coordinator wrote no state file"
+        stray = [path.name for path in workload.checkpoint_dir.iterdir() if path != state]
+        assert not stray, f"host carriers must stay in process memory, found {stray}"
+
+        # Every tracked creator allocation travels through the host carrier: at
+        # least the two each worker made itself (PyTorch's buffers may add more).
+        expected_count, expected_bytes = workload.worker_carriers()
+        saved = prepare.phases["save_host_carrier"]
+        assert int(saved["carrier_count"]) >= expected_count, prepare.out
+        assert int(saved["carrier_bytes"]) >= expected_bytes, prepare.out
+
+        workload.native_checkpoint()
+
+        restore = workload.restore()
+        assert restore.status == 0, restore.failed
+        restored = restore.phases["restore_host_carrier"]
+        assert restored["carrier_count"] == saved["carrier_count"], restore.out
+        assert restored["carrier_bytes"] == saved["carrier_bytes"], restore.out
+        # The phase figure includes creating and mapping the fresh device memory
+        # and the socket round trip; the copy figure is the transfer alone, and
+        # that is what must run at the link's speed.
+        phase = float(restored["gb_per_s"])
+        copied = float(restored["copy_gb_per_s"])
+        print(
+            f"\nhost carrier restore: copies {copied:.2f} GB/s, whole phase {phase:.2f} GB/s over "
+            f"{restored['carrier_bytes']} bytes; pinned copy baseline {h2d_baseline_gbps:.2f} GB/s"
+        )
+        assert copied >= MIN_H2D_FRACTION * h2d_baseline_gbps, (
+            f"host carrier copies reached {copied:.2f} GB/s, below "
+            f"{MIN_H2D_FRACTION:.0%} of the {h2d_baseline_gbps:.2f} GB/s pinned copy baseline"
+        )
+
+        workload.hand_fresh_imports()
+        workload.resume()
+        workload.finish()
+
+
+@pytest.mark.gpu
+def test_prepare_is_refused_while_a_raw_import_is_alive(gpu_environment, tmp_path, seed) -> None:
+    """An import of a descriptor from a process without the shim cannot be
+    repaired after restore, so the coordinator refuses to checkpoint while one
+    is alive, and the workload keeps running untouched."""
+    with Workload(
+        tmp_path,
+        gpu_environment,
+        mode="unicast",
+        carrier_bytes=1 << 20,
+        seed=seed,
+        hold_raw_import=True,
+    ) as workload:
+        workload.start()
+
+        prepare = workload.prepare()
+        assert prepare.status != 0, "prepare must be refused while a raw import is alive"
+        assert "live raw imports" in prepare.err, prepare.err
+        assert not (workload.checkpoint_dir / harness.STATE_FILENAME).exists()
+
+        workload.resume()
+        workload.finish()

--- a/agent/cmd/cuinterpose/tests/gpu/worker.py
+++ b/agent/cmd/cuinterpose/tests/gpu/worker.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The interposed workload for the GPU tests.
+
+Started by ``harness.Workload`` with ``LD_PRELOAD=libcuinterpose.so``. The
+parent forks ``WORLD_SIZE`` workers before touching CUDA (a fork after CUDA
+state exists is unsupported); each worker then behaves like one rank of a
+tensor-parallel server:
+
+* creates two POSIX-shareable allocations of its own, one small one *before*
+  any CUDA context exists (the driver allows that) and one large one whose
+  contents must travel through the host carrier, both filled with seeded
+  random bytes;
+* imports a descriptor from a process without the shim (a raw import) and
+  releases it again, or keeps it alive in ``hold-raw-import`` mode so the
+  coordinator has something to refuse;
+* shares a PyTorch symmetric-memory buffer with the other rank and captures a
+  collective into a CUDA graph;
+* signals ``ready``, waits for ``continue``, and after the checkpoint round
+  trip verifies every byte and replays the graph.
+
+Progress and results are communicated to the test through marker files in the
+sync directory; failures print a traceback and exit non-zero.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import sys
+import time
+import traceback
+from multiprocessing.reduction import recv_handle
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cuda.bindings import driver
+
+import harness
+from harness import POSIX_FD_HANDLE_TYPE, WORLD_SIZE, WORKER_TIMEOUT_SECONDS, cuda_call
+
+NUMEL = 2048
+
+
+class Options:
+    def __init__(self, argv: list[str]) -> None:
+        if len(argv) != 11:
+            raise SystemExit(
+                "usage: worker.py RAW_FD_0 RAW_FD_1 RESTORE_FD_0 RESTORE_FD_1 SYNC_DIR "
+                "STORE_PATH (unicast|multicast) CARRIER_BYTES SEED "
+                "(hold-raw-import|release-raw-import)"
+            )
+        self.raw_fds = (int(argv[1]), int(argv[2]))
+        self.restore_fds = (int(argv[3]), int(argv[4]))
+        self.sync_dir = Path(argv[5])
+        self.store_path = Path(argv[6])
+        if argv[7] not in {"unicast", "multicast"}:
+            raise SystemExit("mode must be unicast or multicast")
+        self.multicast = argv[7] == "multicast"
+        self.carrier_bytes = int(argv[8])
+        self.seed = int(argv[9])
+        if argv[10] not in {"hold-raw-import", "release-raw-import"}:
+            raise SystemExit("raw import handling must be hold-raw-import or release-raw-import")
+        self.hold_raw_import = argv[10] == "hold-raw-import"
+
+
+# --- seeded contents ----------------------------------------------------------
+
+
+def _pattern(nbytes: int, seed: int, device_index: int) -> torch.Tensor:
+    generator = torch.Generator(device=f"cuda:{device_index}")
+    generator.manual_seed(seed)
+    return torch.randint(
+        0, 256, (nbytes,), dtype=torch.uint8, device=f"cuda:{device_index}", generator=generator
+    )
+
+
+def _fill(address: int, nbytes: int, seed: int, device_index: int) -> None:
+    pattern = _pattern(nbytes, seed, device_index)
+    cuda_call(driver.cuMemcpyDtoD, address, pattern.data_ptr(), nbytes)
+    torch.cuda.synchronize()
+
+
+def _verify(address: int, nbytes: int, seed: int, device_index: int, stage: str) -> None:
+    expected = _pattern(nbytes, seed, device_index)
+    actual = torch.empty(nbytes, dtype=torch.uint8, device=f"cuda:{device_index}")
+    cuda_call(driver.cuMemcpyDtoD, actual.data_ptr(), address, nbytes)
+    torch.cuda.synchronize()
+    if not torch.equal(actual, expected):
+        mismatches = actual != expected
+        first = int(torch.nonzero(mismatches)[0].item())
+        raise AssertionError(
+            f"{stage}: {int(mismatches.sum().item())} of {nbytes} bytes differ, "
+            f"first at offset {first} (seed {seed})"
+        )
+
+
+# --- the worker ---------------------------------------------------------------
+
+
+def _wait_for_continue(sync_dir: Path) -> None:
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while not (sync_dir / "continue").exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for the test to continue")
+        time.sleep(0.05)
+
+
+def _import_raw(fd: int, size: int, device, expected: bytes, stage: str) -> tuple[object, int]:
+    """Import a descriptor from an uninterposed process, map it, and check its
+    contents. Returns the (raw) handle and the mapped address."""
+    try:
+        handle = cuda_call(driver.cuMemImportFromShareableHandle, fd, POSIX_FD_HANDLE_TYPE)
+        harness.assert_handle_namespace(handle, False, stage)
+    finally:
+        os.close(fd)
+    try:
+        address = harness.map_allocation(handle, size, device)
+    except Exception:
+        cuda_call(driver.cuMemRelease, handle)
+        raise
+    try:
+        harness.assert_bytes(address, expected, stage)
+    except Exception:
+        harness.destroy_mapped_allocation(address, size, handle)
+        raise
+    return handle, address
+
+
+def _worker(rank: int, options: Options) -> None:
+    harness.require_launch_job()
+    cuda_call(driver.cuInit, 0)
+    device = cuda_call(driver.cuDeviceGet, rank)
+    properties = harness.allocation_properties(device)
+    granularity = harness.allocation_granularity(properties)
+    private_size = granularity
+    bulk_size = harness.round_up(options.carrier_bytes, granularity)
+    private_seed = options.seed + 2 * rank
+    bulk_seed = options.seed + 2 * rank + 1
+
+    # The driver does not need a context for cuMemCreate, so neither may the shim.
+    harness.assert_no_current_context("worker before the first cuMemCreate")
+    private_handle = cuda_call(driver.cuMemCreate, private_size, properties, 0)
+    harness.assert_handle_namespace(private_handle, True, "tracked cuMemCreate")
+
+    torch.cuda.set_device(rank)
+    for other_rank, fd in enumerate(options.raw_fds):
+        if other_rank != rank:
+            os.close(fd)
+    for other_rank, fd in enumerate(options.restore_fds):
+        if other_rank != rank:
+            os.close(fd)
+    restore_socket = socket.socket(fileno=options.restore_fds[rank])
+
+    raw_handle, raw_address = _import_raw(
+        options.raw_fds[rank], granularity, device, bytes([rank + 1]) * 32, "raw import"
+    )
+    if not options.hold_raw_import:
+        harness.destroy_mapped_allocation(raw_address, granularity, raw_handle)
+
+    private_address = harness.map_allocation(private_handle, private_size, device)
+    retained_handle = cuda_call(driver.cuMemRetainAllocationHandle, private_address)
+    harness.assert_handle_namespace(retained_handle, True, "tracked retain")
+    cuda_call(driver.cuMemRelease, retained_handle)
+    _fill(private_address, private_size, private_seed, rank)
+
+    bulk_handle = cuda_call(driver.cuMemCreate, bulk_size, properties, 0)
+    harness.assert_handle_namespace(bulk_handle, True, "tracked bulk cuMemCreate")
+    bulk_address = harness.map_allocation(bulk_handle, bulk_size, device)
+    _fill(bulk_address, bulk_size, bulk_seed, rank)
+    (options.sync_dir / f"carrier-{rank}").write_text(f"2 {private_size + bulk_size}\n")
+
+    if options.hold_raw_import:
+        # Nothing to restore in this mode: the test only checks that prepare is
+        # refused and that the workload keeps working afterwards.
+        restore_socket.close()
+        (options.sync_dir / f"ready-{rank}").touch()
+        _wait_for_continue(options.sync_dir)
+        harness.destroy_mapped_allocation(raw_address, granularity, raw_handle)
+        probe = cuda_call(driver.cuMemCreate, granularity, properties, 0)
+        harness.assert_handle_namespace(probe, True, "cuMemCreate after a refused prepare")
+        cuda_call(driver.cuMemRelease, probe)
+        _verify(private_address, private_size, private_seed, rank, "private after refused prepare")
+        _verify(bulk_address, bulk_size, bulk_seed, rank, "bulk after refused prepare")
+        (options.sync_dir / f"done-{rank}").touch()
+        harness.destroy_mapped_allocation(bulk_address, bulk_size, bulk_handle)
+        harness.destroy_mapped_allocation(private_address, private_size, private_handle)
+        return
+
+    dist.init_process_group(
+        "gloo", init_method=f"file://{options.store_path}", rank=rank, world_size=WORLD_SIZE
+    )
+    group_name = dist.group.WORLD.group_name
+    input_tensor = symm_mem.empty(NUMEL, dtype=torch.float32, device="cuda")
+    input_tensor.fill_(rank + 1)
+    symm_handle = symm_mem.rendezvous(input_tensor, group=group_name)
+    if options.multicast:
+        if not symm_handle.has_multicast_support:
+            raise AssertionError("PyTorch silently fell back from CUDA multicast")
+        if int(symm_handle.multicast_ptr) == 0:
+            raise AssertionError("PyTorch selected multicast without a multicast VA")
+        _replace_local_binding_with_address(rank, input_tensor, symm_handle, properties)
+        dist.barrier()
+    output = torch.empty_like(input_tensor)
+
+    _collective(input_tensor, group_name, output, options.multicast)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _collective(input_tensor, group_name, output, options.multicast)
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "before checkpoint")
+    (options.sync_dir / f"ready-{rank}").touch()
+
+    _wait_for_continue(options.sync_dir)
+
+    # A raw import made after restore must work like before.
+    fresh_fd = recv_handle(restore_socket)
+    restore_socket.close()
+    fresh_handle, fresh_address = _import_raw(
+        fresh_fd, granularity, device, bytes([0x40 + rank]) * 32, "raw import after restore"
+    )
+    harness.destroy_mapped_allocation(fresh_address, granularity, fresh_handle)
+
+    _verify(private_address, private_size, private_seed, rank, "private allocation after restore")
+    _verify(bulk_address, bulk_size, bulk_seed, rank, "bulk allocation after restore")
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "after restore")
+    (options.sync_dir / f"done-{rank}").touch()
+
+    dist.barrier()
+    del graph, output, symm_handle, input_tensor
+    torch.cuda.empty_cache()
+    dist.destroy_process_group()
+    harness.destroy_mapped_allocation(bulk_address, bulk_size, bulk_handle)
+    harness.destroy_mapped_allocation(private_address, private_size, private_handle)
+
+
+def _collective(
+    input_tensor: torch.Tensor, group_name: str, output: torch.Tensor, multicast: bool
+) -> None:
+    operation = (
+        torch.ops.symm_mem.multimem_one_shot_all_reduce_out
+        if multicast
+        else torch.ops.symm_mem.one_shot_all_reduce_out
+    )
+    operation(input_tensor, "sum", group_name, output)
+
+
+def _replace_local_binding_with_address(
+    rank: int, input_tensor: torch.Tensor, symm_handle, properties: driver.CUmemAllocationProp
+) -> None:
+    """Rebind this rank's slice of the multicast object through
+    cuMulticastBindAddr, so both bind entry points are exercised."""
+    granularity = int(
+        cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+        )
+    )
+    buffer_size = input_tensor.numel() * input_tensor.element_size()
+    signal_offset = (buffer_size + 15) // 16 * 16
+    unrounded_size = signal_offset + symm_mem.get_signal_pad_size()
+    block_size = harness.round_up(unrounded_size, granularity)
+    multicast_handle = cuda_call(
+        driver.cuMemRetainAllocationHandle, int(symm_handle.multicast_ptr)
+    )
+    harness.assert_handle_namespace(multicast_handle, True, "retained multicast handle")
+    device = cuda_call(driver.cuDeviceGet, rank)
+    try:
+        cuda_call(driver.cuMulticastUnbind, multicast_handle, device, 0, block_size)
+        cuda_call(
+            driver.cuMulticastBindAddr,
+            multicast_handle,
+            0,
+            int(symm_handle.buffer_ptrs[rank]),
+            block_size,
+            0,
+        )
+    finally:
+        cuda_call(driver.cuMemRelease, multicast_handle)
+
+
+def _assert_exact_result(output: torch.Tensor, stage: str) -> None:
+    expected = torch.full((NUMEL,), 3.0, dtype=torch.float32)
+    actual = output.cpu()
+    if not torch.equal(actual, expected):
+        mismatch = torch.nonzero(actual != expected)[0].item()
+        raise AssertionError(
+            f"{stage}: output[{mismatch}] is {actual[mismatch].item()}, expected 3.0"
+        )
+
+
+# --- the parent ---------------------------------------------------------------
+
+
+def _fork_workers(options: Options) -> None:
+    if torch.cuda.is_initialized():
+        raise RuntimeError("parent initialized CUDA before forking workers")
+    harness.assert_no_current_context("parent before forking workers")
+
+    children = []
+    for rank in range(WORLD_SIZE):
+        child = os.fork()
+        if child == 0:
+            try:
+                _worker(rank, options)
+            except BaseException:  # noqa: BLE001 -- report child failures to the parent
+                traceback.print_exc()
+                os._exit(1)
+            os._exit(0)
+        children.append((rank, child))
+        (options.sync_dir / f"pid-{rank}").write_text(f"{child}\n")
+
+    for fd in options.raw_fds + options.restore_fds:
+        os.close(fd)
+
+    remaining = dict(children)
+    while remaining:
+        failures = []
+        for rank, child in tuple(remaining.items()):
+            waited, status = os.waitpid(child, os.WNOHANG)
+            if waited == 0:
+                continue
+            del remaining[rank]
+            exit_code = os.waitstatus_to_exitcode(status)
+            if not os.WIFEXITED(status) or exit_code != 0:
+                failures.append(f"rank {rank} PID {child}: {exit_code}")
+        if failures:
+            for child in remaining.values():
+                try:
+                    os.kill(child, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            for child in remaining.values():
+                os.waitpid(child, 0)
+            raise RuntimeError(f"forked workers failed: {', '.join(failures)}")
+        time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    _fork_workers(Options(sys.argv))


### PR DESCRIPTION

## Summary

`agent/cmd/cuinterpose/tests/gpu`: a pytest suite that runs the shim and the coordinator against the real driver on two GPUs through `cuda-checkpoint --launch-job`. One interposed parent forks two PyTorch workers; each creates POSIX-shareable allocations (one before any CUDA context exists, one large one filled with seeded random bytes), imports a descriptor from the uninterposed test process, shares a symmetric-memory buffer with the other rank, and captures a collective into a CUDA graph. The test runs the coordinator, the native `cuCheckpointProcess*` sequence through `cuda.bindings`, and the coordinator again, then checks the state file, the coordinator's carrier counts, the copy throughput against a pinned baseline measured on the same machine, every byte, the graph replay, and a fresh raw import. A second test holds a raw import across prepare and checks the refusal. `test_multicast.py` runs PyTorch's multimem all-reduce with a `cuMulticastBindAddr` rebind and skips without NVLink.

`CUINTERPOSE_BUILD_DIR` points at prebuilt binaries (for example copied out of the agent image); otherwise the tests build the shim with `CUDA_HOME`. Dependencies are pinned in `pyproject.toml` against the cu130 torch index.

## Origin

Re-cut of `test_cucheckpoint.py` from #152/#165/#166 and its multicast case from #133.

## Review threads carried

| Old thread | Raised | Disposition |
| --- | --- | --- |
| #78 Copilot `test_cucheckpoint.py:373`, CodeRabbit `test_cucheckpoint.py:288` | GPU test failed instead of skipping without prerequisites; prerequisite check missed `grep`. | Fixed: `conftest.py` skips without torch, cuda-bindings, two GPUs, or a launch job; prebuilt binaries avoid the native build entirely. |

## Validation

- Fake-driver suites (GoogleTest, AddressSanitizer + UndefinedBehaviorSanitizer) run in the agent image build against CUDA 13.1 headers at every layer of the stack; at the top: proto 22, table 3, forward 12, coordinator 12, state 14, lifecycle 4, multicast 6, no sanitizer reports.
- `go test ./...` in `api`, `operator`, `agent`; `make lint`, `make helm-lint`, `make verify-license-headers`.
- Agent image built from the top of the stack and deployed on nscale-dev (B200, kernel driver 595.58.03) with this chart.
- GPU tests (two B200s, `cuda-checkpoint --launch-job`): POSIX round trip with seeded 1 GiB carriers per rank, multicast round trip with PyTorch's multimem all-reduce and a `cuMulticastBindAddr` rebind, refusal while a raw import is alive: 3 passed. Host-carrier restore phase 87 to 108 GB/s aggregate over two GPUs (pinned-copy baseline 55 GB/s per GPU).
- End to end: vLLM 0.27.1 `AsyncLLM`, Qwen3-0.6B, tensor parallel 2, FlashInfer TRT-LLM attention and fused allreduce (`trtllm` backend), PodSnapshot of a Deployment shaped with `podcontract.ShapeCuinterposeCapture`, then restore: checkpoint 52 s (CRIU dump 49 s, cuinterpose prepare 0.43 s; 4 CUDA processes, 1052 records, 382 host carriers, 2.08 GB); restore 5.7 s (cuinterpose 0.35 s: carriers 0.05 s, unicast 0.09 s, multicast 0.18 s); the restored replica answers coherently ("The capital of Italy is Rome").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
