### PR TITLE
feat: deliver CUDA tools and launch multi-GPU sources

### DIFF
--- a/agent/cmd/ns-bind-mount/main.c
+++ b/agent/cmd/ns-bind-mount/main.c
@@ -2,15 +2,17 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
- * ns-bind-mount installs and removes the two mounts used by restore:
+ * ns-bind-mount installs and removes the fixed mounts used by restore:
  *
  *   mount-bundle-fd <namespace-fd>
+ *   mount-snapshot-cuda-fd <namespace-fd>
  *   mount-checkpoint-fd <namespace-fd> <checkpoint-path>
  *   unmount-bundle-fd <namespace-fd> [created]
+ *   unmount-snapshot-cuda-fd <namespace-fd> [created]
  *   unmount-checkpoint-fd <namespace-fd> [created]
  *
  * The caller pins the target mount namespace and passes its descriptor through
- * ExtraFiles. Bundle and checkpoint policy is deliberately fixed here: callers
+ * ExtraFiles. Bundle, snapshot-cuda, and checkpoint policy is deliberately fixed here: callers
  * cannot select arbitrary host sources, container destinations, or attributes.
  */
 
@@ -58,6 +60,14 @@ struct mount_attr {
 
 #define BUNDLE_SOURCE "/snapshot-binaries"
 #define BUNDLE_DESTINATION "/tmp/snapshot-binaries"
+/*
+ * snapshot-cuda: cuda-checkpoint (the --launch-job wrapper) and the cuinterpose
+ * shim, as delivered to the source workload. The destination must equal
+ * podcontract.CUDAToolsMountPath, because CRIU re-opens the file-backed mappings
+ * of both by that path.
+ */
+#define SNAPSHOT_CUDA_SOURCE "/snapshot-binaries/snapshot-cuda"
+#define SNAPSHOT_CUDA_DESTINATION "/tmp/snapshot-cuda"
 #define CHECKPOINT_ROOT "/checkpoints"
 #define CHECKPOINT_DESTINATION "/tmp/checkpoint"
 #define PAGEBROKER_RESTORE_ROOT "/pagebroker/staging/restore"
@@ -235,6 +245,23 @@ mount_bundle(int argc, char* argv[])
 }
 
 static int
+mount_snapshot_cuda(int argc, char* argv[])
+{
+  if (argc != 3) {
+    fprintf(stderr, "usage: ns-bind-mount mount-snapshot-cuda-fd <namespace-fd>\n");
+    return 1;
+  }
+  int ns_fd = parse_fd(argv[2]);
+  if (ns_fd < 0)
+    return 1;
+  return install_mount(
+      ns_fd,
+      SNAPSHOT_CUDA_SOURCE,
+      SNAPSHOT_CUDA_DESTINATION,
+      MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV);
+}
+
+static int
 mount_checkpoint(int argc, char* argv[])
 {
   if (argc != 4) {
@@ -298,6 +325,8 @@ main(int argc, char* argv[])
   }
   if (strcmp(argv[1], "mount-bundle-fd") == 0)
     return mount_bundle(argc, argv);
+  if (strcmp(argv[1], "mount-snapshot-cuda-fd") == 0)
+    return mount_snapshot_cuda(argc, argv);
   if (strcmp(argv[1], "mount-checkpoint-fd") == 0)
     return mount_checkpoint(argc, argv);
   if (strcmp(argv[1], "mount-pagebroker-fd") == 0)
@@ -308,6 +337,12 @@ main(int argc, char* argv[])
         argv,
         BUNDLE_DESTINATION,
         "usage: ns-bind-mount unmount-bundle-fd <namespace-fd> [created]");
+  if (strcmp(argv[1], "unmount-snapshot-cuda-fd") == 0)
+    return unmount_role(
+        argc,
+        argv,
+        SNAPSHOT_CUDA_DESTINATION,
+        "usage: ns-bind-mount unmount-snapshot-cuda-fd <namespace-fd> [created]");
   if (strcmp(argv[1], "unmount-checkpoint-fd") == 0)
     return unmount_role(
         argc,

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -91,6 +91,10 @@ func (noopInjector) MountArtifact(_ context.Context, _ nsmount.MountPoint, _ str
 	return noopMountPoint{}, nil
 }
 
+func (noopInjector) MountCUDATools(context.Context, nsmount.MountPoint) (nsmount.MountPoint, error) {
+	return nil, nil
+}
+
 func (noopInjector) MountPageBroker(_ context.Context, _ nsmount.MountPoint, _ string) (nsmount.MountPoint, error) {
 	return noopMountPoint{}, nil
 }

--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	snapshotruntime "github.com/ai-dynamo/snapshot/agent/internal/runtime"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -595,6 +596,7 @@ func (w *NodeController) executorCheckpoint(ctx context.Context, params Checkpoi
 		PodIP:               params.Pod.Status.PodIP,
 		Clientset:           w.clientset,
 		PageBrokerRequested: params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
+		CUDAToolsDelivered:  podcontract.CUDAToolsDelivered(&params.Pod.Spec, params.ContainerName),
 	}
 	if err := executor.Checkpoint(ctx, w.runtime, log, req, w.config); err != nil {
 		if executor.CheckpointNeedsSourceKill(err) {

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -55,6 +55,10 @@ type CheckpointRequest struct {
 	PodIP               string
 	Clientset           kubernetes.Interface
 	PageBrokerRequested bool
+	// CUDAToolsDelivered is true when the source container mounts Snapshot's
+	// CUDA tools (podcontract.CUDAToolsDelivered); recorded in the manifest so
+	// restore mounts them at the same path.
+	CUDAToolsDelivered bool
 }
 
 type checkpointPhaseTimings struct {
@@ -300,6 +304,7 @@ func configureCheckpoint(
 	if len(state.CUDANSPIDs) > 0 {
 		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs)
 	}
+	m.CUDATools.Delivered = req.CUDAToolsDelivered
 
 	if err := types.WriteManifest(checkpointDir, m); err != nil {
 		return nil, nil, fmt.Errorf("failed to write checkpoint manifest: %w", err)

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -32,6 +32,7 @@ import (
 // artifact inside a placeholder container's mount namespace.
 type RestoreMounter interface {
 	MountBundle(ctx context.Context, pid int) (nsmount.MountPoint, error)
+	MountCUDATools(ctx context.Context, namespaceMount nsmount.MountPoint) (nsmount.MountPoint, error)
 	MountArtifact(ctx context.Context, namespaceMount nsmount.MountPoint, artifactPath string) (nsmount.MountPoint, error)
 	MountPageBroker(ctx context.Context, namespaceMount nsmount.MountPoint, stagingPath string) (nsmount.MountPoint, error)
 }
@@ -159,8 +160,8 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		point:  bundleMount,
 	})
 
-	containerCheckpointPath := nsmount.CheckpointDst
 	var pageBrokerStageDuration, pageBrokerMountDuration, pageBrokerCommitDuration time.Duration
+	stagedPath := ""
 	if brokered {
 		transactionID = uuid.NewString()
 		broker = pagebroker.Client{ControlSocketPath: req.PageBrokerControlSocketPath}
@@ -170,26 +171,17 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		if err != nil {
 			return 0, fmt.Errorf("stage PageBroker restore: %w", err)
 		}
-		mountStart := time.Now()
-		stagingMount, err := mounts.MountPageBroker(ctx, bundleMount, staged)
+		stagedPath = staged
+	}
+	mountStart := time.Now()
+	inputMounts, containerCheckpointPath, err := mountRestoreInputs(
+		ctx, mounts, manifest.CUDATools.Delivered, bundleMount, artifactPath, stagedPath)
+	activeMounts = append(activeMounts, inputMounts...)
+	if err != nil {
+		return 0, err
+	}
+	if brokered {
 		pageBrokerMountDuration = time.Since(mountStart)
-		if err != nil {
-			return 0, fmt.Errorf("mount PageBroker staging: %w", err)
-		}
-		activeMounts = append(activeMounts, restoreMount{
-			action: "unmount PageBroker staging from placeholder",
-			point:  stagingMount,
-		})
-		containerCheckpointPath = nsmount.PageBrokerDst
-	} else {
-		artifactMount, err := mounts.MountArtifact(ctx, bundleMount, artifactPath)
-		if err != nil {
-			return 0, fmt.Errorf("mount checkpoint artifact into placeholder: %w", err)
-		}
-		activeMounts = append(activeMounts, restoreMount{
-			action: "unmount checkpoint artifact from placeholder",
-			point:  artifactMount,
-		})
 	}
 
 	result, err := execNSRestore(ctx, log, req, snap, bundleMount, containerCheckpointPath)
@@ -448,4 +440,52 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	}
 
 	return &result, nil
+}
+
+// mountRestoreInputs installs, after the agent bundle, the mounts nsrestore
+// reads from inside the placeholder: the CUDA tools when the source had them
+// delivered (CRIU re-opens cuda-checkpoint, and the shim if it was preloaded,
+// by that path), then either the PageBroker staging directory (stagedPath !=
+// "") or the checkpoint artifact itself. Order matters: the brokered path
+// unmounts the *last* returned mount early, so the staging mount must come
+// last. Mounts that succeeded before an error are returned so the caller can
+// unmount them.
+func mountRestoreInputs(
+	ctx context.Context,
+	mounts RestoreMounter,
+	cudaTools bool,
+	bundleMount nsmount.MountPoint,
+	artifactPath string,
+	stagedPath string,
+) (mounted []restoreMount, containerCheckpointPath string, err error) {
+	if cudaTools {
+		toolsMount, err := mounts.MountCUDATools(ctx, bundleMount)
+		if err != nil {
+			return mounted, "", fmt.Errorf("mount CUDA tools into placeholder: %w", err)
+		}
+		mounted = append(mounted, restoreMount{
+			action: "unmount CUDA tools from placeholder",
+			point:  toolsMount,
+		})
+	}
+	if stagedPath != "" {
+		stagingMount, err := mounts.MountPageBroker(ctx, bundleMount, stagedPath)
+		if err != nil {
+			return mounted, "", fmt.Errorf("mount PageBroker staging: %w", err)
+		}
+		mounted = append(mounted, restoreMount{
+			action: "unmount PageBroker staging from placeholder",
+			point:  stagingMount,
+		})
+		return mounted, nsmount.PageBrokerDst, nil
+	}
+	artifactMount, err := mounts.MountArtifact(ctx, bundleMount, artifactPath)
+	if err != nil {
+		return mounted, "", fmt.Errorf("mount checkpoint artifact into placeholder: %w", err)
+	}
+	mounted = append(mounted, restoreMount{
+		action: "unmount checkpoint artifact from placeholder",
+		point:  artifactMount,
+	})
+	return mounted, nsmount.CheckpointDst, nil
 }

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -193,3 +193,82 @@ func TestRemainingDuration(t *testing.T) {
 		t.Fatal("remainingDuration should not go negative")
 	}
 }
+
+// recordingMounter records the order of role mounts for mountRestoreInputs.
+type recordingMounter struct {
+	calls   []string
+	failOn  string
+	failErr error
+}
+
+func (m *recordingMounter) record(role string) (nsmount.MountPoint, error) {
+	m.calls = append(m.calls, role)
+	if role == m.failOn {
+		return nil, m.failErr
+	}
+	return testMountPoint{}, nil
+}
+
+func (m *recordingMounter) MountBundle(context.Context, int) (nsmount.MountPoint, error) {
+	return m.record("bundle")
+}
+
+func (m *recordingMounter) MountCUDATools(context.Context, nsmount.MountPoint) (nsmount.MountPoint, error) {
+	return m.record("cudatools")
+}
+
+func (m *recordingMounter) MountArtifact(context.Context, nsmount.MountPoint, string) (nsmount.MountPoint, error) {
+	return m.record("artifact")
+}
+
+func (m *recordingMounter) MountPageBroker(context.Context, nsmount.MountPoint, string) (nsmount.MountPoint, error) {
+	return m.record("pagebroker")
+}
+
+func TestMountRestoreInputsOrdersCUDAToolsBeforeStaging(t *testing.T) {
+	cases := map[string]struct {
+		tools     bool
+		staged    string
+		wantCalls []string
+		wantPath  string
+	}{
+		"plain artifact":      {wantCalls: []string{"artifact"}, wantPath: nsmount.CheckpointDst},
+		"tools then artifact": {tools: true, wantCalls: []string{"cudatools", "artifact"}, wantPath: nsmount.CheckpointDst},
+		"brokered":            {staged: "/pagebroker/staging/restore/tx", wantCalls: []string{"pagebroker"}, wantPath: nsmount.PageBrokerDst},
+		"tools then brokered": {tools: true, staged: "/pagebroker/staging/restore/tx", wantCalls: []string{"cudatools", "pagebroker"}, wantPath: nsmount.PageBrokerDst},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := &recordingMounter{}
+			mounted, path, err := mountRestoreInputs(context.Background(), m, tc.tools, testMountPoint{}, "/checkpoints/x", tc.staged)
+			if err != nil {
+				t.Fatalf("mountRestoreInputs: %v", err)
+			}
+			if strings.Join(m.calls, ",") != strings.Join(tc.wantCalls, ",") {
+				t.Fatalf("mount order = %v, want %v", m.calls, tc.wantCalls)
+			}
+			if path != tc.wantPath {
+				t.Fatalf("checkpoint path = %q, want %q", path, tc.wantPath)
+			}
+			if len(mounted) != len(tc.wantCalls) {
+				t.Fatalf("mounted %d, want %d", len(mounted), len(tc.wantCalls))
+			}
+			// The brokered path unmounts the last active mount early; it must
+			// be the staging mount, never the tools mount.
+			if tc.staged != "" && mounted[len(mounted)-1].action != "unmount PageBroker staging from placeholder" {
+				t.Fatalf("last mount = %q, want the staging mount", mounted[len(mounted)-1].action)
+			}
+		})
+	}
+}
+
+func TestMountRestoreInputsReturnsEarlierMountsOnFailure(t *testing.T) {
+	m := &recordingMounter{failOn: "artifact", failErr: errors.New("boom")}
+	mounted, _, err := mountRestoreInputs(context.Background(), m, true, testMountPoint{}, "/checkpoints/x", "")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected the artifact mount error, got %v", err)
+	}
+	if len(mounted) != 1 || mounted[0].action != "unmount CUDA tools from placeholder" {
+		t.Fatalf("earlier mounts must be returned for cleanup, got %+v", mounted)
+	}
+}

--- a/agent/internal/nsmount/injector.go
+++ b/agent/internal/nsmount/injector.go
@@ -74,6 +74,21 @@ func (nsm *NSMounter) MountBundle(ctx context.Context, pid int) (MountPoint, err
 
 // MountArtifact exposes one validated checkpoint artifact read-only and
 // non-executable in the namespace pinned by namespaceMount.
+// MountCUDATools exposes cuda-checkpoint and the cuinterpose shim at the path
+// the source workload used (podcontract.CUDAToolsMountPath). Both the source
+// and destination are fixed inside the ns-bind-mount helper.
+func (nsm *NSMounter) MountCUDATools(ctx context.Context, namespaceMount MountPoint) (MountPoint, error) {
+	if namespaceMount == nil || namespaceMount.NsFd() == nil {
+		return nil, fmt.Errorf("mount CUDA tools: pinned mount namespace is required")
+	}
+	nsm.log.Info("mounting CUDA tools into placeholder namespace")
+	ref, err := nsm.mounter.MountCUDATools(ctx, namespaceMount.NsFd())
+	if err != nil {
+		return nil, err
+	}
+	return &mountPoint{mount: ref}, nil
+}
+
 func (nsm *NSMounter) MountArtifact(ctx context.Context, namespaceMount MountPoint, src string) (MountPoint, error) {
 	if err := validateWithin(CheckpointSrc, src); err != nil {
 		return nil, err

--- a/agent/internal/nsmount/injector_test.go
+++ b/agent/internal/nsmount/injector_test.go
@@ -51,6 +51,15 @@ func (m *mockMounter) MountBundle(_ context.Context, pid int) (mountRef, error) 
 	return m.mount("bundle", pid, "")
 }
 
+func (m *mockMounter) MountCUDATools(_ context.Context, nsFd *os.File) (mountRef, error) {
+	i := len(m.calls)
+	m.calls = append(m.calls, mountCall{role: "cudatools", nsFd: nsFd})
+	if i < len(m.results) && m.results[i] != nil {
+		return nil, m.results[i]
+	}
+	return &fakeMountRef{dst: "cudatools", unmountLog: &m.unmountLog}, nil
+}
+
 func (m *mockMounter) MountCheckpoint(_ context.Context, nsFd *os.File, src string) (mountRef, error) {
 	i := len(m.calls)
 	m.calls = append(m.calls, mountCall{role: "checkpoint", nsFd: nsFd, src: src})
@@ -96,10 +105,14 @@ func TestRoleMountsUseFixedPathsAndPolicies(t *testing.T) {
 	if _, err := nsm.MountArtifact(context.Background(), bundle, "/checkpoints/artifacts/content-uid/containers/main"); err != nil {
 		t.Fatalf("MountArtifact: %v", err)
 	}
+	if _, err := nsm.MountCUDATools(context.Background(), bundle); err != nil {
+		t.Fatalf("MountCUDATools: %v", err)
+	}
 
 	want := []mountCall{
 		{role: "bundle", pid: testPID},
 		{role: "checkpoint", src: "/checkpoints/artifacts/content-uid/containers/main"},
+		{role: "cudatools"},
 	}
 	if len(m.calls) != len(want) {
 		t.Fatalf("got %d calls, want %d", len(m.calls), len(want))
@@ -111,6 +124,9 @@ func TestRoleMountsUseFixedPathsAndPolicies(t *testing.T) {
 	}
 	if m.calls[1].nsFd != bundle.NsFd() {
 		t.Fatal("checkpoint mount did not reuse the bundle's pinned namespace fd")
+	}
+	if m.calls[2].nsFd != bundle.NsFd() {
+		t.Fatal("CUDA tools mount did not reuse the bundle's pinned namespace fd")
 	}
 }
 

--- a/agent/internal/nsmount/mount.go
+++ b/agent/internal/nsmount/mount.go
@@ -32,6 +32,7 @@ type mountRef interface {
 
 type mounter interface {
 	MountBundle(ctx context.Context, pid int) (mountRef, error)
+	MountCUDATools(ctx context.Context, nsFd *os.File) (mountRef, error)
 	MountCheckpoint(ctx context.Context, nsFd *os.File, checkpointPath string) (mountRef, error)
 	MountPageBroker(ctx context.Context, nsFd *os.File, stagingPath string) (mountRef, error)
 }
@@ -89,6 +90,23 @@ func (m *execMounter) MountBundle(ctx context.Context, pid int) (mountRef, error
 }
 
 func (m *execMounter) MountCheckpoint(ctx context.Context, nsFd *os.File, checkpointPath string) (mountRef, error) {
+	return m.mountInNamespace(ctx, nsFd, "mount-checkpoint-fd", "unmount-checkpoint-fd", checkpointPath)
+}
+
+// MountCUDATools exposes the agent's copy of cuda-checkpoint and the
+// cuinterpose shim at podcontract.CUDAToolsMountPath; source and destination
+// are fixed inside the helper.
+func (m *execMounter) MountCUDATools(ctx context.Context, nsFd *os.File) (mountRef, error) {
+	return m.mountInNamespace(ctx, nsFd, "mount-snapshot-cuda-fd", "unmount-snapshot-cuda-fd")
+}
+
+func (m *execMounter) mountInNamespace(
+	ctx context.Context,
+	nsFd *os.File,
+	mountCmd string,
+	unmountCmd string,
+	args ...string,
+) (mountRef, error) {
 	if nsFd == nil {
 		return nil, fmt.Errorf("mount namespace fd is required")
 	}
@@ -97,7 +115,7 @@ func (m *execMounter) MountCheckpoint(ctx context.Context, nsFd *os.File, checkp
 		return nil, fmt.Errorf("duplicate mount namespace fd: %w", err)
 	}
 	unix.CloseOnExec(dupFd)
-	return m.mount(ctx, os.NewFile(uintptr(dupFd), nsFd.Name()), "mount-checkpoint-fd", "unmount-checkpoint-fd", checkpointPath)
+	return m.mount(ctx, os.NewFile(uintptr(dupFd), nsFd.Name()), mountCmd, unmountCmd, args...)
 }
 
 func (m *execMounter) MountPageBroker(ctx context.Context, nsFd *os.File, stagingPath string) (mountRef, error) {

--- a/agent/internal/nsmount/mount_test.go
+++ b/agent/internal/nsmount/mount_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 )
 
 func writeFakeBinary(t *testing.T, script string) string {
@@ -191,10 +193,29 @@ func TestCHelperRejectsUnsafeSourcesBeforeMountSyscalls(t *testing.T) {
 	for _, args := range [][]string{
 		{"mount-fd", "3", "/etc", "/tmp/checkpoint"},
 		{"mount-bundle-fd", "3", "/etc"},
+		{"mount-snapshot-cuda-fd", "3", "/etc"},
 		{"unmount-checkpoint-fd", "3", "unexpected"},
 	} {
 		if output, err := exec.Command(binary, args...).CombinedOutput(); err == nil {
 			t.Fatalf("helper accepted %v: %s", args, output)
+		}
+	}
+}
+
+// The C helper hard-codes the CUDA tools destination. It must equal the path
+// podcontract bakes into the cuda-checkpoint command (and LD_PRELOAD) of the
+// source workload, because CRIU re-opens those file-backed mappings by path.
+func TestCHelperCUDAToolsDestinationMatchesPodContract(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", "cmd", "ns-bind-mount", "main.c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`#define SNAPSHOT_CUDA_DESTINATION "` + podcontract.CUDAToolsMountPath + `"`,
+		`#define SNAPSHOT_CUDA_SOURCE "` + SnapshotBinSrc + `/snapshot-cuda"`,
+	} {
+		if !strings.Contains(string(source), want) {
+			t.Errorf("ns-bind-mount/main.c lacks %q", want)
 		}
 	}
 }

--- a/agent/internal/types/manifest.go
+++ b/agent/internal/types/manifest.go
@@ -26,6 +26,18 @@ type CheckpointManifest struct {
 	K8s      SourcePodManifest `yaml:"k8s"`
 	Overlay  OverlayManifest   `yaml:"overlay"`
 	CUDA     CUDAManifest      `yaml:"cudaRestore,omitempty"`
+	// CUDATools records whether the source ran with Snapshot's CUDA tools
+	// (cuda-checkpoint, the cuinterpose shim) delivered into the container.
+	CUDATools CUDAToolsManifest `yaml:"cudaTools,omitempty"`
+}
+
+// CUDAToolsManifest is the restore side's source of truth for the tools mount.
+type CUDAToolsManifest struct {
+	// Delivered is true when the source container mounted the tools volume at
+	// podcontract.CUDAToolsMountPath. Restore then bind-mounts the agent's copy
+	// at the same path before CRIU runs, because the checkpointed processes
+	// have cuda-checkpoint (and possibly the shim) mapped by that path.
+	Delivered bool `yaml:"delivered"`
 }
 
 // ArtifactManifest pins an on-disk checkpoint to the Kubernetes content object

--- a/agent/internal/types/manifest_test.go
+++ b/agent/internal/types/manifest_test.go
@@ -177,3 +177,27 @@ func TestManifestRequiresContainerName(t *testing.T) {
 		t.Fatalf("expected missing container name error, got %v", err)
 	}
 }
+
+func TestManifestRoundTripsCUDATools(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCheckpointManifest("content-uid", "main", CRIUDumpManifest{}, SourcePodManifest{}, OverlayManifest{})
+	m.CUDATools.Delivered = true
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	read, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !read.CUDATools.Delivered {
+		t.Fatalf("cudaTools = %+v, want delivered", read.CUDATools)
+	}
+	// Older manifests without the section read as not delivered.
+	m.CUDATools.Delivered = false
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if read, err = ReadManifest(dir); err != nil || read.CUDATools.Delivered {
+		t.Fatalf("cudaTools = %+v, err = %v, want zero", read.CUDATools, err)
+	}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.27.1
 require (
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 )
 
 require (
@@ -21,7 +22,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/api/podcontract/cudatools.go
+++ b/api/podcontract/cudatools.go
@@ -1,0 +1,502 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// Snapshot delivers two CUDA tools from its own agent image into every source
+// checkpoint target: cuda-checkpoint and the cuinterpose shim. An init
+// container copies both into a per-Pod emptyDir at a fixed path; the agent
+// bind-mounts the same two files at the same path when restoring because CRIU
+// restores file-backed mappings by path. Delivery is unconditional.
+// cuda-checkpoint wraps only targets that may use more than one GPU, while a
+// Pod opts into the otherwise inert cuinterpose library separately (see
+// cuinterpose.go).
+const (
+	// CUDAToolsVolumeName is the emptyDir that carries the tools into the
+	// workload containers.
+	CUDAToolsVolumeName = "snapshot-cuda"
+	// CUDAToolsInitContainerName copies the tools out of the agent image.
+	CUDAToolsInitContainerName = "snapshot-cuda-install"
+	// CUDAToolsMountPath is the fixed path the tools are visible at inside
+	// every checkpoint target, at capture and at restore. The agent's
+	// ns-bind-mount helper hard-codes the same destination.
+	CUDAToolsMountPath = "/tmp/snapshot-cuda"
+	// CUDACheckpointPath is the cuda-checkpoint that wraps the workload
+	// command with --launch-job.
+	CUDACheckpointPath = CUDAToolsMountPath + "/cuda-checkpoint"
+	// CuinterposeLibraryPath is the shim's path, used as the LD_PRELOAD entry
+	// by Pods that opt into cuinterpose. It is copied for every delivery and
+	// is inert until preloaded.
+	CuinterposeLibraryPath = CUDAToolsMountPath + "/libcuinterpose.so"
+
+	// GPUResourceName is the device-plugin GPU resource.
+	GPUResourceName corev1.ResourceName = "nvidia.com/gpu"
+
+	cudaToolsImageCUDACheckpoint = "/usr/local/sbin/cuda-checkpoint"
+	cudaToolsImageLibrary        = "/usr/local/lib/snapshot/libcuinterpose.so"
+	cudaToolsInstallMountPath    = "/snapshot-cuda"
+)
+
+// persistCUDAJobFileScript copies cuda-checkpoint's transient launch-job file
+// (handed to the workload as an inherited procfs fd path) into the per-Pod
+// control volume, so the agent can stage it into the checkpoint artifact, then
+// starts the original command.
+const persistCUDAJobFileScript = `set -eu
+job_file="$1"
+shift
+if [ -z "${CUDA_CHECKPOINT_JOB_FILE:-}" ]; then
+    echo "CUDA_CHECKPOINT_JOB_FILE is missing; cuda-checkpoint --launch-job requires NVIDIA driver 610 or newer" >&2
+    exit 1
+fi
+umask 077
+cat "$CUDA_CHECKPOINT_JOB_FILE" > "$job_file"
+export CUDA_CHECKPOINT_JOB_FILE="$job_file"
+exec "$@"`
+
+// imageReferencePattern is the Docker/OCI reference grammar: an optional
+// registry (host[:port]), path components, an optional tag, and an optional
+// sha256 digest. It rejects whitespace, uppercase path components, and other
+// strings the kubelet would fail to pull.
+var imageReferencePattern = regexp.MustCompile(
+	`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*(?::[0-9]+)?/)?` +
+		`[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*` +
+		`(?::[\w][\w.-]{0,127})?` +
+		`(?:@sha256:[a-f0-9]{64})?$`,
+)
+
+// CUDAToolsDelivery says where the tools come from. The Snapshot installation
+// configures it once (Helm chart -> operator flags); workload users never
+// choose an image.
+type CUDAToolsDelivery struct {
+	// AgentImage is the Snapshot agent image reference.
+	AgentImage string
+	// PullPolicy for the install init container. Empty selects a safe default:
+	// Always for tag references, IfNotPresent for digest references.
+	PullPolicy corev1.PullPolicy
+	// ImagePullSecrets are secret names, expected to exist in the workload's
+	// namespace, added to the Pod so the init container can pull AgentImage
+	// from a private registry.
+	ImagePullSecrets []string
+}
+
+// ClaimDevices resolves one of the Pod's resourceClaims to the number of
+// devices it asks for. known is false when the count cannot be determined
+// (the claim or template is gone, or it allocates "All" devices); callers then
+// assume more than one. A nil ClaimDevices treats every claim as unknown.
+type ClaimDevices func(claim corev1.PodResourceClaim) (devices int, known bool, err error)
+
+// ContainerGPUs counts the GPUs container may use: its nvidia.com/gpu limit
+// (or request when no limit is set) plus every DRA claim it references.
+// undetermined is true when some claim's size is unknown.
+func ContainerGPUs(
+	spec *corev1.PodSpec,
+	container *corev1.Container,
+	claims ClaimDevices,
+) (gpus int, undetermined bool, err error) {
+	quantity, found := container.Resources.Limits[GPUResourceName]
+	if !found {
+		quantity, found = container.Resources.Requests[GPUResourceName]
+	}
+	if found {
+		gpus = int(quantity.Value())
+	}
+	for _, ref := range container.Resources.Claims {
+		index := slices.IndexFunc(spec.ResourceClaims, func(c corev1.PodResourceClaim) bool { return c.Name == ref.Name })
+		if index < 0 {
+			return 0, false, fmt.Errorf(
+				"container %q references resource claim %q, which the pod does not declare", container.Name, ref.Name)
+		}
+		if claims == nil {
+			undetermined = true
+			continue
+		}
+		devices, known, err := claims(spec.ResourceClaims[index])
+		if err != nil {
+			return 0, false, fmt.Errorf("resource claim %q of container %q: %w", ref.Name, container.Name, err)
+		}
+		if !known {
+			undetermined = true
+			continue
+		}
+		gpus += devices
+	}
+	return gpus, undetermined, nil
+}
+
+// NeedsCUDALaunchJob reports whether container must be launched under
+// cuda-checkpoint --launch-job: it may use more than one GPU. The agent
+// refuses to checkpoint a multi-GPU process tree without the job file, so the
+// rule is applied where the Pod is shaped rather than discovered at capture.
+func NeedsCUDALaunchJob(spec *corev1.PodSpec, container *corev1.Container, claims ClaimDevices) (bool, error) {
+	gpus, undetermined, err := ContainerGPUs(spec, container, claims)
+	if err != nil {
+		return false, err
+	}
+	return gpus > 1 || undetermined, nil
+}
+
+// ShapeCUDATools installs one emptyDir and init container, mounts both tools
+// read-only in every target, and wraps only targets that may use more than one
+// GPU with cuda-checkpoint --launch-job. Reapplying it is a no-op. On error the
+// template is left unchanged. It returns the names of the wrapped targets.
+func ShapeCUDATools(
+	podTemplate *corev1.PodTemplateSpec,
+	targetContainers []string,
+	delivery CUDAToolsDelivery,
+	claims ClaimDevices,
+) ([]string, error) {
+	if podTemplate == nil {
+		return nil, fmt.Errorf("cuda-checkpoint launch-job requires a pod template")
+	}
+	if len(targetContainers) == 0 {
+		return nil, fmt.Errorf("CUDA tools require at least one target container")
+	}
+	shaped := podTemplate.DeepCopy()
+	targets := uniqueNames(targetContainers)
+	var wrapped []string
+	for _, name := range targets {
+		container := findContainer(&shaped.Spec, name)
+		if container == nil {
+			return nil, fmt.Errorf("target container %q does not exist", name)
+		}
+		needed, err := NeedsCUDALaunchJob(&shaped.Spec, container, claims)
+		if err != nil {
+			return nil, err
+		}
+		if !needed {
+			continue
+		}
+		wrapped = append(wrapped, name)
+	}
+	if err := ensureCUDATools(&shaped.Spec, delivery); err != nil {
+		return nil, err
+	}
+	for _, name := range targets {
+		container := findContainer(&shaped.Spec, name)
+		if err := ensureCUDAToolsMount(container); err != nil {
+			return nil, err
+		}
+		if slices.Contains(wrapped, name) {
+			if err := EnsureCUDACheckpointLaunchJob(container, CUDACheckpointPath); err != nil {
+				return nil, err
+			}
+		}
+	}
+	*podTemplate = *shaped
+	return wrapped, nil
+}
+
+// VerifyCUDALaunchJob reports whether spec carries the complete launch-job
+// contract for every named container: the volume, the install init container,
+// and per container the mount and the cuda-checkpoint wrapper. The operator
+// uses it to refuse adopting a Job that was created without the contract.
+func VerifyCUDALaunchJob(spec *corev1.PodSpec, containers []string) error {
+	if err := VerifyCUDATools(spec, containers); err != nil {
+		return err
+	}
+	for _, name := range containers {
+		container := findContainer(spec, name)
+		if len(container.Command) != 1 || container.Command[0] != CUDACheckpointPath ||
+			!isCUDACheckpointLaunchJob(container.Args) {
+			return fmt.Errorf("container %q is not launched through %s --launch-job", name, CUDACheckpointPath)
+		}
+	}
+	return nil
+}
+
+// VerifyCUDATools reports whether spec carries the shared volume, install
+// container, and fixed read-only mount for every named target.
+func VerifyCUDATools(spec *corev1.PodSpec, containers []string) error {
+	if err := verifyCUDATools(spec); err != nil {
+		return err
+	}
+	for _, name := range containers {
+		container := findContainer(spec, name)
+		if container == nil {
+			return fmt.Errorf("target container %q does not exist", name)
+		}
+		if !CUDAToolsMounted(container) {
+			return fmt.Errorf("container %q does not mount %s at %s", name, CUDAToolsVolumeName, CUDAToolsMountPath)
+		}
+	}
+	return nil
+}
+
+// CUDAToolsDelivered reports whether the named container of a live Pod has
+// the tools volume mounted at its fixed path, which is what the restore side
+// must reproduce before CRIU runs.
+func CUDAToolsDelivered(spec *corev1.PodSpec, containerName string) bool {
+	if spec == nil || verifyCUDATools(spec) != nil {
+		return false
+	}
+	container := findContainer(spec, containerName)
+	return container != nil && CUDAToolsMounted(container)
+}
+
+// CUDAToolsMounted reports whether container mounts the tools volume at its
+// fixed path.
+func CUDAToolsMounted(container *corev1.Container) bool {
+	return slices.ContainsFunc(container.VolumeMounts, func(m corev1.VolumeMount) bool {
+		return m.Name == CUDAToolsVolumeName && m.MountPath == CUDAToolsMountPath
+	})
+}
+
+func verifyCUDATools(spec *corev1.PodSpec) error {
+	if spec == nil {
+		return fmt.Errorf("cuda tools require a pod spec")
+	}
+	if !slices.ContainsFunc(spec.Volumes, func(v corev1.Volume) bool {
+		return v.Name == CUDAToolsVolumeName && isEmptyDirVolumeSource(v.VolumeSource)
+	}) {
+		return fmt.Errorf("pod lacks the %s emptyDir volume", CUDAToolsVolumeName)
+	}
+	if !slices.ContainsFunc(spec.InitContainers, func(c corev1.Container) bool {
+		return c.Name == CUDAToolsInitContainerName
+	}) {
+		return fmt.Errorf("pod lacks the %s init container", CUDAToolsInitContainerName)
+	}
+	return nil
+}
+
+// ValidateImageReference rejects image references the kubelet cannot pull.
+func ValidateImageReference(image string) error {
+	if image == "" {
+		return fmt.Errorf("image reference is required")
+	}
+	if image != strings.TrimSpace(image) {
+		return fmt.Errorf("image reference %q must not contain surrounding whitespace", image)
+	}
+	if !imageReferencePattern.MatchString(image) {
+		return fmt.Errorf("image reference %q is not a valid registry/repository[:tag][@sha256:digest]", image)
+	}
+	return nil
+}
+
+func uniqueNames(names []string) []string {
+	unique := make([]string, 0, len(names))
+	for _, name := range names {
+		if !slices.Contains(unique, name) {
+			unique = append(unique, name)
+		}
+	}
+	return unique
+}
+
+// ensureCUDATools adds the volume, the init container, and the pull secrets
+// the delivery needs, checking that anything already present agrees.
+func ensureCUDATools(spec *corev1.PodSpec, delivery CUDAToolsDelivery) error {
+	if err := ValidateImageReference(delivery.AgentImage); err != nil {
+		return fmt.Errorf("snapshot agent image: %w", err)
+	}
+	if err := ensureCUDAToolsVolume(spec); err != nil {
+		return err
+	}
+	if err := ensureCUDAToolsInitContainer(spec, delivery); err != nil {
+		return err
+	}
+	ensureImagePullSecrets(spec, delivery.ImagePullSecrets)
+	return nil
+}
+
+func ensureCUDAToolsVolume(spec *corev1.PodSpec) error {
+	found := false
+	for i := range spec.Volumes {
+		volume := &spec.Volumes[i]
+		if volume.Name != CUDAToolsVolumeName {
+			continue
+		}
+		if found {
+			return fmt.Errorf("duplicate %s volume", CUDAToolsVolumeName)
+		}
+		found = true
+		if !isEmptyDirVolumeSource(volume.VolumeSource) {
+			return fmt.Errorf("volume %q must be an emptyDir", CUDAToolsVolumeName)
+		}
+	}
+	if !found {
+		spec.Volumes = append(spec.Volumes, corev1.Volume{
+			Name:         CUDAToolsVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
+	return nil
+}
+
+func ensureImagePullSecrets(spec *corev1.PodSpec, names []string) {
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if slices.ContainsFunc(spec.ImagePullSecrets, func(ref corev1.LocalObjectReference) bool {
+			return ref.Name == name
+		}) {
+			continue
+		}
+		spec.ImagePullSecrets = append(spec.ImagePullSecrets, corev1.LocalObjectReference{Name: name})
+	}
+}
+
+func expectedCUDAToolsInitContainer(delivery CUDAToolsDelivery) corev1.Container {
+	pullPolicy := delivery.PullPolicy
+	if pullPolicy == "" {
+		pullPolicy = corev1.PullAlways
+		if strings.Contains(delivery.AgentImage, "@sha256:") {
+			pullPolicy = corev1.PullIfNotPresent
+		}
+	}
+	return corev1.Container{
+		Name:            CUDAToolsInitContainerName,
+		Image:           delivery.AgentImage,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"/bin/cp"},
+		Args: []string{
+			"--",
+			cudaToolsImageCUDACheckpoint,
+			cudaToolsImageLibrary,
+			cudaToolsInstallMountPath + "/",
+		},
+		// The agent image runs as root and only copies two files into a
+		// world-writable emptyDir, so RunAsNonRoot is not set; everything else
+		// that a restricted namespace expects is.
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      CUDAToolsVolumeName,
+			MountPath: cudaToolsInstallMountPath,
+		}},
+	}
+}
+
+// initContainerMatches compares the fields the contract sets. Fields the API
+// server defaults (termination message path, image pull policy on re-read) are
+// deliberately not compared, so reshaping a live object does not report a
+// conflict.
+func initContainerMatches(actual, expected *corev1.Container) bool {
+	if actual.Name != expected.Name || actual.Image != expected.Image {
+		return false
+	}
+	if !slices.Equal(actual.Command, expected.Command) || !slices.Equal(actual.Args, expected.Args) {
+		return false
+	}
+	if len(actual.VolumeMounts) != len(expected.VolumeMounts) {
+		return false
+	}
+	for i := range expected.VolumeMounts {
+		if actual.VolumeMounts[i].Name != expected.VolumeMounts[i].Name ||
+			actual.VolumeMounts[i].MountPath != expected.VolumeMounts[i].MountPath {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureCUDAToolsInitContainer(spec *corev1.PodSpec, delivery CUDAToolsDelivery) error {
+	expected := expectedCUDAToolsInitContainer(delivery)
+	found := false
+	for i := range spec.InitContainers {
+		container := &spec.InitContainers[i]
+		if container.Name != CUDAToolsInitContainerName {
+			continue
+		}
+		if found {
+			return fmt.Errorf("duplicate %s init container", CUDAToolsInitContainerName)
+		}
+		found = true
+		if !initContainerMatches(container, &expected) {
+			return fmt.Errorf("init container %q conflicts with the snapshot-cuda contract", CUDAToolsInitContainerName)
+		}
+	}
+	if !found {
+		spec.InitContainers = append(spec.InitContainers, expected)
+	}
+	return nil
+}
+
+func ensureCUDAToolsMount(container *corev1.Container) error {
+	found := false
+	for i := range container.VolumeMounts {
+		mount := &container.VolumeMounts[i]
+		if mount.Name != CUDAToolsVolumeName && mount.MountPath != CUDAToolsMountPath {
+			continue
+		}
+		if found {
+			return fmt.Errorf("container %q has duplicate %s mounts", container.Name, CUDAToolsVolumeName)
+		}
+		found = true
+		if mount.Name != CUDAToolsVolumeName || mount.MountPath != CUDAToolsMountPath ||
+			!mount.ReadOnly || mount.SubPath != "" || mount.SubPathExpr != "" ||
+			mount.RecursiveReadOnly != nil ||
+			(mount.MountPropagation != nil && *mount.MountPropagation != corev1.MountPropagationNone) {
+			return fmt.Errorf("container %q has conflicting options on the %s mount", container.Name, CUDAToolsVolumeName)
+		}
+	}
+	if !found {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      CUDAToolsVolumeName,
+			MountPath: CUDAToolsMountPath,
+			ReadOnly:  true,
+		})
+	}
+	return nil
+}
+
+// EnsureCUDACheckpointLaunchJob launches container under
+// `binaryPath --launch-job` and persists the driver's transient job file in
+// the snapshot control volume. Reapplying the same wrapper is a no-op.
+func EnsureCUDACheckpointLaunchJob(container *corev1.Container, binaryPath string) error {
+	if container == nil {
+		return fmt.Errorf("cuda-checkpoint launch-job requires a container")
+	}
+	if binaryPath = strings.TrimSpace(binaryPath); binaryPath == "" {
+		return fmt.Errorf("cuda-checkpoint launch-job requires a binary path")
+	}
+	if len(container.Command) == 1 && container.Command[0] == binaryPath {
+		if isCUDACheckpointLaunchJob(container.Args) {
+			return nil
+		}
+		return fmt.Errorf("container %q command conflicts with the cuda-checkpoint launch-job contract", container.Name)
+	}
+	if len(container.Command) == 0 {
+		return fmt.Errorf("container %q requires container.command for cuda-checkpoint launch-job", container.Name)
+	}
+
+	original := make([]string, 0, len(container.Command)+len(container.Args))
+	original = append(original, container.Command...)
+	original = append(original, container.Args...)
+	container.Command = []string{binaryPath}
+	container.Args = []string{
+		"--launch-job",
+		"/bin/sh",
+		"-c",
+		persistCUDAJobFileScript,
+		"dynamo-cuda-checkpoint",
+		CUDAJobFilePath,
+	}
+	container.Args = append(container.Args, original...)
+	return nil
+}
+
+func isCUDACheckpointLaunchJob(args []string) bool {
+	return len(args) > 6 &&
+		args[0] == "--launch-job" &&
+		args[1] == "/bin/sh" &&
+		args[2] == "-c" &&
+		args[3] == persistCUDAJobFileScript &&
+		args[4] == "dynamo-cuda-checkpoint" &&
+		args[5] == CUDAJobFilePath
+}

--- a/api/podcontract/cudatools_test.go
+++ b/api/podcontract/cudatools_test.go
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testAgentImage = "registry.example/snapshot-agent@sha256:" +
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func testDelivery() CUDAToolsDelivery {
+	return CUDAToolsDelivery{AgentImage: testAgentImage}
+}
+
+func gpuContainer(name string, gpus int, command ...string) corev1.Container {
+	c := corev1.Container{Name: name, Command: command}
+	if gpus > 0 {
+		c.Resources.Limits = corev1.ResourceList{GPUResourceName: *resource.NewQuantity(int64(gpus), resource.DecimalSI)}
+	}
+	return c
+}
+
+func template(containers ...corev1.Container) *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}, Spec: corev1.PodSpec{Containers: containers}}
+}
+
+func TestContainerGPUs(t *testing.T) {
+	spec := &corev1.PodSpec{ResourceClaims: []corev1.PodResourceClaim{{Name: "gpus"}, {Name: "nics"}}}
+	claimed := corev1.Container{Name: "w", Resources: corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{GPUResourceName: resource.MustParse("2")},
+		Claims:   []corev1.ResourceClaim{{Name: "gpus"}, {Name: "nics"}},
+	}}
+	counter := func(claim corev1.PodResourceClaim) (int, bool, error) {
+		switch claim.Name {
+		case "gpus":
+			return 4, true, nil
+		case "nics":
+			return 0, false, nil
+		}
+		return 0, false, errors.New("unexpected claim")
+	}
+	gpus, undetermined, err := ContainerGPUs(spec, &claimed, counter)
+	if err != nil || gpus != 6 || !undetermined {
+		t.Fatalf("ContainerGPUs() = %d, %v, %v; want 6 (request + claim), undetermined", gpus, undetermined, err)
+	}
+	// Without a resolver every claim is unknown.
+	if _, undetermined, err := ContainerGPUs(spec, &claimed, nil); err != nil || !undetermined {
+		t.Fatalf("nil resolver: undetermined = %v, err = %v", undetermined, err)
+	}
+	// A limit wins over a request; no GPUs at all is zero.
+	limited := gpuContainer("l", 1)
+	limited.Resources.Requests = corev1.ResourceList{GPUResourceName: resource.MustParse("8")}
+	if gpus, _, _ := ContainerGPUs(spec, &limited, nil); gpus != 1 {
+		t.Fatalf("limit should win, got %d", gpus)
+	}
+	cpuOnly := corev1.Container{Name: "cpu"}
+	if gpus, undetermined, err := ContainerGPUs(spec, &cpuOnly, nil); gpus != 0 || undetermined || err != nil {
+		t.Fatalf("cpu-only container: %d %v %v", gpus, undetermined, err)
+	}
+	// A claim the pod does not declare is an error.
+	dangling := corev1.Container{Name: "d"}
+	dangling.Resources.Claims = []corev1.ResourceClaim{{Name: "missing"}}
+	if _, _, err := ContainerGPUs(spec, &dangling, nil); err == nil {
+		t.Fatal("undeclared claim was accepted")
+	}
+}
+
+func TestShapeCUDAToolsMountsAllTargetsAndWrapsOnlyMultiGPU(t *testing.T) {
+	tpl := template(
+		gpuContainer("tp", 2, "python3", "-m", "worker"),
+		gpuContainer("single", 1, "/usr/bin/worker"),
+		gpuContainer("helper", 0, "sleep", "infinity"),
+	)
+	tpl.Spec.Containers[0].Args = []string{"--rank", "0"}
+
+	// Shaping twice must be a no-op the second time.
+	var wrapped []string
+	for range 2 {
+		var err error
+		wrapped, err = ShapeCUDATools(tpl, []string{"tp", "single", "helper"}, testDelivery(), nil)
+		if err != nil {
+			t.Fatalf("ShapeCUDATools() failed: %v", err)
+		}
+	}
+	if !reflect.DeepEqual(wrapped, []string{"tp"}) {
+		t.Fatalf("wrapped = %v, want [tp]", wrapped)
+	}
+	if len(tpl.Spec.Volumes) != 1 || tpl.Spec.Volumes[0].Name != CUDAToolsVolumeName ||
+		tpl.Spec.Volumes[0].EmptyDir == nil {
+		t.Fatalf("volumes = %#v", tpl.Spec.Volumes)
+	}
+	wantInit := expectedCUDAToolsInitContainer(testDelivery())
+	if len(tpl.Spec.InitContainers) != 1 || !reflect.DeepEqual(tpl.Spec.InitContainers[0], wantInit) {
+		t.Fatalf("init containers = %#v, want %#v", tpl.Spec.InitContainers, wantInit)
+	}
+	if wantInit.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("digest reference should default to IfNotPresent, got %s", wantInit.ImagePullPolicy)
+	}
+	for _, name := range []string{"tp", "single", "helper"} {
+		c := findContainer(&tpl.Spec, name)
+		if !CUDAToolsMounted(c) || !c.VolumeMounts[0].ReadOnly {
+			t.Fatalf("%s mounts = %#v", name, c.VolumeMounts)
+		}
+	}
+	tp := findContainer(&tpl.Spec, "tp")
+	assertLaunchJob(t, tp, []string{"python3", "-m", "worker", "--rank", "0"})
+	if got := findContainer(&tpl.Spec, "single").Command; !reflect.DeepEqual(got, []string{"/usr/bin/worker"}) {
+		t.Fatalf("single-GPU command = %#v", got)
+	}
+	if got := findContainer(&tpl.Spec, "helper").Command; !reflect.DeepEqual(got, []string{"sleep", "infinity"}) {
+		t.Fatalf("helper command = %#v", got)
+	}
+	if err := VerifyCUDALaunchJob(&tpl.Spec, []string{"tp"}); err != nil {
+		t.Fatalf("VerifyCUDALaunchJob() on a shaped template failed: %v", err)
+	}
+	if err := VerifyCUDATools(&tpl.Spec, []string{"tp", "single", "helper"}); err != nil {
+		t.Fatalf("VerifyCUDATools() on a shaped template failed: %v", err)
+	}
+
+	// A template with no multi-GPU target still receives both tools, but its
+	// command is not rewritten.
+	plain := template(gpuContainer("single", 1, "/usr/bin/worker"))
+	wrapped, err := ShapeCUDATools(plain, []string{"single"}, testDelivery(), nil)
+	if err != nil || wrapped != nil {
+		t.Fatalf("single-GPU shape: wrapped=%v err=%v", wrapped, err)
+	}
+	if !CUDAToolsDelivered(&plain.Spec, "single") ||
+		!reflect.DeepEqual(plain.Spec.Containers[0].Command, []string{"/usr/bin/worker"}) {
+		t.Fatalf("single-GPU target lacks tools or was wrapped: %#v", plain.Spec)
+	}
+}
+
+func TestShapeCUDAToolsTreatsUnknownClaimsAsMultiGPU(t *testing.T) {
+	tpl := template(corev1.Container{
+		Name: "dra", Command: []string{"worker"},
+		Resources: corev1.ResourceRequirements{Claims: []corev1.ResourceClaim{{Name: "gpus"}}},
+	})
+	tpl.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "gpus"}}
+	one := func(corev1.PodResourceClaim) (int, bool, error) { return 1, true, nil }
+	wrapped, err := ShapeCUDATools(tpl.DeepCopy(), []string{"dra"}, testDelivery(), one)
+	if err != nil || wrapped != nil {
+		t.Fatalf("a one-device claim must not wrap: %v %v", wrapped, err)
+	}
+	unknown := func(corev1.PodResourceClaim) (int, bool, error) { return 0, false, nil }
+	wrapped, err = ShapeCUDATools(tpl.DeepCopy(), []string{"dra"}, testDelivery(), unknown)
+	if err != nil || !reflect.DeepEqual(wrapped, []string{"dra"}) {
+		t.Fatalf("an unknown claim must wrap: %v %v", wrapped, err)
+	}
+	failing := func(corev1.PodResourceClaim) (int, bool, error) { return 0, false, errors.New("api down") }
+	if _, err := ShapeCUDATools(tpl.DeepCopy(), []string{"dra"}, testDelivery(), failing); err == nil {
+		t.Fatal("resolver errors must propagate")
+	}
+}
+
+func TestShapeCUDAToolsDeliveryOptions(t *testing.T) {
+	tpl := template(gpuContainer("w", 2, "worker"))
+	tpl.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "existing"}}
+	delivery := CUDAToolsDelivery{
+		AgentImage:       "registry.example/snapshot-agent:v1.2.3",
+		PullPolicy:       corev1.PullNever,
+		ImagePullSecrets: []string{"registry-creds", " ", "existing", "registry-creds"},
+	}
+	if _, err := ShapeCUDATools(tpl, []string{"w"}, delivery, nil); err != nil {
+		t.Fatalf("ShapeCUDATools() failed: %v", err)
+	}
+	if got := tpl.Spec.InitContainers[0].ImagePullPolicy; got != corev1.PullNever {
+		t.Fatalf("pull policy = %s, want Never", got)
+	}
+	var names []string
+	for _, ref := range tpl.Spec.ImagePullSecrets {
+		names = append(names, ref.Name)
+	}
+	if want := []string{"existing", "registry-creds"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("imagePullSecrets = %v, want %v", names, want)
+	}
+	tagged := CUDAToolsDelivery{AgentImage: "registry.example/agent:v1"}
+	if got := expectedCUDAToolsInitContainer(tagged).ImagePullPolicy; got != corev1.PullAlways {
+		t.Fatalf("tag reference should default to Always, got %s", got)
+	}
+
+	// Reshaping a live object the API server has defaulted is fine; a
+	// different image in the init container is not.
+	tpl.Spec.InitContainers[0].TerminationMessagePath = "/dev/termination-log"
+	if _, err := ShapeCUDATools(tpl, []string{"w"}, delivery, nil); err != nil {
+		t.Fatalf("reshaping a defaulted template failed: %v", err)
+	}
+	tpl.Spec.InitContainers[0].Image = "someone-else/image:latest"
+	if _, err := ShapeCUDATools(tpl, []string{"w"}, delivery, nil); err == nil {
+		t.Fatal("init container with a different image was accepted")
+	}
+}
+
+func TestShapeCUDAToolsRejectsInvalidContract(t *testing.T) {
+	worker := gpuContainer("worker", 2, "worker")
+	tests := map[string]struct {
+		template *corev1.PodTemplateSpec
+		targets  []string
+		delivery CUDAToolsDelivery
+	}{
+		"implicit image entrypoint": {template(gpuContainer("worker", 2)), []string{"worker"}, testDelivery()},
+		"missing agent image":       {template(worker), []string{"worker"}, CUDAToolsDelivery{}},
+		"malformed agent image": {template(worker), []string{"worker"}, CUDAToolsDelivery{
+			AgentImage: "registry.example/not valid@sha256:" + strings.Repeat("0", 64),
+		}},
+		"unknown target": {template(worker), []string{"other"}, testDelivery()},
+		"no targets":     {template(worker), nil, testDelivery()},
+		"conflicting mount options": {
+			template(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				Resources:    worker.Resources,
+				VolumeMounts: []corev1.VolumeMount{{Name: CUDAToolsVolumeName, MountPath: CUDAToolsMountPath, SubPath: "x"}},
+			}), []string{"worker"}, testDelivery(),
+		},
+		"volume is not an emptyDir": {
+			func() *corev1.PodTemplateSpec {
+				tpl := template(worker)
+				tpl.Spec.Volumes = []corev1.Volume{{
+					Name:         CUDAToolsVolumeName,
+					VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp"}},
+				}}
+				return tpl
+			}(), []string{"worker"}, testDelivery(),
+		},
+		"foreign cuda-checkpoint wrapper": {
+			template(corev1.Container{
+				Name: "worker", Resources: worker.Resources,
+				Command: []string{CUDACheckpointPath}, Args: []string{"--something-else"},
+			}), []string{"worker"}, testDelivery(),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			before := tc.template.DeepCopy()
+			if _, err := ShapeCUDATools(tc.template, tc.targets, tc.delivery, nil); err == nil {
+				t.Fatal("ShapeCUDATools() succeeded, want error")
+			}
+			if !reflect.DeepEqual(tc.template, before) {
+				t.Fatalf("failed shape mutated template:\ngot:  %#v\nwant: %#v", tc.template, before)
+			}
+		})
+	}
+}
+
+func TestVerifyCUDALaunchJobRejectsUnshapedSpecs(t *testing.T) {
+	shaped := template(gpuContainer("worker", 2, "worker"))
+	if _, err := ShapeCUDATools(shaped, []string{"worker"}, testDelivery(), nil); err != nil {
+		t.Fatal(err)
+	}
+	mutations := map[string]func(*corev1.PodSpec){
+		"no volume":         func(s *corev1.PodSpec) { s.Volumes = nil },
+		"no init container": func(s *corev1.PodSpec) { s.InitContainers = nil },
+		"no mount":          func(s *corev1.PodSpec) { s.Containers[0].VolumeMounts = nil },
+		"unwrapped command": func(s *corev1.PodSpec) {
+			s.Containers[0].Command = []string{"worker"}
+			s.Containers[0].Args = nil
+		},
+		"missing target": func(s *corev1.PodSpec) { s.Containers[0].Name = "other" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			spec := shaped.Spec.DeepCopy()
+			mutate(spec)
+			if err := VerifyCUDALaunchJob(spec, []string{"worker"}); err == nil {
+				t.Fatal("VerifyCUDALaunchJob() accepted an unshaped spec")
+			}
+		})
+	}
+}
+
+func TestValidateImageReference(t *testing.T) {
+	valid := []string{
+		"ghcr.io/ai-dynamo/snapshot/agent:v0.1.0",
+		"ghcr.io/ai-dynamo/snapshot/agent",
+		"localhost:5000/agent:dev",
+		"agent",
+		testAgentImage,
+		"registry.example/agent:v1@sha256:" + strings.Repeat("a", 64),
+	}
+	for _, image := range valid {
+		if err := ValidateImageReference(image); err != nil {
+			t.Errorf("ValidateImageReference(%q) = %v, want nil", image, err)
+		}
+	}
+	invalid := []string{
+		"",
+		" ghcr.io/agent:v1",
+		"registry.example/not valid@sha256:" + strings.Repeat("0", 64),
+		"registry.example/Agent:v1",
+		"registry.example/agent@sha256:short",
+		"registry.example/agent:tag with space",
+	}
+	for _, image := range invalid {
+		if err := ValidateImageReference(image); err == nil {
+			t.Errorf("ValidateImageReference(%q) = nil, want error", image)
+		}
+	}
+}
+
+func assertLaunchJob(t *testing.T, container *corev1.Container, original []string) {
+	t.Helper()
+	if !reflect.DeepEqual(container.Command, []string{CUDACheckpointPath}) {
+		t.Fatalf("%s command = %#v", container.Name, container.Command)
+	}
+	if !isCUDACheckpointLaunchJob(container.Args) {
+		t.Fatalf("%s is not wrapped with cuda-checkpoint: %#v", container.Name, container.Args)
+	}
+	if got := container.Args[6:]; !reflect.DeepEqual(got, original) {
+		t.Fatalf("%s original command = %#v, want %#v", container.Name, got, original)
+	}
+}

--- a/charts/snapshot/templates/_helpers.tpl
+++ b/charts/snapshot/templates/_helpers.tpl
@@ -72,6 +72,14 @@ Name of the operator service account.
 {{- end }}
 
 {{/*
+The one configured agent image used by both the DaemonSet and the snapshot-cuda
+init container injected into source Pods.
+*/}}
+{{- define "snapshot.agentImage" -}}
+{{- printf "%s:%s" .Values.image.agent.repository (.Values.image.agent.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
 Fail fast on unsupported runtime.type values. Called once from daemonset.yaml.
 */}}
 {{- define "snapshot.validateRuntime" -}}

--- a/charts/snapshot/templates/daemonset.yaml
+++ b/charts/snapshot/templates/daemonset.yaml
@@ -135,7 +135,7 @@ spec:
               mountPath: {{ .Values.storage.pvc.basePath }}
         {{- end }}
         - name: agent
-          image: "{{ .Values.image.agent.repository }}:{{ .Values.image.agent.tag | default .Chart.AppVersion }}"
+          image: {{ include "snapshot.agentImage" . | quote }}
           imagePullPolicy: {{ .Values.image.agent.pullPolicy }}
           args:
             - "--runtime"

--- a/charts/snapshot/templates/operator-deployment.yaml
+++ b/charts/snapshot/templates/operator-deployment.yaml
@@ -71,6 +71,11 @@ spec:
             - {{ printf "--artifact-cleanup-scan-interval=%v" .Values.operator.artifactCleanup.scanInterval | quote }}
             - {{ printf "--artifact-cleanup-batch-size=%v" .Values.operator.artifactCleanup.batchSize | quote }}
             - {{ printf "--artifact-cleanup-list-attempts=%v" .Values.operator.artifactCleanup.listAttempts | quote }}
+            # Delivery of cuda-checkpoint (launch-job wrapper for multi-GPU targets)
+            # and the cuinterpose shim from the agent image into source Pods.
+            - {{ printf "--agent-image=%s" (include "snapshot.agentImage" .) | quote }}
+            - {{ printf "--agent-image-pull-policy=%s" .Values.image.agent.pullPolicy | quote }}
+            - {{ printf "--agent-image-pull-secrets=%s" (join "," .Values.cudaTools.imagePullSecrets) | quote }}
           volumeMounts:
             - name: checkpoints
               mountPath: {{ .Values.storage.pvc.basePath | quote }}

--- a/charts/snapshot/templates/operator-rbac.yaml
+++ b/charts/snapshot/templates/operator-rbac.yaml
@@ -47,6 +47,11 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  # Sizing the DRA claims of a SnapshotJob's pod template decides whether its
+  # target is launched under cuda-checkpoint --launch-job.
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims", "resourceclaimtemplates"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]

--- a/charts/snapshot/tests/cudatools_test.yaml
+++ b/charts/snapshot/tests/cudatools_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: cuda tools delivery flags on the operator
+templates:
+  - templates/operator-deployment.yaml
+tests:
+  - it: passes the agent image, pull policy, and no pull secrets by default
+    set:
+      image.agent.tag: v9.9.9
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image=ghcr.io/ai-dynamo/snapshot/agent:v9.9.9"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image-pull-policy=Always"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image-pull-secrets="
+
+  - it: joins configured workload pull secrets
+    set:
+      cudaTools.imagePullSecrets:
+        - registry-creds
+        - mirror-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-image-pull-secrets=registry-creds,mirror-creds"

--- a/charts/snapshot/values.yaml
+++ b/charts/snapshot/values.yaml
@@ -14,6 +14,15 @@ image:
     tag: ""
     pullPolicy: Always
 
+# The operator copies cuda-checkpoint (and the cuinterpose shim) out of
+# image.agent into source Pods whose checkpoint target may use more than one
+# GPU, and launches the target under cuda-checkpoint --launch-job.
+cudaTools:
+  # Names of imagePullSecrets that exist in the workload namespaces, added to
+  # such source Pods so the init container can pull image.agent from a private
+  # registry. The DaemonSet's own pull secrets do not apply there.
+  imagePullSecrets: []
+
 replicaCount: 1
 
 operator:

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -6,13 +6,16 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	"github.com/ai-dynamo/snapshot/api/v1alpha1"
 	"github.com/ai-dynamo/snapshot/operator/internal/controller"
 )
@@ -24,6 +27,21 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	artifactCleanupConfig := bindArtifactCleanupFlags(flag.CommandLine)
+	agentImage := flag.String(
+		"agent-image",
+		"",
+		"Snapshot agent image that supplies cuda-checkpoint and the cuinterpose shim to every source Pod checkpoint target",
+	)
+	agentImagePullPolicy := flag.String(
+		"agent-image-pull-policy",
+		"",
+		"Pull policy for the snapshot-cuda install init container (Always, IfNotPresent, Never); empty picks a default from the reference",
+	)
+	agentImagePullSecrets := flag.String(
+		"agent-image-pull-secrets",
+		"",
+		"Comma-separated imagePullSecret names, present in workload namespaces, added to source Pods that receive the tools",
+	)
 	flag.Parse()
 	if err := artifactCleanupConfig.Validate(); err != nil {
 		ctrl.Log.Error(err, "invalid artifact cleanup configuration")
@@ -87,6 +105,11 @@ func main() {
 		Client:             mgr.GetClient(),
 		NonCacheReadClient: mgr.GetAPIReader(),
 		Recorder:           mgr.GetEventRecorderFor("snapshotjob-controller"),
+		CUDATools: podcontract.CUDAToolsDelivery{
+			AgentImage:       *agentImage,
+			PullPolicy:       corev1.PullPolicy(*agentImagePullPolicy),
+			ImagePullSecrets: splitNonEmpty(*agentImagePullSecrets),
+		},
 	}
 	if err := snapshotJobReconciler.SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to set up SnapshotJob controller")
@@ -97,4 +120,15 @@ func main() {
 		ctrl.Log.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+}
+
+// splitNonEmpty splits a comma-separated flag value, dropping blanks.
+func splitNonEmpty(value string) []string {
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/operator/cmd/snapshotctl/checkpoint.go
+++ b/operator/cmd/snapshotctl/checkpoint.go
@@ -63,6 +63,23 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (_ *result, 
 		return nil, err
 	}
 
+	// Multi-GPU sources must run under cuda-checkpoint --launch-job or the
+	// agent refuses to checkpoint them. DRA claims cannot be sized here, so a
+	// target with any device claim is wrapped as well.
+	wrapLaunchJob := opts.CudaCheckpointWrap
+	if !wrapLaunchJob {
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name != containerName {
+				continue
+			}
+			needed, err := podcontract.NeedsCUDALaunchJob(&pod.Spec, &pod.Spec.Containers[i], nil)
+			if err != nil {
+				return nil, err
+			}
+			wrapLaunchJob = needed
+		}
+	}
+
 	checkpointJobName := captureJobName(snapshotName)
 	job, err := snapshotprotocol.NewSourceJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -75,7 +92,7 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (_ *result, 
 		TargetContainer: containerName,
 		SeccompProfile:  podcontract.DefaultSeccompLocalhostProfile,
 		Name:            checkpointJobName,
-		WrapLaunchJob:   opts.CudaCheckpointWrap,
+		WrapLaunchJob:   wrapLaunchJob,
 	})
 	if err != nil {
 		return nil, err

--- a/operator/cmd/snapshotctl/main.go
+++ b/operator/cmd/snapshotctl/main.go
@@ -50,7 +50,7 @@ func runCheckpoint(args []string) error {
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	snapshotName := flags.String("snapshot", "", "Required. Name of the PodSnapshot to create")
 	container := flags.String("container", "", "Required. Name of the workload container inside the manifest to checkpoint")
-	cudaCheckpointWrap := flags.Bool("cuda-checkpoint-wrap", false, "Wrap the container command with cuda-checkpoint --launch-job (required for multi-GPU checkpoints; the placeholder image must have cuda-checkpoint at the same path as the source container)")
+	cudaCheckpointWrap := flags.Bool("cuda-checkpoint-wrap", false, "Wrap the container command with cuda-checkpoint --launch-job even for a single GPU (multi-GPU targets are always wrapped; the placeholder image must have cuda-checkpoint at the same path as the source container)")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for checkpoint completion")
 
 	if err := flags.Parse(args); err != nil {

--- a/operator/internal/controller/snapshotjob_dra.go
+++ b/operator/internal/controller/snapshotjob_dra.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
+)
+
+// claimLookupError marks a failed ResourceClaim or ResourceClaimTemplate read.
+// The reconcile is retried rather than the SnapshotJob failed.
+type claimLookupError struct{ err error }
+
+func (e claimLookupError) Error() string { return e.err.Error() }
+func (e claimLookupError) Unwrap() error { return e.err }
+
+// claimDevices sizes the pod template's DRA claims through the API, so the
+// launch-job rule (more than one GPU) covers DRA-allocated GPUs as well as the
+// device plugin's nvidia.com/gpu. A claim or template that does not exist
+// counts as unknown, which wraps the target; a read error is retried.
+func (r *SnapshotJobReconciler) claimDevices(ctx context.Context, namespace string) podcontract.ClaimDevices {
+	return func(claim corev1.PodResourceClaim) (int, bool, error) {
+		var requests []resourcev1.DeviceRequest
+		switch {
+		case claim.ResourceClaimTemplateName != nil:
+			template := &resourcev1.ResourceClaimTemplate{}
+			key := client.ObjectKey{Namespace: namespace, Name: *claim.ResourceClaimTemplateName}
+			if err := r.Get(ctx, key, template); err != nil {
+				if apierrors.IsNotFound(err) {
+					return 0, false, nil
+				}
+				return 0, false, claimLookupError{fmt.Errorf("read ResourceClaimTemplate %q: %w", key.Name, err)}
+			}
+			requests = template.Spec.Spec.Devices.Requests
+		case claim.ResourceClaimName != nil:
+			resourceClaim := &resourcev1.ResourceClaim{}
+			key := client.ObjectKey{Namespace: namespace, Name: *claim.ResourceClaimName}
+			if err := r.Get(ctx, key, resourceClaim); err != nil {
+				if apierrors.IsNotFound(err) {
+					return 0, false, nil
+				}
+				return 0, false, claimLookupError{fmt.Errorf("read ResourceClaim %q: %w", key.Name, err)}
+			}
+			requests = resourceClaim.Spec.Devices.Requests
+		default:
+			return 0, false, nil
+		}
+		return countClaimDevices(requests)
+	}
+}
+
+// countClaimDevices sums the devices a claim asks for. An "All" allocation has
+// no fixed size, so the total is unknown; a first-available list counts as its
+// largest alternative.
+func countClaimDevices(requests []resourcev1.DeviceRequest) (int, bool, error) {
+	total := 0
+	for _, request := range requests {
+		switch {
+		case request.Exactly != nil:
+			if request.Exactly.AllocationMode == resourcev1.DeviceAllocationModeAll {
+				return 0, false, nil
+			}
+			total += countOrOne(request.Exactly.Count)
+		case len(request.FirstAvailable) > 0:
+			largest := 0
+			for _, sub := range request.FirstAvailable {
+				if sub.AllocationMode == resourcev1.DeviceAllocationModeAll {
+					return 0, false, nil
+				}
+				largest = max(largest, countOrOne(sub.Count))
+			}
+			total += largest
+		}
+	}
+	return total, true, nil
+}
+
+// countOrOne applies the API default: an unset count means one device.
+func countOrOne(count int64) int {
+	if count <= 0 {
+		return 1
+	}
+	return int(count)
+}
+
+// buildSourceJob constructs the desired source Job with this reconciler's tool
+// delivery and DRA claim sizing.
+func (r *SnapshotJobReconciler) buildSourceJob(ctx context.Context, sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, []string, error) {
+	return buildShapedSourceJob(sj, r.CUDATools, r.claimDevices(ctx, sj.Namespace))
+}

--- a/operator/internal/controller/snapshotjob_dra_test.go
+++ b/operator/internal/controller/snapshotjob_dra_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func exactRequest(count int64) resourcev1.DeviceRequest {
+	return resourcev1.DeviceRequest{Name: "gpu", Exactly: &resourcev1.ExactDeviceRequest{
+		DeviceClassName: "gpu.nvidia.com", AllocationMode: resourcev1.DeviceAllocationModeExactCount, Count: count,
+	}}
+}
+
+func TestCountClaimDevices(t *testing.T) {
+	count, known, err := countClaimDevices([]resourcev1.DeviceRequest{exactRequest(4), exactRequest(0)})
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.Equal(t, 5, count, "an unset count is one device")
+
+	_, known, err = countClaimDevices([]resourcev1.DeviceRequest{{Name: "all", Exactly: &resourcev1.ExactDeviceRequest{
+		DeviceClassName: "gpu.nvidia.com", AllocationMode: resourcev1.DeviceAllocationModeAll,
+	}}})
+	require.NoError(t, err)
+	assert.False(t, known, "\"All\" has no fixed size")
+
+	count, known, err = countClaimDevices([]resourcev1.DeviceRequest{{Name: "either", FirstAvailable: []resourcev1.DeviceSubRequest{
+		{Name: "big", DeviceClassName: "gpu.nvidia.com", AllocationMode: resourcev1.DeviceAllocationModeExactCount, Count: 8},
+		{Name: "small", DeviceClassName: "gpu.nvidia.com", AllocationMode: resourcev1.DeviceAllocationModeExactCount, Count: 2},
+	}}})
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.Equal(t, 8, count, "a first-available list counts as its largest alternative")
+}
+
+func TestClaimDevicesResolvesTemplatesAndClaims(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	require.NoError(t, resourcev1.AddToScheme(s))
+	template := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "inference"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{exactRequest(4)}},
+		}},
+	}
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "one-gpu", Namespace: "inference"},
+		Spec:       resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{exactRequest(1)}}},
+	}
+	r := makeSnapshotJobReconciler(s, template, claim)
+	resolve := r.claimDevices(context.Background(), "inference")
+
+	count, known, err := resolve(corev1.PodResourceClaim{Name: "gpus", ResourceClaimTemplateName: ptr.To("gpu-template")})
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.Equal(t, 4, count)
+
+	count, known, err = resolve(corev1.PodResourceClaim{Name: "gpu", ResourceClaimName: ptr.To("one-gpu")})
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.Equal(t, 1, count)
+
+	_, known, err = resolve(corev1.PodResourceClaim{Name: "gone", ResourceClaimTemplateName: ptr.To("missing")})
+	require.NoError(t, err)
+	assert.False(t, known, "a missing template is unknown, which wraps the target")
+
+	broken := makeSnapshotJobReconcilerWithInterceptor(s, interceptor.Funcs{
+		Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+			return errors.New("apiserver unavailable")
+		},
+	})
+	_, _, err = broken.claimDevices(context.Background(), "inference")(corev1.PodResourceClaim{Name: "gpus", ResourceClaimTemplateName: ptr.To("gpu-template")})
+	require.Error(t, err)
+	assert.True(t, errors.As(err, new(claimLookupError)), "API failures are retried, not terminal: %v", err)
+}

--- a/operator/internal/controller/snapshotjob_job.go
+++ b/operator/internal/controller/snapshotjob_job.go
@@ -15,17 +15,9 @@ import (
 	"github.com/ai-dynamo/snapshot/operator/internal/protocol"
 )
 
-// buildSourceJob constructs the desired batch/v1 Job for a SnapshotJob's source pod.
-// It reuses protocol.NewSourceJob unchanged — that function's body is the agent
-// contract (control volume, readiness probe, labels, seccomp, sidecar opt-outs), not
-// Dynamo-specific code — and adds only the owner label so the PodSnapshot created
-// later (PR 4) can be mapped back to this SnapshotJob without an ownerReference.
-//
-// No storage is injected (spec §5.3: the agent falls back to its own config), and
-// WrapLaunchJob is always false (spec §5.4: PodSnapshotTemplate has no field to
-// source it from — a caller needing cuda-checkpoint --launch-job wrapping sets it
-// up themselves in spec.podTemplate).
-func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
+// buildBaseSourceJob constructs the source Job before Snapshot's configured
+// CUDA tools are added.
+func buildBaseSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
 	// sj.Name is also used as a SnapshotJobOwnerLabel value. Admission caps
 	// metadata.name at the label-value limit;
 	// retain this check for objects that predate or bypass that schema.
@@ -60,4 +52,29 @@ func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
 		TTLSecondsAfterFinish: nil,
 		WrapLaunchJob:         false,
 	})
+}
+
+// buildShapedSourceJob adds Snapshot's CUDA tools to every target of the base
+// source Job and wraps only targets that may use more than one GPU. DRA claims
+// are sized through claims; an unresolvable claim counts as multi-GPU. No
+// storage is injected (spec §5.3: the agent falls back to its own config).
+func buildShapedSourceJob(
+	sj *snapshotv1alpha1.SnapshotJob,
+	delivery podcontract.CUDAToolsDelivery,
+	claims podcontract.ClaimDevices,
+) (*batchv1.Job, []string, error) {
+	job, err := buildBaseSourceJob(sj)
+	if err != nil {
+		return nil, nil, err
+	}
+	wrapped, err := podcontract.ShapeCUDATools(
+		&job.Spec.Template,
+		sj.Spec.PodSnapshotTemplate.TargetContainers,
+		delivery,
+		claims,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return job, wrapped, nil
 }

--- a/operator/internal/controller/snapshotjob_job_test.go
+++ b/operator/internal/controller/snapshotjob_job_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -39,7 +40,7 @@ func TestBuildSourceJob(t *testing.T) {
 	t.Run("wires identity, target, and options through to NewSourceJob", func(t *testing.T) {
 		sj := minimalSnapshotJob()
 
-		job, err := buildSourceJob(sj)
+		job, err := buildBaseSourceJob(sj)
 		require.NoError(t, err)
 
 		assert.Equal(t, "warm-worker", job.Name)
@@ -61,7 +62,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj := minimalSnapshotJob()
 		sj.Spec.PodTemplate.Labels = map[string]string{"existing": "label"}
 
-		job, err := buildSourceJob(sj)
+		job, err := buildBaseSourceJob(sj)
 		require.NoError(t, err)
 
 		assert.Equal(t, "warm-worker", job.Spec.Template.Labels[snapshotv1alpha1.SnapshotJobOwnerLabel])
@@ -77,7 +78,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj.Spec.PodTemplate.Spec.Containers = append(sj.Spec.PodTemplate.Spec.Containers,
 			corev1.Container{Name: "helper", Image: "test:latest"})
 
-		job, err := buildSourceJob(sj)
+		job, err := buildBaseSourceJob(sj)
 		require.NoError(t, err)
 
 		var names []string
@@ -105,7 +106,7 @@ func TestBuildSourceJob(t *testing.T) {
 	t.Run("readiness probe reads the ready file from the control mount", func(t *testing.T) {
 		sj := minimalSnapshotJob()
 
-		job, err := buildSourceJob(sj)
+		job, err := buildBaseSourceJob(sj)
 		require.NoError(t, err)
 
 		main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
@@ -127,7 +128,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj := minimalSnapshotJob()
 		sj.Spec.PodTemplate.Spec.Containers[0].Command = []string{"python3", "-m", "worker"}
 
-		job, err := buildSourceJob(sj)
+		job, err := buildBaseSourceJob(sj)
 		require.NoError(t, err)
 
 		main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
@@ -141,7 +142,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj := minimalSnapshotJob()
 		sj.Name = strings.Repeat("a", 64)
 
-		_, err := buildSourceJob(sj)
+		_, err := buildBaseSourceJob(sj)
 		require.Error(t, err)
 	})
 
@@ -150,7 +151,7 @@ func TestBuildSourceJob(t *testing.T) {
 			sj := minimalSnapshotJob()
 			sj.Name = name
 
-			_, err := buildSourceJob(sj)
+			_, err := buildBaseSourceJob(sj)
 			require.NoError(t, err)
 		}
 	})
@@ -159,7 +160,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj := minimalSnapshotJob()
 		sj.Spec.PodSnapshotTemplate.TargetContainers = nil
 
-		_, err := buildSourceJob(sj)
+		_, err := buildBaseSourceJob(sj)
 		require.Error(t, err)
 	})
 
@@ -180,7 +181,7 @@ func TestBuildSourceJob(t *testing.T) {
 				sj := minimalSnapshotJob()
 				sj.Spec.PodSnapshotTemplate.Metadata = metadata
 
-				_, err := buildSourceJob(sj)
+				_, err := buildBaseSourceJob(sj)
 				require.Error(t, err)
 			})
 		}
@@ -195,7 +196,7 @@ func TestBuildSourceJob(t *testing.T) {
 			corev1.Container{Name: "helper", Image: "test:latest"})
 		sj.Spec.PodSnapshotTemplate.TargetContainers = []string{"worker", "helper"}
 
-		_, err := buildSourceJob(sj)
+		_, err := buildBaseSourceJob(sj)
 		require.Error(t, err)
 	})
 
@@ -203,7 +204,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj := minimalSnapshotJob()
 		sj.Spec.PodSnapshotTemplate.TargetContainers = []string{"does-not-exist"}
 
-		_, err := buildSourceJob(sj)
+		_, err := buildBaseSourceJob(sj)
 		require.Error(t, err)
 	})
 
@@ -211,7 +212,7 @@ func TestBuildSourceJob(t *testing.T) {
 		sj := minimalSnapshotJob()
 		sj.Spec.PodTemplate.Spec.Containers = nil
 
-		_, err := buildSourceJob(sj)
+		_, err := buildBaseSourceJob(sj)
 		require.Error(t, err)
 	})
 }
@@ -237,4 +238,67 @@ func getBatchJobByName(jobs *batchv1.JobList, name string) *batchv1.Job {
 		}
 	}
 	return nil
+}
+
+func multiGPUSnapshotJob() *snapshotv1alpha1.SnapshotJob {
+	sj := minimalSnapshotJob()
+	worker := &sj.Spec.PodTemplate.Spec.Containers[0]
+	worker.Command = []string{"python3", "-m", "worker"}
+	worker.Resources.Limits = corev1.ResourceList{podcontract.GPUResourceName: resource.MustParse("2")}
+	return sj
+}
+
+func testCUDAToolsDelivery() podcontract.CUDAToolsDelivery {
+	return podcontract.CUDAToolsDelivery{AgentImage: "registry.example/snapshot-agent:v1.2.3"}
+}
+
+// buildSourceJob gives controller tests the production-shaped Job without
+// requiring every test to repeat delivery configuration.
+func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
+	job, _, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	return job, err
+}
+
+func TestBuildShapedSourceJobWrapsMultiGPUTargets(t *testing.T) {
+	sj := multiGPUSnapshotJob()
+
+	job, wrapped, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"worker"}, wrapped)
+
+	require.NoError(t, podcontract.VerifyCUDALaunchJob(&job.Spec.Template.Spec, []string{"worker"}))
+	main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
+	assert.Equal(t, []string{podcontract.CUDACheckpointPath}, main.Command,
+		"a multi-GPU target is launched through the cuda-checkpoint copied from the agent image")
+	assert.Equal(t, []string{"python3", "-m", "worker"}, main.Args[len(main.Args)-3:],
+		"the original command follows the launch-job wrapper")
+	init := requireContainer(t, job.Spec.Template.Spec.InitContainers, podcontract.CUDAToolsInitContainerName)
+	assert.Equal(t, "registry.example/snapshot-agent:v1.2.3", init.Image)
+
+	t.Run("every shaped SnapshotJob needs a configured agent image", func(t *testing.T) {
+		_, _, err := buildShapedSourceJob(minimalSnapshotJob(), podcontract.CUDAToolsDelivery{}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("a single-GPU SnapshotJob gets the tools without a wrapper", func(t *testing.T) {
+		sj := minimalSnapshotJob()
+		sj.Spec.PodTemplate.Spec.Containers[0].Command = []string{"python3", "-m", "worker"}
+		job, wrapped, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+		require.NoError(t, err)
+		assert.Empty(t, wrapped)
+		require.NoError(t, podcontract.VerifyCUDATools(&job.Spec.Template.Spec, []string{"worker"}))
+		main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
+		assert.Equal(t, []string{"python3", "-m", "worker"}, main.Command)
+	})
+
+	t.Run("a DRA claim of unknown size is treated as multi-GPU", func(t *testing.T) {
+		sj := minimalSnapshotJob()
+		worker := &sj.Spec.PodTemplate.Spec.Containers[0]
+		worker.Command = []string{"worker"}
+		worker.Resources.Claims = []corev1.ResourceClaim{{Name: "gpus"}}
+		sj.Spec.PodTemplate.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "gpus"}}
+		_, wrapped, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"worker"}, wrapped)
+	})
 }

--- a/operator/internal/controller/snapshotjob_reconciler.go
+++ b/operator/internal/controller/snapshotjob_reconciler.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -56,6 +57,9 @@ type SnapshotJobReconciler struct {
 	client.Client
 	NonCacheReadClient client.Reader
 	Recorder           record.EventRecorder
+	// CUDATools says where cuda-checkpoint and the cuinterpose shim are
+	// delivered from for every source Pod checkpoint target.
+	CUDATools podcontract.CUDAToolsDelivery
 }
 
 type snapshotJobFailure struct {
@@ -146,8 +150,11 @@ func (r *SnapshotJobReconciler) reconcileResources(ctx context.Context, sj *snap
 			}
 			return r.reconcileAcceptedSourceJob(ctx, sj, authoritativeJob)
 		}
-		desiredJob, buildErr := buildSourceJob(sj)
+		desiredJob, _, buildErr := r.buildSourceJob(ctx, sj)
 		if buildErr != nil {
+			if errors.As(buildErr, new(claimLookupError)) {
+				return snapshotJobObservation{}, ctrl.Result{}, buildErr
+			}
 			return terminalObservation(snapshotv1alpha1.ReasonInvalidSpec, buildErr), ctrl.Result{}, nil
 		}
 		return r.createSourceJob(ctx, sj, desiredJob)

--- a/operator/internal/controller/snapshotjob_reconciler_test.go
+++ b/operator/internal/controller/snapshotjob_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -51,6 +52,7 @@ func makeSnapshotJobReconcilerWithInterceptor(s *runtime.Scheme, funcs intercept
 		Client:             testClient,
 		NonCacheReadClient: testClient,
 		Recorder:           record.NewFakeRecorder(10),
+		CUDATools:          testCUDAToolsDelivery(),
 	}
 }
 
@@ -785,4 +787,63 @@ func TestSnapshotJobReconcileSkipsTerminalAndDeleted(t *testing.T) {
 		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "inference", Name: "gone"}})
 		require.NoError(t, err)
 	})
+}
+
+func TestSnapshotJobReconcileRejectsUnshapedMultiGPUJob(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := multiGPUSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	// Shape the target while it appears to use one GPU, so it receives the
+	// tools but no launch-job wrapper. Then make the desired and existing
+	// target multi-GPU to exercise the wrapper-specific adoption check.
+	single := sj.DeepCopy()
+	single.Spec.PodTemplate.Spec.Containers[0].Resources.Limits = nil
+	job, err := buildBaseSourceJob(single)
+	require.NoError(t, err)
+	_, err = podcontract.ShapeCUDATools(
+		&job.Spec.Template,
+		single.Spec.PodSnapshotTemplate.TargetContainers,
+		testCUDAToolsDelivery(),
+		nil,
+	)
+	require.NoError(t, err)
+	job.Spec.Template.Spec.Containers[0].Resources.Limits = sj.Spec.PodTemplate.Spec.Containers[0].Resources.Limits
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.CUDATools = testCUDAToolsDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	failed := meta.FindStatusCondition(updated.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
+	require.NotNil(t, failed, "adopting a multi-GPU Job without the wrapper would fail at checkpoint time")
+	assert.Equal(t, snapshotv1alpha1.ReasonJobNameConflict, failed.Reason)
+	assert.Contains(t, failed.Message, "launch-job contract")
+	assert.Empty(t, updated.Status.SourceJobUID)
+}
+
+func TestSnapshotJobReconcileAdoptsShapedMultiGPUJob(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := multiGPUSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	job, _, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.CUDATools = testCUDAToolsDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	assert.Equal(t, job.UID, updated.Status.SourceJobUID, "a correctly shaped Job is adopted")
 }

--- a/operator/internal/controller/snapshotjob_source_job.go
+++ b/operator/internal/controller/snapshotjob_source_job.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -49,7 +50,11 @@ func (r *SnapshotJobReconciler) observeExistingSourceJob(ctx context.Context, sj
 // reconcileExistingSourceJob applies the one-shot Job identity gate shared by
 // steady-state reconciliation and Create-AlreadyExists recovery.
 func (r *SnapshotJobReconciler) reconcileExistingSourceJob(ctx context.Context, sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Job) (snapshotJobObservation, ctrl.Result, error) {
-	if failure := classifyExistingSourceJob(sj, job); failure != nil {
+	failure, err := r.classifyExistingSourceJob(ctx, sj, job)
+	if err != nil {
+		return snapshotJobObservation{}, ctrl.Result{}, err
+	}
+	if failure != nil {
 		return snapshotJobObservation{failure: failure}, ctrl.Result{}, nil
 	}
 	return r.reconcileAcceptedSourceJob(ctx, sj, job)
@@ -74,7 +79,11 @@ func (r *SnapshotJobReconciler) readAuthoritativeSourceJob(ctx context.Context, 
 		}
 		return nil, nil, err
 	}
-	if failure := classifyExistingSourceJob(sj, job); failure != nil {
+	failure, err := r.classifyExistingSourceJob(ctx, sj, job)
+	if err != nil {
+		return nil, nil, err
+	}
+	if failure != nil {
 		return job, failure, nil
 	}
 	return job, nil, nil
@@ -87,13 +96,19 @@ func sourceJobDeletedFailure(sj *snapshotv1alpha1.SnapshotJob) *snapshotJobFailu
 	}
 }
 
-// classifyExistingSourceJob validates ownership and one-shot Job identity.
-func classifyExistingSourceJob(sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Job) *snapshotJobFailure {
+// classifyExistingSourceJob validates ownership and one-shot Job identity. The
+// error return is a transient API failure while sizing the template's DRA
+// claims; everything else is a terminal failure or acceptance.
+func (r *SnapshotJobReconciler) classifyExistingSourceJob(
+	ctx context.Context,
+	sj *snapshotv1alpha1.SnapshotJob,
+	job *batchv1.Job,
+) (*snapshotJobFailure, error) {
 	if !metav1.IsControlledBy(job, sj) {
 		return &snapshotJobFailure{
 			reason: snapshotv1alpha1.ReasonJobNameConflict,
 			cause:  fmt.Errorf("an object not controlled by this SnapshotJob already holds the name %q", sj.Name),
-		}
+		}, nil
 	}
 	if expectedUID := sj.Status.SourceJobUID; expectedUID != "" {
 		if job.UID != expectedUID {
@@ -101,27 +116,49 @@ func classifyExistingSourceJob(sj *snapshotv1alpha1.SnapshotJob, job *batchv1.Jo
 				reason: snapshotv1alpha1.ReasonJobNameConflict,
 				cause: fmt.Errorf("source Job %q was replaced: found uid %q, expected %q",
 					job.Name, job.UID, expectedUID),
-			}
+			}, nil
 		}
-		return nil
+		return nil, nil
 	}
 
-	desired, err := buildSourceJob(sj)
+	desired, wrapped, err := r.buildSourceJob(ctx, sj)
 	if err != nil {
-		return &snapshotJobFailure{reason: snapshotv1alpha1.ReasonInvalidSpec, cause: err}
+		if errors.As(err, new(claimLookupError)) {
+			return nil, err
+		}
+		return &snapshotJobFailure{reason: snapshotv1alpha1.ReasonInvalidSpec, cause: err}, nil
 	}
 	targetContainer, err := snapshotJobTargetContainer(sj)
 	if err != nil {
-		return &snapshotJobFailure{reason: snapshotv1alpha1.ReasonInvalidSpec, cause: err}
+		return &snapshotJobFailure{reason: snapshotv1alpha1.ReasonInvalidSpec, cause: err}, nil
 	}
 	if !sourceJobHasExpectedIdentity(desired, job, targetContainer) {
 		return &snapshotJobFailure{
 			reason: snapshotv1alpha1.ReasonJobNameConflict,
 			cause: fmt.Errorf("existing source Job %q does not carry the immutable identity expected for this SnapshotJob",
 				job.Name),
+		}, nil
+	}
+	// Every target must carry Snapshot's CUDA tools, independently of whether
+	// its command needs the multi-GPU launch-job wrapper.
+	if err := podcontract.VerifyCUDATools(
+		&job.Spec.Template.Spec,
+		sj.Spec.PodSnapshotTemplate.TargetContainers,
+	); err != nil {
+		return &snapshotJobFailure{
+			reason: snapshotv1alpha1.ReasonJobNameConflict,
+			cause:  fmt.Errorf("existing source Job %q lacks the CUDA tools contract: %w", job.Name, err),
+		}, nil
+	}
+	if len(wrapped) > 0 {
+		if err := podcontract.VerifyCUDALaunchJob(&job.Spec.Template.Spec, wrapped); err != nil {
+			return &snapshotJobFailure{
+				reason: snapshotv1alpha1.ReasonJobNameConflict,
+				cause:  fmt.Errorf("existing source Job %q lacks the cuda-checkpoint launch-job contract: %w", job.Name, err),
+			}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // sourceJobHasExpectedIdentity checks only the immutable identity and capture

--- a/operator/internal/protocol/control_volume.go
+++ b/operator/internal/protocol/control_volume.go
@@ -4,6 +4,9 @@
 package protocol
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/ai-dynamo/snapshot/api/podcontract"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -14,28 +17,38 @@ import (
 // each see an isolated view), and sets both SnapshotControlDirEnv (canonical)
 // and LegacySnapshotControlDirEnv (deprecated) on the container's env, so
 // workload images can migrate off the legacy name independently of the
-// operator release. Idempotent — safe to call from multiple code paths
-// (operator source job, restore pod shaping, etc.); each env var is
-// guarded independently so a pod that already carries one (e.g. a
-// hand-crafted template with only the legacy name) still gets the other
-// injected without duplicating either.
+// operator release. Existing reserved volumes, mounts, and variables must
+// match this exact contract; conflicting workload entries are rejected rather
+// than silently weakening the control directory's isolation. Idempotent —
+// safe to call repeatedly.
 //
 // Callers must pass the container's own name; the subPath makes the mount
 // container-scoped on disk even though the in-container path is the same.
-func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
+func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) error {
 	if podSpec == nil || container == nil {
-		return
+		return fmt.Errorf("snapshot control volume requires a pod spec and target container")
 	}
 
-	hasVolume := false
-	for _, v := range podSpec.Volumes {
-		if v.Name == podcontract.SnapshotControlVolumeName {
-			hasVolume = true
-			break
+	shapedSpec := podSpec.DeepCopy()
+	shapedContainer := container.DeepCopy()
+
+	foundVolume := false
+	for i := range shapedSpec.Volumes {
+		volume := &shapedSpec.Volumes[i]
+		if volume.Name != podcontract.SnapshotControlVolumeName {
+			continue
+		}
+		if foundVolume {
+			return fmt.Errorf("duplicate %s volume", podcontract.SnapshotControlVolumeName)
+		}
+		foundVolume = true
+		if volume.EmptyDir == nil ||
+			!reflect.DeepEqual(volume.VolumeSource, corev1.VolumeSource{EmptyDir: volume.EmptyDir}) {
+			return fmt.Errorf("volume %q must be an emptyDir", podcontract.SnapshotControlVolumeName)
 		}
 	}
-	if !hasVolume {
-		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+	if !foundVolume {
+		shapedSpec.Volumes = append(shapedSpec.Volumes, corev1.Volume{
 			Name:         podcontract.SnapshotControlVolumeName,
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		})
@@ -47,33 +60,68 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 	// behavior for single-container pods.
 	subPath := container.Name
 
-	hasMount := false
-	for _, m := range container.VolumeMounts {
-		if m.Name == podcontract.SnapshotControlVolumeName {
-			hasMount = true
-			break
+	foundMount := false
+	for i := range shapedContainer.VolumeMounts {
+		mount := &shapedContainer.VolumeMounts[i]
+		if mount.Name != podcontract.SnapshotControlVolumeName &&
+			mount.MountPath != podcontract.SnapshotControlMountPath {
+			continue
+		}
+		if foundMount {
+			return fmt.Errorf("container %q has duplicate snapshot control mounts", container.Name)
+		}
+		foundMount = true
+		if mount.Name != podcontract.SnapshotControlVolumeName ||
+			mount.MountPath != podcontract.SnapshotControlMountPath ||
+			mount.SubPath != subPath ||
+			mount.ReadOnly ||
+			mount.RecursiveReadOnly != nil ||
+			mount.SubPathExpr != "" ||
+			(mount.MountPropagation != nil && *mount.MountPropagation != corev1.MountPropagationNone) {
+			return fmt.Errorf(
+				"container %q requires writable volume %q mounted at %s with subPath %q",
+				container.Name,
+				podcontract.SnapshotControlVolumeName,
+				podcontract.SnapshotControlMountPath,
+				subPath,
+			)
 		}
 	}
-	if !hasMount {
-		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+	if !foundMount {
+		shapedContainer.VolumeMounts = append(shapedContainer.VolumeMounts, corev1.VolumeMount{
 			Name:      podcontract.SnapshotControlVolumeName,
 			MountPath: podcontract.SnapshotControlMountPath,
 			SubPath:   subPath,
 		})
 	}
 
-	ensureEnv(container, podcontract.SnapshotControlDirEnv, podcontract.SnapshotControlMountPath)
-	ensureEnv(container, podcontract.LegacySnapshotControlDirEnv, podcontract.SnapshotControlMountPath)
-}
-
-// ensureEnv sets name=value on the container if name is not already present,
-// so repeated calls (e.g. dual-injecting the canonical and legacy control-dir
-// env var names) never duplicate an entry.
-func ensureEnv(container *corev1.Container, name, value string) {
-	for _, e := range container.Env {
-		if e.Name == name {
-			return
+	for _, name := range []string{
+		podcontract.SnapshotControlDirEnv,
+		podcontract.LegacySnapshotControlDirEnv,
+	} {
+		found := false
+		for i := range shapedContainer.Env {
+			env := &shapedContainer.Env[i]
+			if env.Name != name {
+				continue
+			}
+			if found {
+				return fmt.Errorf("container %q has duplicate %s environment variables", container.Name, name)
+			}
+			found = true
+			if env.Value != podcontract.SnapshotControlMountPath || env.ValueFrom != nil {
+				return fmt.Errorf("container %q has conflicting %s environment variable", container.Name, name)
+			}
+		}
+		if !found {
+			shapedContainer.Env = append(
+				shapedContainer.Env,
+				corev1.EnvVar{Name: name, Value: podcontract.SnapshotControlMountPath},
+			)
 		}
 	}
-	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+
+	podSpec.Volumes = shapedSpec.Volumes
+	*container = *shapedContainer
+	return nil
 }

--- a/operator/internal/protocol/control_volume_test.go
+++ b/operator/internal/protocol/control_volume_test.go
@@ -4,6 +4,7 @@
 package protocol
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/ai-dynamo/snapshot/api/podcontract"
@@ -13,7 +14,9 @@ import (
 func TestEnsureControlVolume(t *testing.T) {
 	t.Run("adds volume mount and env from empty", func(t *testing.T) {
 		ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
-		EnsureControlVolume(ps, &ps.Containers[0])
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(ps.Volumes) != 1 || ps.Volumes[0].Name != podcontract.SnapshotControlVolumeName || ps.Volumes[0].EmptyDir == nil {
 			t.Fatalf("expected one %s emptyDir volume, got %#v", podcontract.SnapshotControlVolumeName, ps.Volumes)
@@ -49,8 +52,12 @@ func TestEnsureControlVolume(t *testing.T) {
 			{Name: "engine-0"},
 			{Name: "engine-1"},
 		}}
-		EnsureControlVolume(ps, &ps.Containers[0])
-		EnsureControlVolume(ps, &ps.Containers[1])
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
+		if err := EnsureControlVolume(ps, &ps.Containers[1]); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(ps.Volumes) != 1 {
 			t.Fatalf("expected single shared emptyDir, got %#v", ps.Volumes)
@@ -65,8 +72,12 @@ func TestEnsureControlVolume(t *testing.T) {
 
 	t.Run("idempotent", func(t *testing.T) {
 		ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
-		EnsureControlVolume(ps, &ps.Containers[0])
-		EnsureControlVolume(ps, &ps.Containers[0])
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
 		c := ps.Containers[0]
 		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 2 {
 			t.Fatalf("expected single volume/mount and two envs after two calls, got volumes=%d mounts=%d env=%d", len(ps.Volumes), len(c.VolumeMounts), len(c.Env))
@@ -78,7 +89,9 @@ func TestEnsureControlVolume(t *testing.T) {
 			Name: "main",
 			Env:  []corev1.EnvVar{{Name: podcontract.LegacySnapshotControlDirEnv, Value: podcontract.SnapshotControlMountPath}},
 		}}}
-		EnsureControlVolume(ps, &ps.Containers[0])
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
 		c := ps.Containers[0]
 		if len(c.Env) != 2 {
 			t.Fatalf("expected legacy env preserved and canonical env added, got %#v", c.Env)
@@ -99,7 +112,9 @@ func TestEnsureControlVolume(t *testing.T) {
 			Name: "main",
 			Env:  []corev1.EnvVar{{Name: podcontract.SnapshotControlDirEnv, Value: podcontract.SnapshotControlMountPath}},
 		}}}
-		EnsureControlVolume(ps, &ps.Containers[0])
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
 		c := ps.Containers[0]
 		if len(c.Env) != 2 {
 			t.Fatalf("expected canonical env preserved and legacy env added, got %#v", c.Env)
@@ -115,18 +130,17 @@ func TestEnsureControlVolume(t *testing.T) {
 		}
 	})
 
-	t.Run("nil pod spec no-op", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Fatalf("expected no panic, got %v", r)
-			}
-		}()
-		EnsureControlVolume(nil, &corev1.Container{})
+	t.Run("nil pod spec rejected", func(t *testing.T) {
+		if err := EnsureControlVolume(nil, &corev1.Container{}); err == nil {
+			t.Fatal("expected nil pod spec error")
+		}
 	})
 
-	t.Run("nil container no-op", func(t *testing.T) {
+	t.Run("nil container rejected", func(t *testing.T) {
 		ps := &corev1.PodSpec{}
-		EnsureControlVolume(ps, nil)
+		if err := EnsureControlVolume(ps, nil); err == nil {
+			t.Fatal("expected nil container error")
+		}
 		if len(ps.Volumes) != 0 {
 			t.Fatalf("expected no volumes when container is nil, got %#v", ps.Volumes)
 		}
@@ -144,10 +158,102 @@ func TestEnsureControlVolume(t *testing.T) {
 				Env:          []corev1.EnvVar{{Name: "OTHER", Value: "x"}},
 			}},
 		}
-		EnsureControlVolume(ps, &ps.Containers[0])
+		if err := EnsureControlVolume(ps, &ps.Containers[0]); err != nil {
+			t.Fatal(err)
+		}
 		c := ps.Containers[0]
 		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 3 {
 			t.Fatalf("expected existing + control entries, got volumes=%#v mounts=%#v env=%#v", ps.Volumes, c.VolumeMounts, c.Env)
+		}
+	})
+
+	t.Run("conflicting reserved entries are rejected atomically", func(t *testing.T) {
+		cases := map[string]func(*corev1.PodSpec){
+			"duplicate volume": func(ps *corev1.PodSpec) {
+				volume := corev1.Volume{
+					Name:         podcontract.SnapshotControlVolumeName,
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				}
+				ps.Volumes = []corev1.Volume{volume, volume}
+			},
+			"non-emptyDir volume": func(ps *corev1.PodSpec) {
+				ps.Volumes = []corev1.Volume{{
+					Name: podcontract.SnapshotControlVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "shared"},
+					},
+				}}
+			},
+			"wrong mount path": func(ps *corev1.PodSpec) {
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+					Name:      podcontract.SnapshotControlVolumeName,
+					MountPath: "/shared-control",
+					SubPath:   "main",
+				}}
+			},
+			"wrong mount volume": func(ps *corev1.PodSpec) {
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+					Name:      "shared",
+					MountPath: podcontract.SnapshotControlMountPath,
+				}}
+			},
+			"wrong subPath": func(ps *corev1.PodSpec) {
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+					Name:      podcontract.SnapshotControlVolumeName,
+					MountPath: podcontract.SnapshotControlMountPath,
+					SubPath:   "other",
+				}}
+			},
+			"read-only mount": func(ps *corev1.PodSpec) {
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+					Name:      podcontract.SnapshotControlVolumeName,
+					MountPath: podcontract.SnapshotControlMountPath,
+					SubPath:   "main",
+					ReadOnly:  true,
+				}}
+			},
+			"duplicate mount": func(ps *corev1.PodSpec) {
+				mount := corev1.VolumeMount{
+					Name:      podcontract.SnapshotControlVolumeName,
+					MountPath: podcontract.SnapshotControlMountPath,
+					SubPath:   "main",
+				}
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{mount, mount}
+			},
+			"wrong environment": func(ps *corev1.PodSpec) {
+				ps.Containers[0].Env = []corev1.EnvVar{{
+					Name:  podcontract.SnapshotControlDirEnv,
+					Value: "/shared-control",
+				}}
+			},
+			"valueFrom environment": func(ps *corev1.PodSpec) {
+				ps.Containers[0].Env = []corev1.EnvVar{{
+					Name: podcontract.SnapshotControlDirEnv,
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+					},
+				}}
+			},
+			"duplicate environment": func(ps *corev1.PodSpec) {
+				env := corev1.EnvVar{
+					Name:  podcontract.SnapshotControlDirEnv,
+					Value: podcontract.SnapshotControlMountPath,
+				}
+				ps.Containers[0].Env = []corev1.EnvVar{env, env}
+			},
+		}
+		for name, mutate := range cases {
+			t.Run(name, func(t *testing.T) {
+				ps := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+				mutate(ps)
+				before := ps.DeepCopy()
+				if err := EnsureControlVolume(ps, &ps.Containers[0]); err == nil {
+					t.Fatal("expected conflicting reserved entry to be rejected")
+				}
+				if !reflect.DeepEqual(ps, before) {
+					t.Fatalf("failed shaping mutated pod spec:\ngot  %#v\nwant %#v", ps, before)
+				}
+			})
 		}
 	})
 }

--- a/operator/internal/protocol/source_job.go
+++ b/operator/internal/protocol/source_job.go
@@ -74,7 +74,9 @@ func NewSourceJob(podTemplate *corev1.PodTemplateSpec, opts SourceJobOptions) (*
 	// $SNAPSHOT_CONTROL_DIR/ready-for-snapshot. Any per-container
 	// liveness/startup probes are cleared — a source job runs to a
 	// quiesce-and-sit state, not a long-lived serving state.
-	EnsureControlVolume(&podTemplate.Spec, targetContainer)
+	if err := EnsureControlVolume(&podTemplate.Spec, targetContainer); err != nil {
+		return nil, fmt.Errorf("source job: %w", err)
+	}
 	targetContainer.ReadinessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
@@ -87,13 +89,9 @@ func NewSourceJob(podTemplate *corev1.PodTemplateSpec, opts SourceJobOptions) (*
 	targetContainer.StartupProbe = nil
 
 	if opts.WrapLaunchJob {
-		if len(targetContainer.Command) == 0 {
-			return nil, fmt.Errorf("source job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
+		if err := podcontract.EnsureCUDACheckpointLaunchJob(targetContainer, "cuda-checkpoint"); err != nil {
+			return nil, fmt.Errorf("source job: %w", err)
 		}
-		targetContainer.Command, targetContainer.Args = wrapWithCudaCheckpointLaunchJob(
-			targetContainer.Command,
-			targetContainer.Args,
-		)
 	}
 
 	return &batchv1.Job{
@@ -143,30 +141,4 @@ func DisableSidecarInjection(annotations map[string]string) map[string]string {
 	annotations[linkerdInjectAnnotation] = linkerdInjectDisabled
 	annotations[istioSidecarInjectAnnotation] = istioSidecarInjectDisabled
 	return annotations
-}
-
-// wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the
-// workload is launched under `cuda-checkpoint --launch-job`, required for
-// multi-GPU checkpoints. The launch-job file is copied from its transient
-// procfs FD into the per-pod snapshot control volume before the original
-// command starts. The workload inherits that stable path, while the snapshot
-// agent stages the capture-time contents into the content-owned artifact.
-func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	const persistJobFileScript = `set -eu
-job_file="$1"
-shift
-if [ -z "${CUDA_CHECKPOINT_JOB_FILE:-}" ]; then
-    echo "CUDA_CHECKPOINT_JOB_FILE is missing; cuda-checkpoint --launch-job requires NVIDIA driver 610 or newer" >&2
-    exit 1
-fi
-umask 077
-cat "$CUDA_CHECKPOINT_JOB_FILE" > "$job_file"
-export CUDA_CHECKPOINT_JOB_FILE="$job_file"
-exec "$@"`
-
-	wrappedArgs := make([]string, 0, len(command)+len(args)+7)
-	wrappedArgs = append(wrappedArgs, "--launch-job", "/bin/sh", "-c", persistJobFileScript, "dynamo-cuda-checkpoint", podcontract.CUDAJobFilePath)
-	wrappedArgs = append(wrappedArgs, command...)
-	wrappedArgs = append(wrappedArgs, args...)
-	return []string{"cuda-checkpoint"}, wrappedArgs
 }

--- a/operator/internal/protocol/source_job_identity_test.go
+++ b/operator/internal/protocol/source_job_identity_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ai-dynamo/snapshot/api/podcontract"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
@@ -25,10 +26,14 @@ func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, args := wrapWithCudaCheckpointLaunchJob(
-		[]string{"/bin/sh", "-c"},
-		[]string{`printf '%s' "$CUDA_CHECKPOINT_JOB_FILE" > "$1"`, "workload", observedEnvironment},
-	)
+	container := &corev1.Container{
+		Command: []string{"/bin/sh", "-c"},
+		Args:    []string{`printf '%s' "$CUDA_CHECKPOINT_JOB_FILE" > "$1"`, "workload", observedEnvironment},
+	}
+	if err := podcontract.EnsureCUDACheckpointLaunchJob(container, "cuda-checkpoint"); err != nil {
+		t.Fatal(err)
+	}
+	args := container.Args
 	args[5] = stableJobFile
 	cmd := exec.Command(args[1], args[2:]...)
 	cmd.Env = append(os.Environ(), "CUDA_CHECKPOINT_JOB_FILE="+transientJobFile)
@@ -60,7 +65,11 @@ func TestCudaCheckpointLaunchJobWrapperPersistsJobFile(t *testing.T) {
 }
 
 func TestCudaCheckpointLaunchJobWrapperReportsMissingJobFile(t *testing.T) {
-	_, args := wrapWithCudaCheckpointLaunchJob([]string{"/bin/true"}, nil)
+	container := &corev1.Container{Command: []string{"/bin/true"}}
+	if err := podcontract.EnsureCUDACheckpointLaunchJob(container, "cuda-checkpoint"); err != nil {
+		t.Fatal(err)
+	}
+	args := container.Args
 	cmd := exec.Command(args[1], args[2:]...)
 	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

Layer 2 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293). Closed PR #214 is intentionally not in the active stack.

This PR applies the CUDA launch-job requirement where Snapshot shapes source Pods and makes the required binaries available at stable paths. It does not opt a workload into cuinterpose.

`ShapeCUDATools` creates one `snapshot-cuda` `emptyDir`, runs an init container from the configured Snapshot agent image, copies `cuda-checkpoint` and `libcuinterpose.so`, and mounts both tools read-only at `/tmp/snapshot-cuda` in every target container. Tool delivery is unconditional for Snapshot targets and is independent of cuinterpose opt-in.

Only a target that may use more than one GPU has its command rewritten under:

```text
/tmp/snapshot-cuda/cuda-checkpoint --launch-job ...
```

The CUDA job file is persisted in Snapshot's control volume. The operator counts `nvidia.com/gpu` resources and referenced DRA claims; indeterminate claim sizes are conservatively treated as multi-GPU because unnecessary wrapping is harmless while missing it causes a late capture failure. Existing source Jobs are verified for universal tool delivery and, where required, the launch wrapper before adoption.

Delivery and interposition remain separate. The mounted shim is inert until #222 puts it in `LD_PRELOAD`; opting into cuinterpose does not change the GPU-count-based launch rule.

The `snapshot-control` volume, `/snapshot-control` mount, and canonical and legacy control-directory variables are reserved. If a workload predefines them, source shaping accepts only one `emptyDir`, one exact writable `subPath=<container-name>` mount, and literal `/snapshot-control` variable values. PVC, `hostPath`, alternate-volume, broad-mount, read-only, duplicate, and `valueFrom` collisions are rejected atomically. This matches restore-side fail-closed validation and prevents the coordinator socket directory from becoming cross-Pod storage.

At capture, the manifest records `cudaTools.delivered`. Restore recreates `/tmp/snapshot-cuda` before CRIU by using the fixed `ns-bind-mount` role, allowing CRIU to reopen the launch wrapper and shim at their original file-backed paths.

## Stack boundary

Based on #212. #222 adds explicit Pod opt-in and preloads the shim. This PR does not create control sockets, run the coordinator, or track CUDA state.

## Validation

On the final stack, `make test` passes in `api`, `agent`, and `operator`. The source-shaping tests cover the exact reserved-volume contract and atomic rejection of unsafe collisions. The pinned CUDA 13.1 builder compiles the production binaries and passes all cuinterpose fake-driver suites. The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its physical-GPU suite passed all 3 tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.




