### PR TITLE
feat(agent): package the cuinterpose shim and coordinator

### DIFF
--- a/agent/.dockerignore
+++ b/agent/.dockerignore
@@ -1,0 +1,1 @@
+cmd/cuinterpose/build/

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -142,14 +142,30 @@ RUN mkdir -p /go-src && go mod vendor -o /go-src/vendor
 # =============================================================================
 FROM ${AGENT_BASE_IMAGE} AS cuda-helper-builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# cuinterpose is built against CUDA 13.1 headers (the base image ships 13.0):
+# 13.1 added the device-explicit multicast bind entry points the shim wraps.
+# Headers only; the shim links nothing from libcuda. libgtest-dev runs the
+# shim's unit tests during the build, so a broken shim fails the image.
+# The base image carries no NVIDIA apt repository; the pinned cuda-keyring
+# package adds it.
+ARG CUINTERPOSE_CUDA_HEADERS=13-1
+ADD --checksum=sha256:d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba \
+    https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
+    /tmp/cuda-keyring.deb
+RUN dpkg -i /tmp/cuda-keyring.deb && rm /tmp/cuda-keyring.deb \
+    && apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    libgtest-dev \
+    cuda-driver-dev-${CUINTERPOSE_CUDA_HEADERS} \
+    cuda-cudart-dev-${CUINTERPOSE_CUDA_HEADERS} \
+    cuda-crt-${CUINTERPOSE_CUDA_HEADERS} \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
 COPY cmd/cuda-checkpoint-helper/main.c ./cmd/cuda-checkpoint-helper/main.c
 COPY cmd/ns-bind-mount/main.c ./cmd/ns-bind-mount/main.c
+COPY cmd/cuinterpose/ ./cmd/cuinterpose/
 
 RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
     ./cmd/cuda-checkpoint-helper/main.c \
@@ -160,6 +176,13 @@ RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
 # ns-bind-mount bind-mounts the snapshot binaries into a target container's mount
 # namespace. It needs no CUDA headers, only mount_setattr (Linux 5.12+).
 RUN gcc -O2 -Wall -Wextra -o /ns-bind-mount ./cmd/ns-bind-mount/main.c
+
+# cuinterpose: LD_PRELOAD shim and static coordinator (see cmd/cuinterpose/README.md).
+# `test` builds a sanitizer-instrumented copy of the shim plus fake CUDA
+# libraries and runs the GoogleTest suites; the production artifacts in
+# /cuinterpose-build are the uninstrumented ones.
+RUN make -C ./cmd/cuinterpose BUILD_DIR=/cuinterpose-build \
+    CUDA_HOME=/usr/local/cuda-$(echo ${CUINTERPOSE_CUDA_HEADERS} | tr - .) all test
 
 # =============================================================================
 # Stage: CRIU Builder - Build CRIU with CUDA plugin
@@ -280,8 +303,11 @@ COPY --from=cuda-helper-builder /cuda-checkpoint-helper /usr/local/bin/cuda-chec
 # nsmount resolves this helper at /usr/local/sbin/ns-bind-mount (see
 # agent/internal/nsmount/mount.go defaultBinaryPath).
 COPY --from=cuda-helper-builder /ns-bind-mount /usr/local/sbin/ns-bind-mount
+COPY --from=cuda-helper-builder /cuinterpose-build/libcuinterpose.so /usr/local/lib/snapshot/libcuinterpose.so
+COPY --from=cuda-helper-builder /cuinterpose-build/cuinterpose-coordinator /usr/local/bin/cuinterpose-coordinator
 RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-helper \
-    /usr/local/sbin/ns-bind-mount
+    /usr/local/sbin/ns-bind-mount /usr/local/bin/cuinterpose-coordinator \
+    && chmod 0644 /usr/local/lib/snapshot/libcuinterpose.so
 
 # Copy the built binaries
 COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
@@ -295,12 +321,20 @@ RUN output=$(/usr/local/bin/pagebroker 2>&1); status=$?; \
 # The placeholder ships none of this. nsrestore redirects all three lookup
 # mechanisms into the mount: criu's libdir -> criu-plugins/ (criu.overrideLibDir),
 # LD_LIBRARY_PATH -> lib/, and PATH -> the bundle root.
-RUN mkdir -p /snapshot-binaries/lib /snapshot-binaries/criu-plugins
+RUN mkdir -p /snapshot-binaries/lib /snapshot-binaries/criu-plugins /snapshot-binaries/snapshot-cuda
 COPY --from=builder /nsrestore /snapshot-binaries/nsrestore
 COPY --from=criu-builder /criu-install/usr/local/sbin/criu /snapshot-binaries/criu
 COPY --from=criu-builder /criu-install/usr/local/lib/snapshot/criu-plugins/ /snapshot-binaries/criu-plugins/
 COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /snapshot-binaries/cuda-checkpoint
 COPY --from=cuda-helper-builder /cuda-checkpoint-helper /snapshot-binaries/cuda-checkpoint-helper
+# snapshot-cuda restore bundle: cuda-checkpoint (the --launch-job wrapper) and the
+# cuinterpose shim, delivered to source Pods from this image and bind-mounted at
+# the same path on restore, because CRIU restores file-backed mappings by path.
+COPY --from=cuda-helper-builder /cuinterpose-build/libcuinterpose.so /snapshot-binaries/snapshot-cuda/libcuinterpose.so
+COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /snapshot-binaries/snapshot-cuda/cuda-checkpoint
+RUN chmod 0644 /snapshot-binaries/snapshot-cuda/libcuinterpose.so \
+    && chmod +x /snapshot-binaries/snapshot-cuda/cuda-checkpoint
+COPY --from=cuda-helper-builder /cuinterpose-build/cuinterpose-coordinator /snapshot-binaries/cuinterpose-coordinator
 
 # Network binaries needed during restore:
 #   ip  — address/route restore (criu/net.c)
@@ -314,6 +348,7 @@ RUN set -eu; \
     cp -L "$(command -v ip)" "$(command -v tar)" /snapshot-binaries/; \
     chmod +x /snapshot-binaries/criu /snapshot-binaries/nsrestore \
              /snapshot-binaries/cuda-checkpoint /snapshot-binaries/cuda-checkpoint-helper \
+             /snapshot-binaries/cuinterpose-coordinator \
              /snapshot-binaries/ip /snapshot-binaries/tar
 
 # Shared-library closure of the bundled binaries and plugins.

--- a/agent/cmd/cuinterpose/.gitignore
+++ b/agent/cmd/cuinterpose/.gitignore
@@ -1,0 +1,4 @@
+build/
+tests/gpu/.venv/
+__pycache__/
+.pytest_cache/

--- a/agent/cmd/cuinterpose/Makefile
+++ b/agent/cmd/cuinterpose/Makefile
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds libcuinterpose.so (the LD_PRELOAD shim) and cuinterpose-coordinator
+# (a static helper the snapshot agent runs), and runs the unit tests against a
+# fake libcuda/libcudart so no GPU is needed.
+#
+#   make                 build both artifacts into $(BUILD_DIR)
+#   make test            build the fakes and GoogleTest binaries, run them
+#   make CUDA_HOME=...   point at a CUDA toolkit (headers only are used)
+#
+# The shim is delivered in layers. Every C file in this directory is part of
+# the shim except coordinator.c; tests are found by name (see "Tests" below).
+# Adding a layer means adding files, not editing this Makefile.
+#
+# util/ holds the generic infrastructure: containers and utilities with no
+# cuinterpose domain logic. Files there may include libc, protocol.h, and each
+# other — never a domain header — and are linked into BOTH binaries, so new
+# generic infrastructure is a new file in util/, never a Makefile edit.
+# Functions and types are unprefixed (the cuinterpose_ prefix means domain
+# code); macros keep the CUINTERPOSE_ prefix because the preprocessor
+# namespace is global.
+
+BUILD_DIR ?= build
+CUDA_HOME ?= /usr/local/cuda
+CC ?= cc
+CXX ?= c++
+
+INTERPOSER := $(BUILD_DIR)/libcuinterpose.so
+COORDINATOR := $(BUILD_DIR)/cuinterpose-coordinator
+
+# The shim must load into any workload image from Ubuntu 22.04 (glibc 2.35)
+# onward. It resolves glibc's dlsym through dlvsym(..., "GLIBC_2.34"), and the
+# build rejects any symbol version newer than this.
+MIN_GLIBC := GLIBC_2.34
+# CUDA 13.1 added the device-explicit multicast bind entry points. The shipped
+# shim is built against 13.1 or newer headers so those wrappers exist; the
+# shim has no runtime dependency on the header version because every driver
+# symbol is looked up at run time. Set ALLOW_OLD_CUDA_HEADERS=1 for local
+# builds against older headers.
+MIN_CUDA_VERSION := 13010
+CUDA_VERSION := $(shell sed -n 's/^\#define CUDA_VERSION \([0-9]*\).*/\1/p' $(CUDA_HOME)/include/cuda.h 2>/dev/null)
+
+# -I. so the util/ headers resolve their top-level siblings ("protocol.h").
+COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror -I.
+INTERPOSER_CPPFLAGS := -DCUINTERPOSE_DLSYM_VERSION=\"$(MIN_GLIBC)\" -I$(CUDA_HOME)/include
+INTERPOSER_CFLAGS := $(COMMON_FLAGS) -fPIC -fvisibility=hidden -Wno-deprecated-declarations
+# -z defs: every reference must resolve at link time, so an accidental direct
+# call into libcuda (which the shim must never link) fails the build instead of
+# failing inside a workload. -Bsymbolic-functions: the shim's own internal calls
+# bind locally and cannot be interposed by the application.
+INTERPOSER_LDFLAGS := -shared -Wl,-Bsymbolic-functions -Wl,-z,defs -ldl -pthread
+UTIL_SOURCES := $(wildcard util/*.c)
+UTIL_HEADERS := $(wildcard util/*.h)
+INTERPOSER_SOURCES := $(filter-out coordinator.c,$(wildcard *.c)) $(UTIL_SOURCES)
+INTERPOSER_HEADERS := $(wildcard *.h) $(UTIL_HEADERS)
+COORDINATOR_SOURCES := coordinator.c protocol.c $(UTIL_SOURCES)
+COORDINATOR_HEADERS := protocol.h $(UTIL_HEADERS)
+# Everything the shim is allowed to export. Anything else is a bug: an
+# LD_PRELOAD library sits first in the process's symbol search order.
+EXPORT_ALLOWLIST := '^(cu[A-Z][A-Za-z0-9_]*|cuda[A-Z][A-Za-z0-9_]*|dlsym|cuinterpose_[a-z_]+)$$'
+
+.PHONY: all clean test check-cuda-headers
+
+all: $(INTERPOSER) $(COORDINATOR)
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+check-cuda-headers:
+	@test -n "$(CUDA_VERSION)" || { echo "cuda.h not found under $(CUDA_HOME)/include" >&2; exit 1; }
+	@if [ "$(CUDA_VERSION)" -lt "$(MIN_CUDA_VERSION)" ] && [ -z "$(ALLOW_OLD_CUDA_HEADERS)" ]; then \
+	  echo "CUDA headers are $(CUDA_VERSION); the shim is built against >= $(MIN_CUDA_VERSION) (set ALLOW_OLD_CUDA_HEADERS=1 to override)" >&2; exit 1; fi
+
+$(INTERPOSER): $(INTERPOSER_SOURCES) $(INTERPOSER_HEADERS) | $(BUILD_DIR) check-cuda-headers
+	$(CC) $(INTERPOSER_CFLAGS) $(INTERPOSER_CPPFLAGS) -o $@.tmp $(INTERPOSER_SOURCES) $(INTERPOSER_LDFLAGS)
+	@# No link-time dependency on the CUDA libraries.
+	! readelf -d $@.tmp | grep -Eq 'NEEDED.*(libcuda|libcudart)'
+	@# No glibc symbol newer than MIN_GLIBC.
+	max=$$(readelf -V $@.tmp | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1); \
+	  [ "$$(printf '%s\n%s\n' "$$max" "$(MIN_GLIBC)" | sort -uV | tail -1)" = "$(MIN_GLIBC)" ]
+	@# The real dlsym is fetched through the pinned dlvsym (once the shim resolves symbols at all).
+	@if [ -f symbols.c ]; then readelf --dyn-syms -W $@.tmp | grep -q 'dlvsym@$(MIN_GLIBC)'; fi
+	@# Only the intended symbols are exported.
+	@bad=$$(nm -D --defined-only $@.tmp | awk '$$2 ~ /^[TWDRBV]$$/ {print $$3}' | grep -Ev $(EXPORT_ALLOWLIST) || true); \
+	  if [ -n "$$bad" ]; then echo "unexpected exported symbols:" $$bad >&2; exit 1; fi
+	mv $@.tmp $@
+
+$(COORDINATOR): $(COORDINATOR_SOURCES) $(COORDINATOR_HEADERS) | $(BUILD_DIR)
+	$(CC) $(COMMON_FLAGS) -static -pthread -o $@.tmp $(COORDINATOR_SOURCES)
+	! readelf -d $@.tmp 2>/dev/null | grep -q NEEDED
+	mv $@.tmp $@
+
+# ---------------------------------------------------------------------------
+# Tests. The shim under test is a separate build with AddressSanitizer and
+# UndefinedBehaviorSanitizer; the production .so above is never instrumented.
+# Fake libcuda.so.1 / libcudart.so.13 record what they were called with.
+#
+# Three kinds of test, told apart by file name:
+#   tests/<name>_unit_test.cc     links the shim's CUDA-free objects (util,
+#                                 posix, tables, export cache) and runs alone
+#   tests/<name>_preload_test.cc  runs with the sanitized shim LD_PRELOADed
+#                                 over the fake libcuda/libcudart
+#   tests/coordinator_test.cc     runs the sanitized coordinator binary
+#                                 against fake participants
+# ---------------------------------------------------------------------------
+TEST_DIR := $(BUILD_DIR)/test
+SANITIZE ?= address,undefined
+SANITIZE_FLAGS := $(if $(SANITIZE),-fsanitize=$(SANITIZE) -fno-omit-frame-pointer,)
+GTEST_CFLAGS ?= $(shell pkg-config --cflags gtest 2>/dev/null)
+GTEST_LIBS ?= $(shell pkg-config --libs gtest_main gtest 2>/dev/null || echo -lgtest_main -lgtest)
+TEST_CXXFLAGS := -std=c++17 -O1 -g -Wall -Wextra -Werror -Wno-deprecated-declarations -I. -I$(CUDA_HOME)/include $(GTEST_CFLAGS)
+TEST_INTERPOSER := $(TEST_DIR)/libcuinterpose.so
+FAKE_CUDA := $(TEST_DIR)/libcuda.so.1
+FAKE_CUDART := $(TEST_DIR)/libcudart.so.13
+TEST_COORDINATOR := $(TEST_DIR)/cuinterpose-coordinator
+TEST_HEADERS := $(wildcard tests/*.h)
+UNIT_TESTS := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/*_unit_test.cc))
+PRELOAD_TESTS := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/*_preload_test.cc))
+COORDINATOR_TEST := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/coordinator_test.cc))
+# Shim sources that need no CUDA driver at run time. symbols.c and context.c
+# resolve driver symbols and are exercised through the preload tests.
+UNIT_SOURCES := $(filter-out coordinator.c interpose.c multicast.c symbols.c context.c,$(wildcard *.c)) $(UTIL_SOURCES)
+UNIT_OBJECTS := $(patsubst %.c,$(TEST_DIR)/%.o,$(UNIT_SOURCES))
+# When the shim under test is ASan-instrumented, the ASan runtime must be the
+# first library in the process, ahead of the shim itself.
+ASAN_PRELOAD := $(if $(findstring address,$(SANITIZE)),$(shell $(CC) -print-file-name=libasan.so):,)
+TEST_ENV := SNAPSHOT_CONTROL_DIR=$(abspath $(TEST_DIR)/control) CUINTERPOSE_COORDINATOR=$(abspath $(TEST_COORDINATOR))
+
+$(TEST_DIR):
+	mkdir -p $@
+
+$(TEST_DIR)/%.o: %.c $(INTERPOSER_HEADERS) | $(TEST_DIR)
+	@mkdir -p $(@D)
+	$(CC) $(COMMON_FLAGS) $(SANITIZE_FLAGS) -g -c -o $@ $<
+
+# symbols.c is compiled without instrumentation: it defines dlsym, which the
+# sanitizer runtime itself calls while it is still initializing, before
+# instrumented code may run.
+SYMBOLS_OBJECT := $(if $(wildcard symbols.c),$(TEST_DIR)/symbols.plain.o,)
+SANITIZED_SOURCES := $(filter-out symbols.c,$(INTERPOSER_SOURCES))
+$(TEST_DIR)/symbols.plain.o: symbols.c $(INTERPOSER_HEADERS) | $(TEST_DIR) check-cuda-headers
+	$(CC) $(INTERPOSER_CFLAGS) $(INTERPOSER_CPPFLAGS) -g -c -o $@ symbols.c
+
+$(TEST_INTERPOSER): $(INTERPOSER_SOURCES) $(INTERPOSER_HEADERS) $(SYMBOLS_OBJECT) | $(TEST_DIR) check-cuda-headers
+	$(CC) $(INTERPOSER_CFLAGS) $(INTERPOSER_CPPFLAGS) $(SANITIZE_FLAGS) -g -o $@ $(SANITIZED_SOURCES) $(SYMBOLS_OBJECT) $(INTERPOSER_LDFLAGS)
+
+$(FAKE_CUDA): tests/fake_cuda.c tests/fake_cuda.h | $(TEST_DIR)
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
+	  -Wl,-soname,libcuda.so.1 -o $@ tests/fake_cuda.c -pthread
+	ln -sf libcuda.so.1 $(TEST_DIR)/libcuda.so
+
+$(FAKE_CUDART): tests/fake_cudart.c tests/fake_cuda.h | $(TEST_DIR) $(FAKE_CUDA)
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations -I$(CUDA_HOME)/include \
+	  -Wl,-soname,libcudart.so.13 -L$(TEST_DIR) -o $@ tests/fake_cudart.c -lcuda
+	ln -sf libcudart.so.13 $(TEST_DIR)/libcudart.so
+
+$(TEST_DIR)/%_unit_test: tests/%_unit_test.cc $(UNIT_OBJECTS) $(INTERPOSER_HEADERS) $(TEST_HEADERS) | $(TEST_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(SANITIZE_FLAGS) -o $@ $< $(UNIT_OBJECTS) $(GTEST_LIBS) -pthread
+
+$(TEST_DIR)/%_preload_test: tests/%_preload_test.cc $(INTERPOSER_HEADERS) $(TEST_HEADERS) $(FAKE_CUDA) $(FAKE_CUDART) | $(TEST_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(SANITIZE_FLAGS) -L$(TEST_DIR) -Wl,-rpath,'$$ORIGIN' -o $@ $< -lcuda -lcudart -ldl $(GTEST_LIBS) -pthread
+
+# A dynamically linked, sanitizer-instrumented coordinator for the tests; the
+# production one above is static and uninstrumented.
+$(TEST_COORDINATOR): $(COORDINATOR_SOURCES) $(COORDINATOR_HEADERS) | $(TEST_DIR)
+	$(CC) $(COMMON_FLAGS) $(SANITIZE_FLAGS) -g -pthread -o $@ $(COORDINATOR_SOURCES)
+
+$(TEST_DIR)/coordinator_test: tests/coordinator_test.cc $(UNIT_OBJECTS) $(TEST_HEADERS) $(TEST_COORDINATOR) | $(TEST_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(SANITIZE_FLAGS) -o $@ $< $(UNIT_OBJECTS) $(GTEST_LIBS) -pthread
+
+test: $(INTERPOSER) $(COORDINATOR) $(UNIT_TESTS) $(COORDINATOR_TEST) $(if $(PRELOAD_TESTS),$(TEST_INTERPOSER) $(TEST_COORDINATOR)) $(PRELOAD_TESTS)
+	@mkdir -p $(TEST_DIR)/control
+	$(foreach t,$(UNIT_TESTS),$(t) &&) true
+	$(foreach t,$(COORDINATOR_TEST),CUINTERPOSE_COORDINATOR=$(abspath $(TEST_COORDINATOR)) $(t) &&) true
+	$(foreach t,$(PRELOAD_TESTS),$(TEST_ENV) LD_PRELOAD=$(ASAN_PRELOAD)$(abspath $(TEST_INTERPOSER)) $(t) &&) true
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Placeholder coordinator. The snapshot agent runs the coordinator only when a
+ * checkpointed CUDA process shows a cuinterpose control socket, and this
+ * build's shim opens none, so this program is never reached in practice. If it
+ * is, it refuses to do anything and says so. The real coordinator replaces it
+ * in a following change; the agent's argument contract is already final and
+ * covered by the Go tests against a fake binary.
+ */
+
+#include <stdio.h>
+
+#include "protocol.h"
+
+int
+main(int argc, char** argv)
+{
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "cuinterpose-coordinator (protocol %u): this build carries no coordinator; nothing was prepared or restored\n",
+          (unsigned)CUINTERPOSE_VERSION);
+  return 1;
+}

--- a/agent/cmd/cuinterpose/export.h
+++ b/agent/cmd/cuinterpose/export.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_EXPORT_H
+#define CUINTERPOSE_EXPORT_H
+
+#include <stdint.h>
+
+/*
+ * The shim is built with -fvisibility=hidden, so nothing leaks into the
+ * workload's global symbol table unless it is marked with CUINTERPOSE_API. Only the
+ * CUDA entry points the shim replaces, dlsym, and cuinterpose_build_info carry
+ * it; the Makefile asserts that no other symbol is exported. An LD_PRELOAD
+ * library sits first in symbol lookup for the whole process, so an accidental
+ * export named like a common helper would silently hijack another library's
+ * call.
+ */
+#define CUINTERPOSE_API __attribute__((visibility("default")))
+
+/*
+ * cuinterpose_build_info lets an operator or a test confirm which CUDA headers
+ * the loaded shim was compiled against, for example with
+ * `nm -D libcuinterpose.so` or by dlsym()ing the symbol.
+ */
+struct cuinterpose_build_info {
+  uint32_t cuda_version; /* CUDA_VERSION from cuda.h at build time */
+  uint32_t protocol_version; /* CUINTERPOSE_VERSION from protocol.h */
+};
+
+extern CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info;
+
+/*
+ * Live counters for tests and operators: how much the shim is tracking in this
+ * process right now. Reading them takes the shim's lock briefly.
+ */
+struct cuinterpose_debug_stats {
+  uint64_t allocations; /* tracked allocation records */
+  uint64_t handles; /* logical handles handed to the application */
+  uint64_t mappings; /* tracked mappings */
+  uint64_t multicasts; /* tracked multicast objects */
+  uint64_t cached_exports; /* descriptors held in the export cache */
+  uint64_t live_raw_imports; /* untracked imports not yet released */
+  uint64_t unsupported_exportable_creations; /* successful creations cuinterpose cannot restore */
+  uint32_t phase; /* enum cuinterpose_phase */
+};
+
+CUINTERPOSE_API void cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats);
+
+#endif

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Placeholder shim. It builds and is packaged as libcuinterpose.so so that the
+ * delivery path (init container, LD_PRELOAD, restore mount) is final before
+ * the interposer exists, and it intercepts nothing. The following changes
+ * replace it: symbol resolution and forwarding, allocation tracking, the
+ * checkpoint lifecycle, multicast objects.
+ */
+
+#include <cuda.h>
+#include <string.h>
+
+#include "export.h"
+#include "protocol.h"
+
+CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info = {CUDA_VERSION, CUINTERPOSE_VERSION};
+
+CUINTERPOSE_API void
+cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
+{
+  memset(stats, 0, sizeof(*stats));
+}

--- a/agent/cmd/cuinterpose/protocol.c
+++ b/agent/cmd/cuinterpose/protocol.c
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "protocol.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+/*
+ * The wire I/O half of protocol.h: one fixed-size header each way, optionally
+ * carrying one descriptor as SCM_RIGHTS ancillary data.
+ */
+
+bool
+cuinterpose_header_strings_terminated(const struct cuinterpose_header* header)
+{
+  return memchr(header->participant_id, '\0', sizeof(header->participant_id)) != NULL &&
+         memchr(header->message, '\0', sizeof(header->message)) != NULL;
+}
+
+void
+cuinterpose_header_error(struct cuinterpose_header* header, const char* message)
+{
+  header->status = -1;
+  snprintf(header->message, sizeof(header->message), "%s", message);
+}
+
+int
+cuinterpose_send_header(int fd, const struct cuinterpose_header* header, int passed_fd)
+{
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {.iov_base = (void*)header, .iov_len = sizeof(*header)};
+  struct msghdr message = {.msg_iov = &vector, .msg_iovlen = 1};
+  ssize_t count;
+
+  if (passed_fd >= 0) {
+    struct cmsghdr* item;
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(item), &passed_fd, sizeof(passed_fd));
+  }
+  do {
+    count = sendmsg(fd, &message, MSG_NOSIGNAL);
+  } while (count < 0 && errno == EINTR);
+  return count == (ssize_t)sizeof(*header) ? 0 : -1;
+}
+
+/*
+ * The kernel installs any SCM_RIGHTS descriptors into this process before
+ * recvmsg returns, even when the message is truncated or carries more than
+ * expected. Every failure path below therefore closes whatever arrived so a
+ * misbehaving peer cannot make the process leak descriptors.
+ */
+int
+cuinterpose_receive_header(int fd, struct cuinterpose_header* header, int* passed_fd)
+{
+  /* Room for two descriptors so a second one is detected instead of truncated. */
+  char control[CMSG_SPACE(sizeof(int) * 2)] = {0};
+  struct iovec vector = {.iov_base = header, .iov_len = sizeof(*header)};
+  struct msghdr message = {
+      .msg_iov = &vector,
+      .msg_iovlen = 1,
+      .msg_control = control,
+      .msg_controllen = sizeof(control),
+  };
+  struct cmsghdr* item;
+  ssize_t count;
+  int received[2] = {-1, -1};
+  size_t received_count = 0;
+  bool ok;
+
+  *passed_fd = -1;
+  do {
+    count = recvmsg(fd, &message, MSG_WAITALL | MSG_CMSG_CLOEXEC);
+  } while (count < 0 && errno == EINTR);
+  if (count < 0)
+    return -1;
+  for (item = CMSG_FIRSTHDR(&message); item != NULL; item = CMSG_NXTHDR(&message, item)) {
+    if (item->cmsg_level != SOL_SOCKET || item->cmsg_type != SCM_RIGHTS)
+      continue;
+    size_t bytes = item->cmsg_len - CMSG_LEN(0);
+    size_t index;
+    for (index = 0; index < bytes / sizeof(int); index++) {
+      int value;
+      memcpy(&value, CMSG_DATA(item) + index * sizeof(int), sizeof(value));
+      if (received_count < 2)
+        received[received_count] = value;
+      else
+        close(value);
+      received_count++;
+    }
+  }
+  ok = count == (ssize_t)sizeof(*header) && (message.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) == 0 &&
+       received_count <= 1;
+  if (!ok) {
+    if (received[0] >= 0)
+      close(received[0]);
+    if (received[1] >= 0)
+      close(received[1]);
+    return -1;
+  }
+  *passed_fd = received[0];
+  return 0;
+}

--- a/agent/cmd/cuinterpose/protocol.h
+++ b/agent/cmd/cuinterpose/protocol.h
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_PROTOCOL_H
+#define CUINTERPOSE_PROTOCOL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* The headers are shared with C++ tests. */
+#ifdef __cplusplus
+#define CUINTERPOSE_STATIC_ASSERT static_assert
+#else
+#define CUINTERPOSE_STATIC_ASSERT _Static_assert
+#endif
+
+/*
+ * Wire contract between the shim's control socket and the coordinator, and
+ * the fixed names the Go agent relies on. The Go side pins these strings with a
+ * test (agent/internal/cuda), so renaming one here breaks that test rather
+ * than silently disabling interposition.
+ */
+
+/* Directory (inside the workload container) holding per-process control sockets. */
+#define CUINTERPOSE_CONTROL_DIR "/snapshot-control"
+/* Environment variable overriding CUINTERPOSE_CONTROL_DIR; must be absolute. */
+#define CUINTERPOSE_CONTROL_DIR_ENV "SNAPSHOT_CONTROL_DIR"
+/* Socket name: <prefix><namespace-pid>.sock */
+#define CUINTERPOSE_SOCKET_PREFIX "cuinterpose-"
+/* Topology sidecar the coordinator writes into the checkpoint directory. */
+#define CUINTERPOSE_STATE_FILENAME "cuinterpose.state"
+/* Optional stable participant identity: 32 lowercase hex characters. */
+#define CUINTERPOSE_PARTICIPANT_ID_ENV "CUINTERPOSE_PARTICIPANT_ID"
+/* Whole-second send/receive timeout for every control socket, both sides. */
+#define CUINTERPOSE_CONTROL_TIMEOUT_ENV "SNAPSHOT_CONTROL_TIMEOUT_SECONDS"
+#define CUINTERPOSE_CONTROL_TIMEOUT_SECONDS_DEFAULT 10U
+/* Longer timeout for the two operations that copy allocation contents between
+ * device and host; they scale with the amount of tracked memory. */
+#define CUINTERPOSE_CARRIER_TIMEOUT_ENV "SNAPSHOT_CARRIER_TIMEOUT_SECONDS"
+#define CUINTERPOSE_CARRIER_TIMEOUT_SECONDS_DEFAULT 3600U
+/* First line of the state file; bump when the record layout changes. */
+#define CUINTERPOSE_STATE_HEADER "cuinterpose-state-v2"
+
+#define CUINTERPOSE_MAGIC 0x44564d4dU
+#define CUINTERPOSE_VERSION 2U
+#define CUINTERPOSE_ID_SIZE 33U
+#define CUINTERPOSE_ALLOCATION_ID_SIZE 16U
+/* Access descriptors kept per mapping. The shim merges access calls per
+ * location, so this bounds the number of distinct GPUs (plus host NUMA nodes)
+ * that may be granted access to one mapping. */
+#define CUINTERPOSE_MAX_ACCESS 32U
+#define CUINTERPOSE_MAX_RECORDS 4096U
+#define CUINTERPOSE_POSIX_HANDLE_TYPE 1U
+
+enum cuinterpose_operation {
+  CUINTERPOSE_HANDSHAKE = 1,
+  CUINTERPOSE_INSPECT = 2,
+  CUINTERPOSE_PREPARE_MULTICAST = 3,
+  CUINTERPOSE_SAVE_ALLOCATIONS = 4,
+  CUINTERPOSE_PREPARE_UNICAST = 5,
+  CUINTERPOSE_EXPORT = 6,
+  CUINTERPOSE_LOAD_ALLOCATIONS = 7,
+  CUINTERPOSE_RESTORE_UNICAST = 8,
+  CUINTERPOSE_RESTORE_MULTICAST_CREATORS = 9,
+  CUINTERPOSE_RESTORE_MULTICAST_IMPORTERS = 10,
+  CUINTERPOSE_RESTORE_MULTICAST_DEVICES = 11,
+  CUINTERPOSE_RESTORE_MULTICAST_BINDINGS = 12,
+};
+
+enum cuinterpose_record_kind {
+  CUINTERPOSE_ALLOCATION = 1,
+  CUINTERPOSE_MAPPING = 2,
+  CUINTERPOSE_MULTICAST = 3,
+  CUINTERPOSE_MULTICAST_DEVICE = 4,
+  CUINTERPOSE_MULTICAST_BINDING = 5,
+  CUINTERPOSE_MULTICAST_MAPPING = 6,
+};
+
+enum cuinterpose_record_flags {
+  CUINTERPOSE_CREATOR = 1U << 0,
+  CUINTERPOSE_APPLICATION_HANDLE_LIVE = 1U << 1,
+  CUINTERPOSE_ALLOCATION_CONTENT = 1U << 2,
+  /* A creator allocation that was never exported. It is reported only so its
+   * contents can be preserved; no importer refers to it. */
+  CUINTERPOSE_CONTENT_ONLY = 1U << 3,
+};
+
+/* Where a participant is in the checkpoint/restore lifecycle; reported in
+ * HANDSHAKE replies for diagnostics. */
+enum cuinterpose_phase {
+  CUINTERPOSE_PHASE_ACTIVE = 1,
+  CUINTERPOSE_PHASE_PREPARING = 2,
+  CUINTERPOSE_PHASE_PREPARED = 3,
+  CUINTERPOSE_PHASE_RESTORING = 4,
+  CUINTERPOSE_PHASE_FAILED = 5,
+};
+
+enum cuinterpose_resource_kind {
+  CUINTERPOSE_RESOURCE_UNICAST = 1,
+  CUINTERPOSE_RESOURCE_MULTICAST = 2,
+};
+
+enum cuinterpose_multicast_binding_kind {
+  CUINTERPOSE_MULTICAST_BIND_MEM = 1,
+  CUINTERPOSE_MULTICAST_BIND_ADDR = 2,
+};
+
+/*
+ * Every control exchange is one fixed-size header each way, optionally
+ * followed by `count` records (`payload_size` bytes) and optionally carrying
+ * one file descriptor as SCM_RIGHTS ancillary data.
+ */
+struct cuinterpose_header {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t operation;
+  int32_t status; /* 0 on success, -1 with `message` on failure */
+  uint32_t count;
+  uint64_t payload_size;
+  char participant_id[CUINTERPOSE_ID_SIZE];
+  char message[96];
+  uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  uint32_t resource_kind;
+  /* Set by the shim in HANDSHAKE and INSPECT replies. */
+  uint32_t live_raw_imports; /* untracked imports still held; prepare refuses if non-zero */
+  /* Successful exportable creations using a handle type cuinterpose cannot
+   * restore. Prepare refuses if this is non-zero. */
+  uint32_t unsupported_exportable_creations;
+  uint8_t phase; /* enum cuinterpose_phase, 0 when unknown */
+  uint8_t reserved_align[3];
+  uint32_t copy_us; /* allocation save/load replies: device-copy time in microseconds */
+  uint8_t reserved[64];
+};
+
+struct cuinterpose_access {
+  int32_t location_type;
+  int32_t location_id;
+  uint64_t flags;
+};
+
+struct cuinterpose_record {
+  uint32_t kind;
+  uint32_t flags;
+  uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  uint64_t address;
+  uint64_t size;
+  uint64_t offset;
+  uint64_t allocation_size;
+  int32_t allocation_type;
+  uint32_t requested_handle_types;
+  int32_t allocation_location_type;
+  int32_t allocation_location_id;
+  uint32_t access_count;
+  uint32_t application_handle_count;
+  struct cuinterpose_access access[CUINTERPOSE_MAX_ACCESS];
+  uint8_t member_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  char creator_participant[CUINTERPOSE_ID_SIZE];
+  uint8_t binding_kind;
+  uint8_t api_version;
+  uint8_t reserved[5];
+  uint64_t member_offset;
+  uint64_t operation_flags;
+  uint64_t handle_types;
+  uint64_t object_flags;
+  uint32_t num_devices;
+  int32_t device;
+};
+
+/*
+ * Wire I/O (implemented in protocol.c): one header each way, optionally
+ * carrying one descriptor as SCM_RIGHTS ancillary data.
+ */
+
+bool cuinterpose_header_strings_terminated(const struct cuinterpose_header* header);
+void cuinterpose_header_error(struct cuinterpose_header* header, const char* message);
+/* Sends one header and, when passed_fd >= 0, that descriptor as SCM_RIGHTS. */
+int cuinterpose_send_header(int fd, const struct cuinterpose_header* header, int passed_fd);
+/* Receives one header. On success *passed_fd is the received descriptor or -1.
+ * On failure no descriptor is left open, whatever the peer sent. */
+int cuinterpose_receive_header(int fd, struct cuinterpose_header* header, int* passed_fd);
+
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_header) == 256, "cuinterpose header layout changed");
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_access) == 16, "cuinterpose access layout changed");
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_record) == 688, "cuinterpose record layout changed");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_ALLOCATION < CUINTERPOSE_MULTICAST_BINDING, "unicast members must sort before multicast bindings");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_MULTICAST < CUINTERPOSE_MULTICAST_DEVICE, "multicast objects must sort before their devices");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_MULTICAST_DEVICE < CUINTERPOSE_MULTICAST_BINDING,
+    "multicast devices must sort before their bindings");
+CUINTERPOSE_STATIC_ASSERT(
+    CUINTERPOSE_MULTICAST < CUINTERPOSE_MULTICAST_MAPPING, "multicast objects must sort before their mappings");
+
+#endif

--- a/agent/cmd/cuinterpose/tests/util_unit_test.cc
+++ b/agent/cmd/cuinterpose/tests/util_unit_test.cc
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "util/cleanup.h"
+#include "util/id.h"
+#include "util/time.h"
+}
+
+namespace {
+
+TEST(util, identity_compare_and_copy)
+{
+  char id[CUINTERPOSE_ID_SIZE] = "0123456789abcdef0123456789abcdef";
+  char same[CUINTERPOSE_ID_SIZE] = "0123456789abcdef0123456789abcdef";
+  char different[CUINTERPOSE_ID_SIZE] = "ffffffffffffffffffffffffffffffff";
+  char copied[CUINTERPOSE_ID_SIZE] = {0};
+  uint8_t allocation[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  uint8_t other[CUINTERPOSE_ALLOCATION_ID_SIZE];
+
+  EXPECT_TRUE(id_eq(id, same));
+  EXPECT_FALSE(id_eq(id, different));
+  id_copy(copied, id);
+  EXPECT_TRUE(id_eq(copied, id));
+
+  memset(allocation, 0x5a, sizeof(allocation));
+  memset(other, 0x5a, sizeof(other));
+  EXPECT_TRUE(allocation_id_eq(allocation, other));
+  other[CUINTERPOSE_ALLOCATION_ID_SIZE - 1] = 0;
+  EXPECT_FALSE(allocation_id_eq(allocation, other));
+  allocation_id_copy(other, allocation);
+  EXPECT_TRUE(allocation_id_eq(allocation, other));
+}
+
+TEST(util, hex_digit)
+{
+  EXPECT_EQ(hex_digit('0'), 0);
+  EXPECT_EQ(hex_digit('9'), 9);
+  EXPECT_EQ(hex_digit('a'), 10);
+  EXPECT_EQ(hex_digit('f'), 15);
+  EXPECT_EQ(hex_digit('g'), -1);
+  EXPECT_EQ(hex_digit('A'), -1);
+  EXPECT_EQ(hex_digit(EOF), -1);
+}
+
+TEST(util, elapsed_time_handles_nanosecond_rollover)
+{
+  const timespec start = {.tv_sec = 10, .tv_nsec = 900000000};
+  const timespec end = {.tv_sec = 12, .tv_nsec = 100000000};
+
+  EXPECT_DOUBLE_EQ(elapsed_milliseconds(&start, &end), 1200.0);
+}
+
+TEST(util, cleanup_closes_fd_and_take_releases_it)
+{
+  int taken;
+  int closed;
+
+  taken = open("/dev/null", O_RDONLY);
+  ASSERT_GE(taken, 0);
+  {
+    CUINTERPOSE_CLEANUP(close_fd) int fd = open("/dev/null", O_RDONLY);
+    ASSERT_GE(fd, 0);
+    closed = fd;
+  }
+  EXPECT_EQ(fcntl(closed, F_GETFD), -1);
+  {
+    CUINTERPOSE_CLEANUP(close_fd) int fd = open("/dev/null", O_RDONLY);
+    ASSERT_GE(fd, 0);
+    closed = take_fd(&fd);
+  }
+  EXPECT_GE(fcntl(closed, F_GETFD), 0);
+  close(closed);
+  close(taken);
+}
+
+TEST(util, cleanup_closes_file)
+{
+  FILE* file = tmpfile();
+  int raw;
+  ASSERT_NE(file, nullptr);
+  raw = fileno(file);
+  ASSERT_GE(raw, 0);
+  {
+    CUINTERPOSE_CLEANUP(close_file) FILE* scoped = file;
+    (void)scoped;
+  }
+  EXPECT_EQ(fcntl(raw, F_GETFD), -1);
+  {
+    CUINTERPOSE_CLEANUP(close_file) FILE* nothing = nullptr;
+    (void)nothing;
+  }
+}
+
+TEST(util, unlink_guard_removes_unless_disarmed)
+{
+  char path[] = "/tmp/cuinterpose-util-test-XXXXXX";
+  int fd = mkstemp(path);
+  ASSERT_GE(fd, 0);
+  close(fd);
+  {
+    CUINTERPOSE_CLEANUP(unlink_guard_release) struct unlink_guard guard = {path, true};
+  }
+  EXPECT_EQ(access(path, F_OK), -1);
+
+  {
+    char kept[] = "/tmp/cuinterpose-util-test-XXXXXX";
+    fd = mkstemp(kept);
+    ASSERT_GE(fd, 0);
+    close(fd);
+    {
+      CUINTERPOSE_CLEANUP(unlink_guard_release) struct unlink_guard guard = {kept, true};
+      guard.armed = false;
+    }
+    EXPECT_EQ(access(kept, F_OK), 0);
+    EXPECT_EQ(unlink(kept), 0);
+  }
+}
+
+} // namespace

--- a/agent/cmd/cuinterpose/util/cleanup.h
+++ b/agent/cmd/cuinterpose/util/cleanup.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_UTIL_CLEANUP_H
+#define CUINTERPOSE_UTIL_CLEANUP_H
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/*
+ * Scoped cleanup: FUNCTION receives the variable's address on every exit from
+ * its scope, however the scope is left. Transfer ownership out of a cleanup
+ * scope with take_fd. This is the one macro in util/: the cleanup attribute
+ * exists only on declarations, so no function can express it; everything that
+ * can be a function below is one.
+ *
+ *   CUINTERPOSE_CLEANUP(close_fd) int fd = open(...);
+ */
+#define CUINTERPOSE_CLEANUP(FUNCTION) __attribute__((cleanup(FUNCTION)))
+
+static inline void
+close_fd(int* fd)
+{
+  if (*fd >= 0)
+    close(*fd);
+}
+
+/* Hands the descriptor to the caller and disarms the cleanup variable. */
+static inline int
+take_fd(int* fd)
+{
+  int taken = *fd;
+
+  *fd = -1;
+  return taken;
+}
+
+static inline void
+free_ptr(void* pointer)
+{
+  free(*(void**)pointer);
+}
+
+static inline void
+close_file(FILE** file)
+{
+  if (*file != NULL)
+    fclose(*file);
+}
+
+/*
+ * Removes a temporary file at scope exit unless disarmed; backs the
+ * write-temporary-then-rename protocol:
+ *
+ *   CUINTERPOSE_CLEANUP(unlink_guard_release) struct unlink_guard guard = {temporary, true};
+ *   ... write, fsync, rename ...
+ *   guard.armed = false;
+ */
+struct unlink_guard {
+  const char* path;
+  bool armed;
+};
+
+static inline void
+unlink_guard_release(struct unlink_guard* guard)
+{
+  if (guard->armed && guard->path != NULL)
+    unlink(guard->path);
+}
+
+#endif

--- a/agent/cmd/cuinterpose/util/id.c
+++ b/agent/cmd/cuinterpose/util/id.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "id.h"
+
+#include <stdio.h>
+
+#include "misc.h"
+
+int
+hex_digit(int value)
+{
+  if (value >= '0' && value <= '9')
+    return value - '0';
+  if (value >= 'a' && value <= 'f')
+    return value - 'a' + 10;
+  return -1;
+}
+
+bool
+is_lower_hex_id(const char value[CUINTERPOSE_ID_SIZE])
+{
+  size_t index;
+
+  if (value == NULL)
+    return false;
+  for (index = 0; index < CUINTERPOSE_ID_SIZE - 1; index++) {
+    if (hex_digit((unsigned char)value[index]) < 0)
+      return false;
+  }
+  return value[CUINTERPOSE_ID_SIZE - 1] == '\0';
+}
+
+int
+random_id(char output[CUINTERPOSE_ID_SIZE])
+{
+  uint8_t value[16];
+  size_t index;
+
+  if (random_bytes(value, sizeof(value)) != 0)
+    return -1;
+  for (index = 0; index < sizeof(value); index++)
+    snprintf(output + index * 2, CUINTERPOSE_ID_SIZE - index * 2, "%02x", value[index]);
+  return 0;
+}

--- a/agent/cmd/cuinterpose/util/id.h
+++ b/agent/cmd/cuinterpose/util/id.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_UTIL_ID_H
+#define CUINTERPOSE_UTIL_ID_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "protocol.h"
+
+/* Participant identities are fixed-size NUL-terminated buffers. */
+static inline bool
+id_eq(const char a[CUINTERPOSE_ID_SIZE], const char b[CUINTERPOSE_ID_SIZE])
+{
+  return memcmp(a, b, CUINTERPOSE_ID_SIZE) == 0;
+}
+
+static inline void
+id_copy(char destination[CUINTERPOSE_ID_SIZE], const char source[CUINTERPOSE_ID_SIZE])
+{
+  memcpy(destination, source, CUINTERPOSE_ID_SIZE);
+}
+
+/* Allocation identities are fixed-size binary. */
+static inline bool
+allocation_id_eq(
+    const uint8_t a[CUINTERPOSE_ALLOCATION_ID_SIZE], const uint8_t b[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  return memcmp(a, b, CUINTERPOSE_ALLOCATION_ID_SIZE) == 0;
+}
+
+static inline void
+allocation_id_copy(
+    uint8_t destination[CUINTERPOSE_ALLOCATION_ID_SIZE], const uint8_t source[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  memcpy(destination, source, CUINTERPOSE_ALLOCATION_ID_SIZE);
+}
+
+/* The lowercase-hex value of one character, or -1 for anything else. */
+int hex_digit(int value);
+bool is_lower_hex_id(const char value[CUINTERPOSE_ID_SIZE]);
+/* Writes 32 lowercase hex characters plus the terminator. */
+int random_id(char output[CUINTERPOSE_ID_SIZE]);
+
+#endif

--- a/agent/cmd/cuinterpose/util/io.c
+++ b/agent/cmd/cuinterpose/util/io.c
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "io.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+int
+write_all(int fd, const void* value, size_t size)
+{
+  const uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = write(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+send_all(int fd, const void* value, size_t size)
+{
+  const uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = send(fd, current, size, MSG_NOSIGNAL);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+read_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = read(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+pread_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+  off_t offset = 0;
+
+  while (size != 0) {
+    ssize_t count = pread(fd, current, size, offset);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    offset += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+set_socket_timeouts(int fd, unsigned seconds)
+{
+  struct timeval timeout = {.tv_sec = (time_t)seconds};
+
+  return setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) == 0 &&
+                 setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == 0
+             ? 0
+             : -1;
+}

--- a/agent/cmd/cuinterpose/util/io.h
+++ b/agent/cmd/cuinterpose/util/io.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_UTIL_IO_H
+#define CUINTERPOSE_UTIL_IO_H
+
+#include <stddef.h>
+
+/*
+ * Full-buffer descriptor I/O shared by the shim and the coordinator. All of
+ * these are internal: the shim is built with hidden visibility, and the
+ * coordinator is a static binary.
+ */
+
+/* Loops until every byte is written. For files and memfds; not for sockets. */
+int write_all(int fd, const void* value, size_t size);
+/* Like write_all for a socket: uses send(MSG_NOSIGNAL) so a peer that hung up
+ * produces EPIPE instead of killing the process with SIGPIPE. */
+int send_all(int fd, const void* value, size_t size);
+int read_all(int fd, void* value, size_t size);
+/* Reads `size` bytes from offset 0 without moving the file position. */
+int pread_all(int fd, void* value, size_t size);
+/* Sets SO_SNDTIMEO and SO_RCVTIMEO together. */
+int set_socket_timeouts(int fd, unsigned seconds);
+
+#endif

--- a/agent/cmd/cuinterpose/util/misc.c
+++ b/agent/cmd/cuinterpose/util/misc.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "misc.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/random.h>
+
+#include "protocol.h"
+
+int
+random_bytes(void* output, size_t size)
+{
+  unsigned char* current = output;
+
+  while (size != 0) {
+    ssize_t count = getrandom(current, size, 0);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+/*
+ * Hand-rolled rather than strtol: the shim is compiled with _GNU_SOURCE, which
+ * turns on _ISOC23_SOURCE and makes <stdlib.h> route the strtol family to
+ * __isoc23_strtol@GLIBC_2.38. That would raise the shim's glibc floor above the
+ * 2.34 the Makefile asserts. Trailing garbage is rejected rather than ignored
+ * so "3x" cannot silently arm a 3-second timeout.
+ */
+unsigned
+bounded_seconds(const char* value, unsigned fallback)
+{
+  unsigned long parsed = 0;
+  const char* digits;
+
+  if (value == NULL)
+    return fallback;
+  while (*value == ' ' || *value == '\t' || *value == '\n' || *value == '\r')
+    value++;
+  for (digits = value; *value >= '0' && *value <= '9'; value++) {
+    parsed = parsed * 10 + (unsigned long)(*value - '0');
+    if (parsed > 86400)
+      return fallback;
+  }
+  if (value == digits || parsed == 0)
+    return fallback;
+  while (*value == ' ' || *value == '\t' || *value == '\n' || *value == '\r')
+    value++;
+  return *value == '\0' ? (unsigned)parsed : fallback;
+}
+
+unsigned
+cuinterpose_control_timeout_seconds(void)
+{
+  static unsigned cached;
+
+  if (cached == 0)
+    cached = bounded_seconds(getenv(CUINTERPOSE_CONTROL_TIMEOUT_ENV), CUINTERPOSE_CONTROL_TIMEOUT_SECONDS_DEFAULT);
+  return cached;
+}

--- a/agent/cmd/cuinterpose/util/misc.h
+++ b/agent/cmd/cuinterpose/util/misc.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_UTIL_MISC_H
+#define CUINTERPOSE_UTIL_MISC_H
+
+#include <stddef.h>
+
+/*
+ * Odds and ends with no better home. When two helpers here share a theme they
+ * graduate to a file of their own; io, id, cleanup, and table all started as
+ * recognizable themes rather than growing out of this file.
+ */
+
+int random_bytes(void* output, size_t size);
+/* Parses a whole-second override; anything malformed yields `fallback`. */
+unsigned bounded_seconds(const char* value, unsigned fallback);
+/* CUINTERPOSE_CONTROL_TIMEOUT_ENV or the default, read once. The prefix is
+ * deliberate: this is cuinterpose policy (one environment variable), shared
+ * from here because the shim and the coordinator both read it. */
+unsigned cuinterpose_control_timeout_seconds(void);
+
+#endif

--- a/agent/cmd/cuinterpose/util/time.c
+++ b/agent/cmd/cuinterpose/util/time.c
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "time.h"
+
+double
+elapsed_milliseconds(const struct timespec* start, const struct timespec* end)
+{
+  return (double)(end->tv_sec - start->tv_sec) * 1e3 +
+         (double)(end->tv_nsec - start->tv_nsec) / 1e6;
+}
+
+double
+elapsed_since_milliseconds(const struct timespec* start)
+{
+  struct timespec end;
+
+  clock_gettime(CLOCK_MONOTONIC, &end);
+  return elapsed_milliseconds(start, &end);
+}

--- a/agent/cmd/cuinterpose/util/time.h
+++ b/agent/cmd/cuinterpose/util/time.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_UTIL_TIME_H
+#define CUINTERPOSE_UTIL_TIME_H
+
+#include <time.h>
+
+double elapsed_milliseconds(const struct timespec* start, const struct timespec* end);
+double elapsed_since_milliseconds(const struct timespec* start);
+
+#endif


### PR DESCRIPTION
## Summary

This is the first layer of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293): #212 → #213 → #222 → #223 → #215 → #216 → #217 → #292 → #218 → #219 → #220. Closed PR #214 is intentionally not part of the active stack.

Cuinterpose lets Snapshot checkpoint and restore same-node CUDA memory shared between processes, including CUDA multicast objects. This PR establishes only the build, packaging, and shared wire contract. The shim and coordinator are placeholders at this layer.

`agent/cmd/cuinterpose/Makefile` builds `libcuinterpose.so` without linking CUDA, builds a static `cuinterpose-coordinator`, enforces hidden visibility and the glibc 2.34 ceiling, and discovers the fake-driver test suites added by later layers. The CUDA helper image installs CUDA 13.1 headers and packages both binaries under `/snapshot-binaries/snapshot-cuda` for restore.

`protocol.h` defines the fixed header and state-record layouts, participant and allocation identity, diagnostics, and the final operation vocabulary:

```text
HANDSHAKE → INSPECT
capture: PREPARE_MULTICAST → SAVE_ALLOCATIONS → PREPARE_UNICAST
restore: LOAD_ALLOCATIONS → RESTORE_UNICAST → RESTORE_MULTICAST_*
```

Allocation content is represented generically by `ALLOCATION_CONTENT` and `CONTENT_ONLY`; host carriers are an implementation behind the save/load operations in #292 and #218. The protocol also reports live raw imports and unsupported exportable CUDA resource creations so #216 can refuse checkpoint before destructive work.

The bounded Unix-socket helpers support fixed messages, optional records, and one `SCM_RIGHTS` descriptor. They suppress `SIGPIPE`, reject malformed ancillary data, and close received descriptors on every error path. Generic arrays, cleanup, identity, I/O, parsing/randomness, tables/ranges, and timing are centralized under `agent/cmd/cuinterpose/util/`; feature modules keep domain-specific logic.

## Stack boundary

Based on `main`. The next PR, #213, delivers `cuda-checkpoint` and the shim into workload containers. This layer does not inject the shim, discover participants, intercept CUDA, or execute lifecycle operations.

## Validation

On the final stack, `make test` passes in all three Go modules. The pinned CUDA 13.1 builder compiles the production shared shim and static coordinator with `-Werror`, then passes 9 protocol, 9 table/cache, 6 utility, 14 coordinator, 12 forwarding, 4 lifecycle, 6 multicast, and 13 tracking tests with ASan/UBSan where configured.

The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its physical-GPU suite passed all 3 tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.



