### PR TITLE
feat(agent): orchestrate the cuinterpose coordinator around checkpoint and restore

### DIFF
--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -585,18 +585,23 @@ func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *
 func (w *NodeController) executorCheckpoint(ctx context.Context, params CheckpointParams) error {
 	log := logr.FromContextOrDiscard(ctx)
 
+	cuinterposeRequested, err := podcontract.CuinterposeEnabled(params.Pod.Annotations)
+	if err != nil {
+		return fmt.Errorf("source pod %s/%s: %w", params.Pod.Namespace, params.Pod.Name, err)
+	}
 	req := executor.CheckpointRequest{
-		ContainerID:         params.ContainerID,
-		ContainerName:       params.ContainerName,
-		ContentUID:          params.ContentUID,
-		StartedAt:           params.StartedAt,
-		NodeName:            w.config.NodeName,
-		PodName:             params.Pod.Name,
-		PodNamespace:        params.Pod.Namespace,
-		PodIP:               params.Pod.Status.PodIP,
-		Clientset:           w.clientset,
-		PageBrokerRequested: params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
-		CUDAToolsDelivered:  podcontract.CUDAToolsDelivered(&params.Pod.Spec, params.ContainerName),
+		ContainerID:          params.ContainerID,
+		ContainerName:        params.ContainerName,
+		ContentUID:           params.ContentUID,
+		StartedAt:            params.StartedAt,
+		NodeName:             w.config.NodeName,
+		PodName:              params.Pod.Name,
+		PodNamespace:         params.Pod.Namespace,
+		PodIP:                params.Pod.Status.PodIP,
+		Clientset:            w.clientset,
+		PageBrokerRequested:  params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
+		CUDAToolsDelivered:   podcontract.CUDAToolsDelivered(&params.Pod.Spec, params.ContainerName),
+		CuinterposeRequested: cuinterposeRequested,
 	}
 	if err := executor.Checkpoint(ctx, w.runtime, log, req, w.config); err != nil {
 		if executor.CheckpointNeedsSourceKill(err) {

--- a/agent/internal/cuda/cuinterpose.go
+++ b/agent/internal/cuda/cuinterpose.go
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+)
+
+// cuinterpose is the CUDA interposer shim (agent/cmd/cuinterpose). Each CUDA
+// process running it listens on a Unix socket under the pod's snapshot control
+// directory. The agent never talks to those sockets itself; it runs the
+// cuinterpose-coordinator binary, which does, once before the native CUDA
+// checkpoint (prepare) and once after the native CUDA restore (restore).
+//
+// The string constants below mirror agent/cmd/cuinterpose/protocol.h; a test
+// checks they agree.
+const (
+	// CoordinatorBinaryName is the cuinterpose-coordinator executable name.
+	CoordinatorBinaryName = "cuinterpose-coordinator"
+	// DefaultCoordinatorBinaryPath is where the agent image installs the
+	// coordinator, used for prepare. Restore runs inside the restored
+	// container's mount namespace, which does not contain the agent bundle, so
+	// that call site passes a /proc/self/fd path opened before CRIU ran.
+	DefaultCoordinatorBinaryPath = "/usr/local/bin/" + CoordinatorBinaryName
+	// CuinterposeStateFile is the topology sidecar the coordinator writes into
+	// the checkpoint directory during prepare and reads during restore.
+	CuinterposeStateFile = "cuinterpose.state"
+
+	cuinterposeSocketPrefix = "cuinterpose-"
+	cuinterposeSocketSuffix = ".sock"
+	coordinatorReportPrefix = "cuinterpose-coordinator "
+)
+
+// cuinterposeEndpointPath is the shim's control socket for one CUDA process,
+// reached through the host's /proc mount: <procRoot>/<pid>/root is the
+// process's own root filesystem.
+func cuinterposeEndpointPath(procRoot string, observedPID, namespacePID int) string {
+	return filepath.Join(
+		procRoot,
+		strconv.Itoa(observedPID),
+		"root",
+		strings.TrimPrefix(podcontract.SnapshotControlMountPath, string(os.PathSeparator)),
+		cuinterposeSocketName(namespacePID),
+	)
+}
+
+func cuinterposeSocketName(namespacePID int) string {
+	return fmt.Sprintf("%s%d%s", cuinterposeSocketPrefix, namespacePID, cuinterposeSocketSuffix)
+}
+
+// DetectCuinterpose reports whether the live CUDA processes run the shim. The
+// signal is the shim's control socket, one per CUDA process, not the process
+// environment: Python's setproctitle (vLLM, SGLang) overwrites what /proc
+// shows as the environment while the sockets remain. No sockets at all means
+// the workload is not interposed and is checkpointed natively. Some but not
+// all sockets, or a non-socket file in a socket's place, is an error: a
+// half-interposed process tree cannot be checkpointed consistently.
+func DetectCuinterpose(procRoot string, observedPIDs, namespacePIDs []int) (bool, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return false, fmt.Errorf(
+			"cuinterpose PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return false, nil
+	}
+	valid := 0
+	seen := 0
+	for index, observedPID := range observedPIDs {
+		endpoint := cuinterposeEndpointPath(procRoot, observedPID, namespacePIDs[index])
+		info, err := os.Lstat(endpoint)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("stat cuinterpose endpoint %q: %w", endpoint, err)
+		}
+		seen++
+		if info.Mode()&os.ModeSocket != 0 {
+			valid++
+		}
+	}
+	if seen == 0 {
+		return false, nil
+	}
+	if valid != len(observedPIDs) {
+		return false, fmt.Errorf(
+			"cuinterpose endpoint missing or invalid for %d of %d CUDA processes",
+			len(observedPIDs)-valid,
+			len(observedPIDs),
+		)
+	}
+	return true, nil
+}
+
+// CheckCuinterposeEnablement is the rule for what the Pod asked for versus what
+// the CUDA processes are running. Both disagreements are refused:
+//
+//   - requested but no process exposes a socket: the shim never loaded (wrong
+//     path, glibc too old, LD_PRELOAD stripped). A native checkpoint would look
+//     fine and restore with stale sharing, so it must not be taken.
+//   - not requested but sockets are present: something other than Snapshot
+//     preloaded the shim; the restore side would not mount it.
+//
+// With no CUDA processes there is nothing to interpose and nothing to check.
+func CheckCuinterposeEnablement(requested, detected bool, cudaProcesses int) error {
+	if cudaProcesses == 0 {
+		return nil
+	}
+	if requested && !detected {
+		return fmt.Errorf(
+			"cuinterpose was requested (%s) but no CUDA process exposes a control socket; the shim did not load, refusing to checkpoint without it",
+			podcontract.CuinterposeAnnotation)
+	}
+	if !requested && detected {
+		return fmt.Errorf(
+			"CUDA processes run the cuinterpose shim but the source Pod did not request it (%s); restore would not mount the shim",
+			podcontract.CuinterposeAnnotation)
+	}
+	return nil
+}
+
+// HasCuinterposeState reports whether the checkpoint directory holds the
+// coordinator's state file.
+func HasCuinterposeState(checkpointDir string) (bool, error) {
+	_, err := os.Stat(filepath.Join(checkpointDir, CuinterposeStateFile))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// RemoveStaleCuinterposeSockets deletes leftover shim sockets from an earlier
+// incarnation of the pod. Each shim binds its socket by namespace PID, and
+// CRIU recreates the checkpointed process with the same namespace PID, so a
+// stale file at that path makes the restored bind() fail. Called inside the
+// container's mount namespace before CRIU runs. Returns how many were removed.
+func RemoveStaleCuinterposeSockets(controlDir string) (int, error) {
+	entries, err := os.ReadDir(controlDir)
+	if err != nil {
+		return 0, fmt.Errorf("list cuinterpose control directory %s: %w", controlDir, err)
+	}
+	removed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, cuinterposeSocketPrefix) || !strings.HasSuffix(name, cuinterposeSocketSuffix) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(controlDir, name)); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("remove stale cuinterpose socket %s: %w", name, err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// CoordinatorPhase is one progress line the coordinator printed:
+// "cuinterpose-coordinator phase=<name> status=ok key=value ...".
+type CoordinatorPhase struct {
+	Phase  string
+	Fields map[string]string
+}
+
+// PrepareCuinterpose runs the coordinator against the live CUDA processes,
+// through the host's /proc mount, before the native CUDA checkpoint. On
+// success the coordinator has written CuinterposeStateFile into checkpointDir.
+// There is no undo: once prepare has torn down shared mappings the source
+// workload can only continue by being restored, so a later checkpoint failure
+// is fail-stop for the source (the caller terminates it).
+func PrepareCuinterpose(
+	ctx context.Context,
+	checkpointDir string,
+	procRoot string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) ([]CoordinatorPhase, error) {
+	args, err := cuinterposeArgs("prepare", checkpointDir, procRoot, podcontract.SnapshotControlMountPath, observedPIDs, namespacePIDs)
+	if err != nil {
+		return nil, err
+	}
+	return runCoordinator(ctx, coordinatorBinaryPath, args, log)
+}
+
+// RestoreCuinterpose runs the coordinator inside the restored container's
+// mount namespace after the native CUDA restore, so procRoot is empty and the
+// control sockets are addressed directly under the control directory.
+func RestoreCuinterpose(
+	ctx context.Context,
+	checkpointDir string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) ([]CoordinatorPhase, error) {
+	args, err := cuinterposeArgs("restore", checkpointDir, "", podcontract.SnapshotControlMountPath, observedPIDs, namespacePIDs)
+	if err != nil {
+		return nil, err
+	}
+	return runCoordinator(ctx, coordinatorBinaryPath, args, log)
+}
+
+func runCoordinator(ctx context.Context, binary string, args []string, log logr.Logger) ([]CoordinatorPhase, error) {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	phases := parseCoordinatorReports(stdout.String())
+	for _, phase := range phases {
+		values := make([]any, 0, 2+2*len(phase.Fields))
+		values = append(values, "operation", args[0], "phase", phase.Phase)
+		for key, value := range phase.Fields {
+			values = append(values, key, value)
+		}
+		log.Info("cuinterpose coordinator phase", values...)
+	}
+	if runErr != nil {
+		completed := make([]string, 0, len(phases))
+		for _, phase := range phases {
+			completed = append(completed, phase.Phase)
+		}
+		return phases, fmt.Errorf(
+			"%s %s failed: %w (completed phases: %s; stderr: %s)",
+			binary, args[0], runErr,
+			strings.Join(completed, ","),
+			strings.TrimSpace(stderr.String()),
+		)
+	}
+	return phases, nil
+}
+
+// parseCoordinatorReports extracts progress lines from the coordinator's
+// stdout; anything else on stdout is ignored.
+func parseCoordinatorReports(output string) []CoordinatorPhase {
+	var phases []CoordinatorPhase
+	for _, line := range strings.Split(output, "\n") {
+		if phase, ok := parseCoordinatorReport(line); ok {
+			phases = append(phases, phase)
+		}
+	}
+	return phases
+}
+
+func parseCoordinatorReport(line string) (CoordinatorPhase, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, coordinatorReportPrefix) {
+		return CoordinatorPhase{}, false
+	}
+	phase := CoordinatorPhase{Fields: map[string]string{}}
+	for _, field := range strings.Fields(strings.TrimPrefix(line, coordinatorReportPrefix)) {
+		key, value, found := strings.Cut(field, "=")
+		if !found {
+			continue
+		}
+		if key == "phase" {
+			phase.Phase = value
+			continue
+		}
+		phase.Fields[key] = value
+	}
+	if phase.Phase == "" {
+		return CoordinatorPhase{}, false
+	}
+	return phase, true
+}
+
+func cuinterposeArgs(operation, checkpointDir, procRoot, controlDir string, observedPIDs, namespacePIDs []int) ([]string, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return nil, fmt.Errorf(
+			"cuinterpose PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return nil, errors.New("cuinterpose coordinator requires at least one CUDA process")
+	}
+	args := []string{
+		"--" + operation,
+		"--proc-root", procRoot,
+		"--checkpoint-dir", checkpointDir,
+		"--control-dir", controlDir,
+	}
+	for index, observedPID := range observedPIDs {
+		args = append(args, "--process", strconv.Itoa(observedPID), strconv.Itoa(namespacePIDs[index]))
+	}
+	return args, nil
+}

--- a/agent/internal/cuda/cuinterpose_test.go
+++ b/agent/internal/cuda/cuinterpose_test.go
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+)
+
+func TestDetectCuinterpose(t *testing.T) {
+	cases := map[string]struct {
+		setup        func(t *testing.T, procRoot string)
+		pids, nsPIDs []int
+		want         bool
+		wantErr      bool
+	}{
+		"no CUDA processes": {},
+		"pid list mismatch": {pids: []int{101}, wantErr: true},
+		"no sockets": {
+			setup: func(t *testing.T, root string) { mustControlDir(t, root, 101, 1) },
+			pids:  []int{101, 102}, nsPIDs: []int{1, 2},
+		},
+		"procfs environ is not evidence": {
+			setup: func(t *testing.T, root string) {
+				mustControlDir(t, root, 101, 1)
+				mustEnviron(t, root, 101, "LD_PRELOAD="+podcontract.CuinterposeLibraryPath+"\x00")
+			},
+			pids: []int{101}, nsPIDs: []int{1},
+		},
+		"one of two sockets missing": {
+			setup: func(t *testing.T, root string) { listenUnix(t, cuinterposeEndpointPath(root, 101, 1)) },
+			pids:  []int{101, 102}, nsPIDs: []int{1, 2}, wantErr: true,
+		},
+		"every process has a socket": {
+			setup: func(t *testing.T, root string) {
+				listenUnix(t, cuinterposeEndpointPath(root, 101, 1))
+				listenUnix(t, cuinterposeEndpointPath(root, 102, 2))
+			},
+			pids: []int{101, 102}, nsPIDs: []int{1, 2}, want: true,
+		},
+		"endpoint is not a socket": {
+			setup: func(t *testing.T, root string) {
+				listenUnix(t, cuinterposeEndpointPath(root, 101, 1))
+				path := cuinterposeEndpointPath(root, 102, 2)
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("not a socket"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			pids: []int{101, 102}, nsPIDs: []int{1, 2}, wantErr: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			procRoot := shortTempDir(t)
+			if tc.setup != nil {
+				tc.setup(t, procRoot)
+			}
+			got, err := DetectCuinterpose(procRoot, tc.pids, tc.nsPIDs)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("DetectCuinterpose() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("DetectCuinterpose() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasCuinterposeState(t *testing.T) {
+	checkpointDir := t.TempDir()
+	present, err := HasCuinterposeState(checkpointDir)
+	if err != nil || present {
+		t.Fatalf("HasCuinterposeState() = %v, %v for a missing file", present, err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, CuinterposeStateFile), []byte("state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	present, err = HasCuinterposeState(checkpointDir)
+	if err != nil || !present {
+		t.Fatalf("HasCuinterposeState() = %v, %v, want true", present, err)
+	}
+}
+
+func TestRemoveStaleCuinterposeSockets(t *testing.T) {
+	control := shortTempDir(t)
+	listenUnix(t, filepath.Join(control, cuinterposeSocketName(7)))
+	listenUnix(t, filepath.Join(control, cuinterposeSocketName(8)))
+	for _, keep := range []string{"restore-complete", "cuda-checkpoint-job", "other-1.sock"} {
+		if err := os.WriteFile(filepath.Join(control, keep), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, err := RemoveStaleCuinterposeSockets(control)
+	if err != nil {
+		t.Fatalf("RemoveStaleCuinterposeSockets() error = %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed %d, want 2", removed)
+	}
+	entries, _ := os.ReadDir(control)
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if strings.Join(names, ",") != "cuda-checkpoint-job,other-1.sock,restore-complete" {
+		t.Fatalf("unexpected leftovers: %v", names)
+	}
+	if _, err := RemoveStaleCuinterposeSockets(filepath.Join(control, "missing")); err == nil {
+		t.Fatal("a missing control directory must be an error, not a silent no-op")
+	}
+}
+
+func TestParseCoordinatorReport(t *testing.T) {
+	phase, ok := parseCoordinatorReport("cuinterpose-coordinator phase=save_host_carrier status=ok elapsed_ms=12.5 participants=8 carrier_count=3 carrier_bytes=1610612736 gb_per_s=41.20")
+	if !ok || phase.Phase != "save_host_carrier" {
+		t.Fatalf("parse = %+v, %v", phase, ok)
+	}
+	if phase.Fields["carrier_bytes"] != "1610612736" || phase.Fields["gb_per_s"] != "41.20" || phase.Fields["status"] != "ok" {
+		t.Fatalf("fields = %v", phase.Fields)
+	}
+	for _, junk := range []string{"", "prepare failed: participant inspect", "cuinterpose-coordinator status=ok", "phase=inspect"} {
+		if _, ok := parseCoordinatorReport(junk); ok {
+			t.Fatalf("parsed %q as a report", junk)
+		}
+	}
+}
+
+// A shell script standing in for the coordinator: records its argv, prints
+// two progress lines, and exits as told.
+func fakeCoordinator(t *testing.T, exitCode int) (binary, argvFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	argvFile = filepath.Join(dir, "argv")
+	binary = filepath.Join(dir, "coordinator.sh")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > " + argvFile + "\n" +
+		"echo 'cuinterpose-coordinator phase=inspect status=ok elapsed_ms=1.0 participants=2 records=4'\n" +
+		"echo 'not a report line'\n" +
+		"echo 'cuinterpose-coordinator phase=validate status=ok elapsed_ms=0.2 participants=2'\n" +
+		"echo 'prepare failed: participant prepare' >&2\n" +
+		"exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(binary, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return binary, argvFile
+}
+
+func TestCoordinatorArgvContractAndReports(t *testing.T) {
+	binary, argvFile := fakeCoordinator(t, 0)
+	phases, err := PrepareCuinterpose(context.Background(), "/checkpoints/x", "/host/proc", []int{4242, 4243}, []int{7, 9}, binary, testr.New(t))
+	if err != nil {
+		t.Fatalf("PrepareCuinterpose() error = %v", err)
+	}
+	argv, _ := os.ReadFile(argvFile)
+	want := strings.Join([]string{
+		"--prepare", "--proc-root", "/host/proc", "--checkpoint-dir", "/checkpoints/x",
+		"--control-dir", podcontract.SnapshotControlMountPath,
+		"--process", "4242", "7", "--process", "4243", "9", "",
+	}, "\n")
+	if string(argv) != want {
+		t.Fatalf("argv:\n%s\nwant:\n%s", argv, want)
+	}
+	if len(phases) != 2 || phases[0].Phase != "inspect" || phases[1].Phase != "validate" || phases[0].Fields["records"] != "4" {
+		t.Fatalf("phases = %+v", phases)
+	}
+
+	// Restore runs inside the restored mount namespace: no proc root.
+	binary, argvFile = fakeCoordinator(t, 0)
+	if _, err := RestoreCuinterpose(context.Background(), "/tmp/checkpoint", []int{100}, []int{1}, binary, logr.Discard()); err != nil {
+		t.Fatalf("RestoreCuinterpose() error = %v", err)
+	}
+	argv, _ = os.ReadFile(argvFile)
+	if !strings.HasPrefix(string(argv), "--restore\n--proc-root\n\n--checkpoint-dir\n/tmp/checkpoint\n--control-dir\n"+podcontract.SnapshotControlMountPath+"\n") {
+		t.Fatalf("restore argv:\n%s", argv)
+	}
+}
+
+func TestCoordinatorFailureReportsStderrAndCompletedPhases(t *testing.T) {
+	binary, _ := fakeCoordinator(t, 3)
+	phases, err := PrepareCuinterpose(context.Background(), "/c", "/p", []int{1}, []int{1}, binary, logr.Discard())
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if len(phases) != 2 {
+		t.Fatalf("phases before failure = %d, want 2", len(phases))
+	}
+	for _, want := range []string{"exit status 3", "completed phases: inspect,validate", "prepare failed: participant prepare"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q lacks %q", err, want)
+		}
+	}
+}
+
+func TestCuinterposeArgsRejectsEmptyOrMismatchedPIDs(t *testing.T) {
+	if _, err := cuinterposeArgs("prepare", "/c", "/p", "/snapshot-control", nil, nil); err == nil {
+		t.Fatal("no processes must be an error")
+	}
+	if _, err := cuinterposeArgs("prepare", "/c", "/p", "/snapshot-control", []int{1, 2}, []int{1}); err == nil {
+		t.Fatal("mismatched PID lists must be an error")
+	}
+}
+
+// The Go constants and the coordinator's command line mirror the C sources.
+// This test reads them so a rename on one side cannot silently turn
+// interposition off.
+func TestGoConstantsMatchTheCSources(t *testing.T) {
+	protocol, err := os.ReadFile(filepath.Join("..", "..", "cmd", "cuinterpose", "protocol.h"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator, err := os.ReadFile(filepath.Join("..", "..", "cmd", "cuinterpose", "coordinator.c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	define := func(name string) string {
+		match := regexp.MustCompile(`(?m)^#define ` + name + ` "([^"]*)"`).FindSubmatch(protocol)
+		if match == nil {
+			t.Fatalf("protocol.h lacks #define %s", name)
+		}
+		return string(match[1])
+	}
+	if got := define("CUINTERPOSE_SOCKET_PREFIX"); got != cuinterposeSocketPrefix {
+		t.Errorf("socket prefix: C %q, Go %q", got, cuinterposeSocketPrefix)
+	}
+	if got := define("CUINTERPOSE_STATE_FILENAME"); got != CuinterposeStateFile {
+		t.Errorf("state file: C %q, Go %q", got, CuinterposeStateFile)
+	}
+	if got := define("CUINTERPOSE_CONTROL_DIR"); got != podcontract.SnapshotControlMountPath {
+		t.Errorf("control dir: C %q, podcontract %q", got, podcontract.SnapshotControlMountPath)
+	}
+	if got := define("CUINTERPOSE_CONTROL_DIR_ENV"); got != podcontract.SnapshotControlDirEnv {
+		t.Errorf("control dir env: C %q, podcontract %q", got, podcontract.SnapshotControlDirEnv)
+	}
+	if strings.Contains(string(coordinator), "this build carries no coordinator") {
+		t.Log("coordinator.c is the packaging placeholder; the argument contract is pinned once the coordinator lands")
+		return
+	}
+	for _, flag := range []string{"--prepare", "--restore", "--proc-root", "--checkpoint-dir", "--control-dir", "--process"} {
+		if !strings.Contains(string(coordinator), `"`+flag+`"`) {
+			t.Errorf("coordinator.c does not parse %s", flag)
+		}
+	}
+	if !strings.Contains(string(coordinator), `"cuinterpose-coordinator phase=%s status=ok`) {
+		t.Error("coordinator.c progress line format changed; update parseCoordinatorReport")
+	}
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	// Unix socket paths are limited to 108 bytes; t.TempDir() paths are long.
+	dir, err := os.MkdirTemp("", "cui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func mustControlDir(t *testing.T, procRoot string, observedPID, namespacePID int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(cuinterposeEndpointPath(procRoot, observedPID, namespacePID)), 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustEnviron(t *testing.T, procRoot string, observedPID int, content string) {
+	t.Helper()
+	path := filepath.Join(procRoot, strconv.Itoa(observedPID), "environ")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listenUnix(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+}
+
+func TestCheckCuinterposeEnablement(t *testing.T) {
+	cases := []struct {
+		requested, detected bool
+		cuda                int
+		wantErr             bool
+	}{
+		{false, false, 0, false},
+		{true, false, 0, false}, // no CUDA processes: nothing to interpose
+		{false, false, 4, false},
+		{true, true, 4, false},
+		{true, false, 4, true}, // asked for, shim never loaded
+		{false, true, 4, true}, // shim present without the opt-in
+	}
+	for _, tc := range cases {
+		err := CheckCuinterposeEnablement(tc.requested, tc.detected, tc.cuda)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("CheckCuinterposeEnablement(%v, %v, %d) = %v, wantErr %v", tc.requested, tc.detected, tc.cuda, err, tc.wantErr)
+		}
+	}
+}

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -59,12 +59,16 @@ type CheckpointRequest struct {
 	// CUDA tools (podcontract.CUDAToolsDelivered); recorded in the manifest so
 	// restore mounts them at the same path.
 	CUDAToolsDelivered bool
+	// CuinterposeRequested is the source Pod's nvidia.com/cuinterpose opt-in.
+	// Detection is checked against it and it is recorded in the manifest.
+	CuinterposeRequested bool
 }
 
 type checkpointPhaseTimings struct {
-	CUDACheckpointDuration time.Duration
-	CRIUDumpDuration       time.Duration
-	OverlayCaptureDuration time.Duration
+	CuinterposePrepareDuration time.Duration
+	CUDACheckpointDuration     time.Duration
+	CRIUDumpDuration           time.Duration
+	OverlayCaptureDuration     time.Duration
 }
 
 // Checkpoint performs a CRIU dump of a container.
@@ -162,6 +166,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	wall := time.Since(checkpointStart)
 	unaccounted := remainingDuration(wall,
 		gpuDeviceMapDuration,
+		captureTimings.CuinterposePrepareDuration,
 		captureTimings.CUDACheckpointDuration,
 		captureTimings.CRIUDumpDuration,
 		captureTimings.OverlayCaptureDuration,
@@ -171,6 +176,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 		"duration": wall.String(),
 		"phases": map[string]string{
 			"gpu_device_map":                gpuDeviceMapDuration.String(),
+			"cuinterpose_prepare":           captureTimings.CuinterposePrepareDuration.String(),
 			"cuda_checkpoint":               captureTimings.CUDACheckpointDuration.String(),
 			"criu_dump":                     captureTimings.CRIUDumpDuration.String(),
 			"overlay_capture":               captureTimings.OverlayCaptureDuration.String(),
@@ -247,6 +253,13 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	if len(cudaHostPIDs) > 0 {
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
+	cuinterpose, err := cuda.DetectCuinterpose(snapshotruntime.HostProcPath, cudaHostPIDs, cudaNamespacePIDs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("detect cuinterpose: %w", err)
+	}
+	if err := cuda.CheckCuinterposeEnablement(req.CuinterposeRequested, cuinterpose, len(cudaHostPIDs)); err != nil {
+		return nil, 0, err
+	}
 	var gpuUUIDs []string
 	var gpuDeviceMapDuration time.Duration
 	if len(cudaHostPIDs) > 0 {
@@ -279,6 +292,7 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		CUDAHostPIDs:   cudaHostPIDs,
 		CUDANSPIDs:     cudaNamespacePIDs,
 		GPUUUIDs:       gpuUUIDs,
+		Cuinterpose:    cuinterpose,
 	}, gpuDeviceMapDuration, nil
 }
 
@@ -305,6 +319,7 @@ func configureCheckpoint(
 		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs)
 	}
 	m.CUDATools.Delivered = req.CUDAToolsDelivered
+	m.Cuinterpose.Requested = req.CuinterposeRequested
 
 	if err := types.WriteManifest(checkpointDir, m); err != nil {
 		return nil, nil, fmt.Errorf("failed to write checkpoint manifest: %w", err)
@@ -318,6 +333,30 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 
 	// CUDA lock+checkpoint must happen before CRIU dump
 	if len(state.CUDAHostPIDs) > 0 {
+		if state.Cuinterpose {
+			// Prepare runs on the live workload before the native CUDA lock: it
+			// tears down shared mappings so the native checkpoint sees plain
+			// memory. There is no rollback; if anything after this fails the
+			// caller terminates the source (checkpointNeedsSourceKill).
+			prepareStart := time.Now()
+			_, err := cuda.PrepareCuinterpose(
+				ctx,
+				checkpointDir,
+				snapshotruntime.HostProcPath,
+				state.CUDAHostPIDs,
+				state.CUDANSPIDs,
+				cuda.DefaultCoordinatorBinaryPath,
+				log,
+			)
+			timings.CuinterposePrepareDuration = time.Since(prepareStart)
+			if err != nil {
+				return nil, fmt.Errorf("prepare cuinterpose: %w", err)
+			}
+			data.Cuinterpose.Prepared = true
+			if err := types.WriteManifest(checkpointDir, data); err != nil {
+				return nil, fmt.Errorf("record cuinterpose prepare in checkpoint manifest: %w", err)
+			}
+		}
 		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -38,6 +38,9 @@ type RestoreInNamespaceResult struct {
 	CRIUPrepareDuration    time.Duration `json:"criuPrepareDuration"`
 	CRIURestoreDuration    time.Duration `json:"criuRestoreDuration"`
 	CUDARestoreDuration    time.Duration `json:"cudaRestoreDuration"`
+	// CuinterposeRestoreDuration is the coordinator's restore step, which runs
+	// after the native CUDA restore and rebuilds shared memory topology.
+	CuinterposeRestoreDuration time.Duration `json:"cuinterposeRestoreDuration"`
 }
 
 // CleanupError is the wire representation of a successful restore whose
@@ -94,11 +97,12 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	}
 
 	result := &RestoreInNamespaceResult{
-		RestoredPID:            restoredPID,
-		OverlayCaptureDuration: executeTimings.overlayCaptureDuration,
-		CRIUPrepareDuration:    executeTimings.criuPrepareDuration,
-		CRIURestoreDuration:    executeTimings.criuRestoreDuration,
-		CUDARestoreDuration:    executeTimings.cudaRestoreDuration,
+		RestoredPID:                restoredPID,
+		OverlayCaptureDuration:     executeTimings.overlayCaptureDuration,
+		CRIUPrepareDuration:        executeTimings.criuPrepareDuration,
+		CRIURestoreDuration:        executeTimings.criuRestoreDuration,
+		CUDARestoreDuration:        executeTimings.cudaRestoreDuration,
+		CuinterposeRestoreDuration: executeTimings.cuinterposeRestoreDuration,
 	}
 	if cleanupErr != nil {
 		result.CleanupError = &CleanupError{
@@ -110,10 +114,11 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 }
 
 type nsrestorePhaseTimings struct {
-	overlayCaptureDuration time.Duration
-	criuPrepareDuration    time.Duration
-	criuRestoreDuration    time.Duration
-	cudaRestoreDuration    time.Duration
+	overlayCaptureDuration     time.Duration
+	criuPrepareDuration        time.Duration
+	criuRestoreDuration        time.Duration
+	cudaRestoreDuration        time.Duration
+	cuinterposeRestoreDuration time.Duration
 }
 
 func executeRestore(
@@ -168,6 +173,7 @@ func executeRestore(
 	// opening the binary now and exec'ing via /proc/self/fd/N after CRIU returns,
 	// the fd remains valid even if the mount is gone.
 	var cudaHelperFdPath string
+	var coordinatorFdPath string
 	if !m.CUDA.IsEmpty() {
 		helperPath := filepath.Join(opts.BundleDir, cuda.HelperBinaryName)
 		f, err := os.Open(helperPath)
@@ -177,6 +183,17 @@ func executeRestore(
 		defer f.Close()
 		cudaHelperFdPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
 	}
+	if m.Cuinterpose.Prepared {
+		if err := requireCuinterposeState(m, opts.CheckpointPath); err != nil {
+			return nil, 0, nil, err
+		}
+		coordinator, err := os.Open(filepath.Join(opts.BundleDir, cuda.CoordinatorBinaryName))
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("failed to open %s before CRIU restore: %w", cuda.CoordinatorBinaryName, err)
+		}
+		defer coordinator.Close()
+		coordinatorFdPath = fmt.Sprintf("/proc/self/fd/%d", coordinator.Fd())
+	}
 
 	// The restore-complete sentinel lives on the pod emptyDir mounted at
 	// SnapshotControlMountPath. Clear it here, in that mount namespace, so a
@@ -185,6 +202,18 @@ func executeRestore(
 	// a missing mount is a hard error.
 	if err := snapshotruntime.RemoveControlSentinel(podcontract.SnapshotControlMountPath, podcontract.RestoreCompleteFile); err != nil {
 		return nil, 0, nil, fmt.Errorf("remove stale restore-complete sentinel: %w", err)
+	}
+	if m.Cuinterpose.Requested {
+		// The shim binds its control socket by namespace PID, which CRIU
+		// reproduces exactly; a socket file left by an earlier incarnation of
+		// this pod (agent restart, replaced container) would make that bind fail.
+		removed, err := cuda.RemoveStaleCuinterposeSockets(podcontract.SnapshotControlMountPath)
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("remove stale cuinterpose sockets: %w", err)
+		}
+		if removed > 0 {
+			log.Info("Removed stale cuinterpose control sockets before restore", "count", removed)
+		}
 	}
 
 	criuPID, cleanup, prepare, restore, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, opts.BundleDir, log)
@@ -253,7 +282,42 @@ func executeRestore(
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("CUDA restore failed: %w", err)
 		}
+		if m.Cuinterpose.Prepared {
+			// The driver is unlocked so the shims can issue CUDA calls, but the
+			// application itself is still parked in its restore-complete poll
+			// loop, so nothing else touches the shared memory while the
+			// coordinator rebuilds it.
+			cuinterposeStart := time.Now()
+			_, err := cuda.RestoreCuinterpose(ctx, opts.CheckpointPath, restorePIDs, m.CUDA.PIDs, coordinatorFdPath, log)
+			timings.cuinterposeRestoreDuration = time.Since(cuinterposeStart)
+			if err != nil {
+				return nil, 0, nil, fmt.Errorf("restore cuinterpose: %w", err)
+			}
+		}
 	}
 
 	return timings, restoredPID, nil, nil
+}
+
+// requireCuinterposeState checks that a checkpoint whose manifest records a
+// cuinterpose prepare also carries the coordinator's state file. Without it
+// the shims inside the restored processes would stay frozen mid-checkpoint
+// forever, so restoring such an artifact is refused up front.
+func requireCuinterposeState(m *types.CheckpointManifest, checkpointPath string) error {
+	if !m.Cuinterpose.Prepared {
+		return nil
+	}
+	if m.CUDA.IsEmpty() {
+		return fmt.Errorf("checkpoint manifest records a cuinterpose prepare but no CUDA processes")
+	}
+	hasState, err := cuda.HasCuinterposeState(checkpointPath)
+	if err != nil {
+		return fmt.Errorf("stat cuinterpose state: %w", err)
+	}
+	if !hasState {
+		return fmt.Errorf(
+			"checkpoint manifest records a cuinterpose prepare but %s is missing from %s; the artifact is incomplete",
+			cuda.CuinterposeStateFile, checkpointPath)
+	}
+	return nil
 }

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -220,19 +220,21 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		result.CRIUPrepareDuration,
 		result.CRIURestoreDuration,
 		result.CUDARestoreDuration,
+		result.CuinterposeRestoreDuration,
 	)
 	summary := map[string]any{
 		"duration": wall.String(),
 		"phases": map[string]string{
-			"pagebroker_stage":  pageBrokerStageDuration.String(),
-			"pagebroker_mount":  pageBrokerMountDuration.String(),
-			"pagebroker_commit": pageBrokerCommitDuration.String(),
-			"gpu_device_map":    gpuDeviceMapDuration.String(),
-			"overlay_capture":   result.OverlayCaptureDuration.String(),
-			"criu_prepare":      result.CRIUPrepareDuration.String(),
-			"criu_restore":      result.CRIURestoreDuration.String(),
-			"cuda_restore":      result.CUDARestoreDuration.String(),
-			"unaccounted":       unaccounted.String(),
+			"pagebroker_stage":    pageBrokerStageDuration.String(),
+			"pagebroker_mount":    pageBrokerMountDuration.String(),
+			"pagebroker_commit":   pageBrokerCommitDuration.String(),
+			"gpu_device_map":      gpuDeviceMapDuration.String(),
+			"overlay_capture":     result.OverlayCaptureDuration.String(),
+			"criu_prepare":        result.CRIUPrepareDuration.String(),
+			"criu_restore":        result.CRIURestoreDuration.String(),
+			"cuda_restore":        result.CUDARestoreDuration.String(),
+			"cuinterpose_restore": result.CuinterposeRestoreDuration.String(),
+			"unaccounted":         unaccounted.String(),
 		},
 	}
 	if !req.StartedAt.IsZero() {

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
@@ -270,5 +271,30 @@ func TestMountRestoreInputsReturnsEarlierMountsOnFailure(t *testing.T) {
 	}
 	if len(mounted) != 1 || mounted[0].action != "unmount CUDA tools from placeholder" {
 		t.Fatalf("earlier mounts must be returned for cleanup, got %+v", mounted)
+	}
+}
+
+func TestRequireCuinterposeState(t *testing.T) {
+	dir := t.TempDir()
+	plain := &types.CheckpointManifest{}
+	if err := requireCuinterposeState(plain, dir); err != nil {
+		t.Fatalf("a checkpoint without cuinterpose needs no state file: %v", err)
+	}
+	prepared := &types.CheckpointManifest{
+		CUDA:        types.NewCUDAManifest([]int{1}, nil),
+		Cuinterpose: types.CuinterposeManifest{Requested: true, Prepared: true},
+	}
+	if err := requireCuinterposeState(prepared, dir); err == nil {
+		t.Fatal("a prepared checkpoint without its state file must be refused")
+	}
+	if err := os.WriteFile(dir+"/"+cuda.CuinterposeStateFile, []byte("cuinterpose-state-v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireCuinterposeState(prepared, dir); err != nil {
+		t.Fatalf("state present: %v", err)
+	}
+	noCUDA := &types.CheckpointManifest{Cuinterpose: types.CuinterposeManifest{Prepared: true}}
+	if err := requireCuinterposeState(noCUDA, dir); err == nil {
+		t.Fatal("prepared without CUDA processes is inconsistent")
 	}
 }

--- a/agent/internal/types/inspect.go
+++ b/agent/internal/types/inspect.go
@@ -31,6 +31,7 @@ type CheckpointContainerSnapshot struct {
 	CUDAHostPIDs   []int    // host-visible PIDs used for checkpoint-side CUDA actions
 	CUDANSPIDs     []int    // namespace-relative PIDs stored in the checkpoint manifest
 	GPUUUIDs       []string // source GPU UUIDs from kubelet PodResources API
+	Cuinterpose    bool     // every CUDA process runs the cuinterpose shim (its control socket is present)
 }
 
 // RestoreContainerSnapshot holds inspected state for the restore target.

--- a/agent/internal/types/manifest.go
+++ b/agent/internal/types/manifest.go
@@ -29,6 +29,23 @@ type CheckpointManifest struct {
 	// CUDATools records whether the source ran with Snapshot's CUDA tools
 	// (cuda-checkpoint, the cuinterpose shim) delivered into the container.
 	CUDATools CUDAToolsManifest `yaml:"cudaTools,omitempty"`
+	// Cuinterpose records whether the CUDA interposer shim was in play. It is
+	// the restore side's only source of truth: the restore Pod's annotations
+	// may be absent or edited, and the state file alone cannot say whether
+	// prepare was supposed to have run.
+	Cuinterpose CuinterposeManifest `yaml:"cuinterpose,omitempty"`
+}
+
+// CuinterposeManifest carries two separate facts about the shim.
+type CuinterposeManifest struct {
+	// Requested is true when the source Pod opted in. Restore then removes
+	// stale shim sockets before CRIU recreates the processes. The shim itself
+	// is mounted through the CUDA tools delivery (CUDAToolsManifest).
+	Requested bool `yaml:"requested"`
+	// Prepared is true when the coordinator's prepare step completed and wrote
+	// the state file. Restore then runs the coordinator, and a missing state
+	// file is an error rather than a plain restore.
+	Prepared bool `yaml:"prepared"`
 }
 
 // CUDAToolsManifest is the restore side's source of truth for the tools mount.

--- a/agent/internal/types/manifest_test.go
+++ b/agent/internal/types/manifest_test.go
@@ -201,3 +201,27 @@ func TestManifestRoundTripsCUDATools(t *testing.T) {
 		t.Fatalf("cudaTools = %+v, err = %v, want zero", read.CUDATools, err)
 	}
 }
+
+func TestManifestRoundTripsCuinterpose(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCheckpointManifest("content-uid", "main", CRIUDumpManifest{}, SourcePodManifest{}, OverlayManifest{})
+	m.Cuinterpose = CuinterposeManifest{Requested: true, Prepared: true}
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	read, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !read.Cuinterpose.Requested || !read.Cuinterpose.Prepared {
+		t.Fatalf("cuinterpose = %+v, want both true", read.Cuinterpose)
+	}
+	// Older manifests without the section read as not requested, not prepared.
+	m.Cuinterpose = CuinterposeManifest{}
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if read, err = ReadManifest(dir); err != nil || read.Cuinterpose.Requested || read.Cuinterpose.Prepared {
+		t.Fatalf("cuinterpose = %+v, err = %v, want zero", read.Cuinterpose, err)
+	}
+}

--- a/api/podcontract/cuinterpose.go
+++ b/api/podcontract/cuinterpose.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// cuinterpose is the CUDA interposer: an LD_PRELOAD library that lets Snapshot
+// checkpoint and restore CUDA memory shared between processes on one node. A
+// Pod opts in with CuinterposeAnnotation. The shim travels with the CUDA tools
+// delivery (cudatools.go); shaping puts it first in LD_PRELOAD and launches
+// every target under cuda-checkpoint --launch-job whatever its GPU count,
+// because the shim's checkpoint path needs the CUDA job file.
+const ldPreloadEnv = "LD_PRELOAD"
+
+// CuinterposeEnabled reports whether a workload opted into the CUDA interposer
+// through CuinterposeAnnotation. An absent annotation disables it; any value
+// other than "enabled" is an error rather than a silent no.
+func CuinterposeEnabled(annotations map[string]string) (bool, error) {
+	raw, found := annotations[CuinterposeAnnotation]
+	if !found {
+		return false, nil
+	}
+	if raw != strings.TrimSpace(raw) {
+		return false, fmt.Errorf("%s must not contain surrounding whitespace", CuinterposeAnnotation)
+	}
+	if raw != CuinterposeAnnotationEnabled {
+		return false, fmt.Errorf("%s must be %q", CuinterposeAnnotation, CuinterposeAnnotationEnabled)
+	}
+	return true, nil
+}
+
+// ShapeCuinterposeCapture installs the capture-side contract on every target
+// container when the template opts in: the CUDA tools delivery and launch-job
+// wrapper (ShapeCUDALaunchJob's contract, applied regardless of GPU count) plus
+// LD_PRELOAD pointing at the shim. Reapplying to an already shaped template is
+// a no-op. On error the template is left unchanged.
+func ShapeCuinterposeCapture(
+	podTemplate *corev1.PodTemplateSpec,
+	targetContainers []string,
+	delivery CUDAToolsDelivery,
+) error {
+	if podTemplate == nil {
+		return fmt.Errorf("cuinterpose requires a pod template")
+	}
+	enabled, err := CuinterposeEnabled(podTemplate.Annotations)
+	if err != nil || !enabled {
+		return err
+	}
+	if len(targetContainers) == 0 {
+		return fmt.Errorf("cuinterpose requires at least one target container")
+	}
+	shaped := podTemplate.DeepCopy()
+	targets := uniqueNames(targetContainers)
+	if err := shapeCUDALaunchJob(shaped, targets, delivery); err != nil {
+		return fmt.Errorf("cuinterpose: %w", err)
+	}
+	for _, name := range targets {
+		if err := setCuinterposePreload(findContainer(&shaped.Spec, name)); err != nil {
+			return err
+		}
+	}
+	*podTemplate = *shaped
+	return nil
+}
+
+// VerifyCuinterposeCapture reports whether spec already carries the complete
+// capture contract for every target container: the launch-job contract and
+// the LD_PRELOAD entry. The operator uses it to refuse adopting a Job that was
+// created without the shim.
+func VerifyCuinterposeCapture(spec *corev1.PodSpec, targetContainers []string) error {
+	if err := VerifyCUDALaunchJob(spec, targetContainers); err != nil {
+		return err
+	}
+	for _, name := range targetContainers {
+		container := findContainer(spec, name)
+		if !slices.Contains(preloadFields(envValue(container.Env, ldPreloadEnv)), CuinterposeLibraryPath) {
+			return fmt.Errorf("container %q does not preload %s", name, CuinterposeLibraryPath)
+		}
+	}
+	return nil
+}
+
+// setCuinterposePreload puts the shim first in LD_PRELOAD, keeping any entries
+// the workload already had. First position matters: the dynamic loader
+// resolves symbols in LD_PRELOAD order, and the shim must see CUDA calls
+// before any other interposer.
+func setCuinterposePreload(container *corev1.Container) error {
+	index := -1
+	for i := range container.Env {
+		if container.Env[i].Name != ldPreloadEnv {
+			continue
+		}
+		if index != -1 {
+			return fmt.Errorf("container %q has duplicate %s environment variables", container.Name, ldPreloadEnv)
+		}
+		index = i
+	}
+	if index == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  ldPreloadEnv,
+			Value: CuinterposeLibraryPath,
+		})
+		return nil
+	}
+	env := &container.Env[index]
+	if env.ValueFrom != nil {
+		return fmt.Errorf("container %q uses valueFrom for %s", container.Name, ldPreloadEnv)
+	}
+	fields := preloadFields(env.Value)
+	filtered := make([]string, 0, len(fields)+1)
+	filtered = append(filtered, CuinterposeLibraryPath)
+	for _, field := range fields {
+		if field != CuinterposeLibraryPath {
+			filtered = append(filtered, field)
+		}
+	}
+	env.Value = strings.Join(filtered, " ")
+	return nil
+}
+
+func preloadFields(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		return r == ':' || unicode.IsSpace(r)
+	})
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for i := range env {
+		if env[i].Name == name {
+			return env[i].Value
+		}
+	}
+	return ""
+}

--- a/api/podcontract/cuinterpose_test.go
+++ b/api/podcontract/cuinterpose_test.go
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func enabledTemplate(containers ...corev1.Container) *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{CuinterposeAnnotation: CuinterposeAnnotationEnabled},
+		},
+		Spec: corev1.PodSpec{Containers: containers},
+	}
+}
+
+func TestShapeCuinterposeCapture(t *testing.T) {
+	template := enabledTemplate(
+		corev1.Container{
+			Name:    "worker-a",
+			Command: []string{"python3", "-m", "worker"},
+			Args:    []string{"--rank", "0"},
+			Env:     []corev1.EnvVar{{Name: ldPreloadEnv, Value: "/opt/first.so:/opt/second.so"}},
+		},
+		corev1.Container{Name: "worker-b", Command: []string{"/usr/bin/worker"}},
+		corev1.Container{Name: "helper"},
+	)
+
+	// Shaping twice must be a no-op the second time.
+	for range 2 {
+		if err := ShapeCuinterposeCapture(template, []string{"worker-a", "worker-b"}, testDelivery()); err != nil {
+			t.Fatalf("ShapeCuinterposeCapture() failed: %v", err)
+		}
+	}
+
+	if len(template.Spec.Volumes) != 1 ||
+		template.Spec.Volumes[0].Name != CUDAToolsVolumeName ||
+		template.Spec.Volumes[0].EmptyDir == nil {
+		t.Fatalf("unexpected volumes: %#v", template.Spec.Volumes)
+	}
+	wantInit := expectedCUDAToolsInitContainer(testDelivery())
+	if len(template.Spec.InitContainers) != 1 ||
+		!reflect.DeepEqual(template.Spec.InitContainers[0], wantInit) {
+		t.Fatalf("init containers = %#v, want %#v", template.Spec.InitContainers, wantInit)
+	}
+	if wantInit.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("digest reference should default to IfNotPresent, got %s", wantInit.ImagePullPolicy)
+	}
+	if wantInit.SecurityContext.SeccompProfile == nil ||
+		wantInit.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("init container lacks the RuntimeDefault seccomp profile: %#v", wantInit.SecurityContext)
+	}
+	for _, name := range []string{"worker-a", "worker-b"} {
+		container := findContainer(&template.Spec, name)
+		if got := container.VolumeMounts; len(got) != 1 ||
+			got[0].Name != CUDAToolsVolumeName ||
+			got[0].MountPath != CUDAToolsMountPath ||
+			!got[0].ReadOnly {
+			t.Fatalf("%s mounts: %#v", name, got)
+		}
+	}
+	if got := findContainer(&template.Spec, "helper"); len(got.VolumeMounts) != 0 {
+		t.Fatalf("non-target helper mounts: %#v", got.VolumeMounts)
+	}
+	wantPreload := CuinterposeLibraryPath + " /opt/first.so /opt/second.so"
+	if got := envValue(findContainer(&template.Spec, "worker-a").Env, ldPreloadEnv); got != wantPreload {
+		t.Fatalf("%s = %q, want %q", ldPreloadEnv, got, wantPreload)
+	}
+	if got := envValue(findContainer(&template.Spec, "worker-b").Env, ldPreloadEnv); got != CuinterposeLibraryPath {
+		t.Fatalf("%s = %q, want %q", ldPreloadEnv, got, CuinterposeLibraryPath)
+	}
+	assertLaunchJob(
+		t, findContainer(&template.Spec, "worker-a"), []string{"python3", "-m", "worker", "--rank", "0"})
+	assertLaunchJob(t, findContainer(&template.Spec, "worker-b"), []string{"/usr/bin/worker"})
+	if got := findContainer(&template.Spec, "helper").Command; len(got) != 0 {
+		t.Fatalf("non-target helper command: %#v", got)
+	}
+	if err := VerifyCuinterposeCapture(&template.Spec, []string{"worker-a", "worker-b"}); err != nil {
+		t.Fatalf("VerifyCuinterposeCapture() on a shaped template failed: %v", err)
+	}
+
+	// Without the annotation nothing is touched.
+	plain := &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "worker"}}}}
+	if err := ShapeCuinterposeCapture(plain, []string{"worker"}, CUDAToolsDelivery{}); err != nil ||
+		len(plain.Spec.Volumes) != 0 || len(plain.Spec.InitContainers) != 0 {
+		t.Fatalf("disabled capture: err = %v, spec = %#v", err, plain.Spec)
+	}
+}
+
+func TestShapeCuinterposeCaptureRejectsInvalidContract(t *testing.T) {
+	worker := corev1.Container{Name: "worker", Command: []string{"worker"}}
+	tests := map[string]struct {
+		template *corev1.PodTemplateSpec
+		targets  []string
+		delivery CUDAToolsDelivery
+	}{
+		"invalid annotation": {
+			template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CuinterposeAnnotation: "true"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{worker}},
+			},
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"implicit image entrypoint": {
+			template: enabledTemplate(corev1.Container{Name: "worker"}),
+			targets:  []string{"worker"}, delivery: testDelivery(),
+		},
+		"missing agent image": {
+			template: enabledTemplate(worker),
+			targets:  []string{"worker"}, delivery: CUDAToolsDelivery{},
+		},
+		"malformed agent image": {
+			template: enabledTemplate(worker),
+			targets:  []string{"worker"},
+			delivery: CUDAToolsDelivery{
+				AgentImage: "registry.example/not valid@sha256:" + strings.Repeat("0", 64),
+			},
+		},
+		"unknown target": {
+			template: enabledTemplate(worker),
+			targets:  []string{"other"}, delivery: testDelivery(),
+		},
+		"no targets": {
+			template: enabledTemplate(worker),
+			targets:  nil, delivery: testDelivery(),
+		},
+		"LD_PRELOAD from valueFrom": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				Env: []corev1.EnvVar{{Name: ldPreloadEnv, ValueFrom: &corev1.EnvVarSource{}}},
+			}),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"conflicting mount options": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				VolumeMounts: []corev1.VolumeMount{{Name: CUDAToolsVolumeName, MountPath: CUDAToolsMountPath, SubPath: "x"}},
+			}),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"volume is not an emptyDir": {
+			template: func() *corev1.PodTemplateSpec {
+				tpl := enabledTemplate(worker)
+				tpl.Spec.Volumes = []corev1.Volume{{
+					Name:         CUDAToolsVolumeName,
+					VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp"}},
+				}}
+				return tpl
+			}(),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+		"foreign cuda-checkpoint wrapper": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{CUDACheckpointPath}, Args: []string{"--something-else"},
+			}),
+			targets: []string{"worker"}, delivery: testDelivery(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			before := tc.template.DeepCopy()
+			if err := ShapeCuinterposeCapture(tc.template, tc.targets, tc.delivery); err == nil {
+				t.Fatal("ShapeCuinterposeCapture() succeeded, want error")
+			}
+			if !reflect.DeepEqual(tc.template, before) {
+				t.Fatalf("failed shape mutated template:\ngot:  %#v\nwant: %#v", tc.template, before)
+			}
+		})
+	}
+}
+
+func TestVerifyCuinterposeCaptureRejectsUnshapedSpecs(t *testing.T) {
+	shaped := enabledTemplate(corev1.Container{Name: "worker", Command: []string{"worker"}})
+	if err := ShapeCuinterposeCapture(shaped, []string{"worker"}, testDelivery()); err != nil {
+		t.Fatal(err)
+	}
+	mutations := map[string]func(*corev1.PodSpec){
+		"no volume":         func(s *corev1.PodSpec) { s.Volumes = nil },
+		"no init container": func(s *corev1.PodSpec) { s.InitContainers = nil },
+		"no mount":          func(s *corev1.PodSpec) { s.Containers[0].VolumeMounts = nil },
+		"no preload":        func(s *corev1.PodSpec) { s.Containers[0].Env = nil },
+		"unwrapped command": func(s *corev1.PodSpec) {
+			s.Containers[0].Command = []string{"worker"}
+			s.Containers[0].Args = nil
+		},
+		"missing target": func(s *corev1.PodSpec) { s.Containers[0].Name = "other" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			spec := shaped.Spec.DeepCopy()
+			mutate(spec)
+			if err := VerifyCuinterposeCapture(spec, []string{"worker"}); err == nil {
+				t.Fatal("VerifyCuinterposeCapture() accepted an unshaped spec")
+			}
+		})
+	}
+}
+
+func TestCuinterposeEnabled(t *testing.T) {
+	for name, annotations := range map[string]map[string]string{
+		"absent":  nil,
+		"enabled": {CuinterposeAnnotation: CuinterposeAnnotationEnabled},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := CuinterposeEnabled(annotations)
+			if err != nil {
+				t.Fatalf("CuinterposeEnabled() failed: %v", err)
+			}
+			if got != (name == "enabled") {
+				t.Fatalf("CuinterposeEnabled() = %v", got)
+			}
+		})
+	}
+	for _, value := range []string{"", "true", " enabled ", "Enabled"} {
+		if _, err := CuinterposeEnabled(map[string]string{CuinterposeAnnotation: value}); err == nil {
+			t.Fatalf("CuinterposeEnabled() accepted %q", value)
+		}
+	}
+}

--- a/api/podcontract/protocol.go
+++ b/api/podcontract/protocol.go
@@ -22,6 +22,16 @@ const (
 	// uses the captured container name as the destination.
 	RestoreContainerMapAnnotation = "nvidia.com/restore-container-map"
 
+	// CuinterposeAnnotation opts a SnapshotJob's checkpoint targets into the
+	// CUDA interposer (cuinterpose), which lets Snapshot checkpoint and restore
+	// CUDA memory shared between processes. The only supported value is
+	// CuinterposeAnnotationEnabled. Snapshot supplies the shim from its own
+	// configured agent image; workload users do not select an image.
+	CuinterposeAnnotation = "nvidia.com/cuinterpose"
+
+	// CuinterposeAnnotationEnabled is the only accepted CuinterposeAnnotation value.
+	CuinterposeAnnotationEnabled = "enabled"
+
 	// DefaultSeccompLocalhostProfile is the kubelet-local profile installed by
 	// the Snapshot Helm chart to block io_uring for CRIU.
 	DefaultSeccompLocalhostProfile = "profiles/block-iouring.json"

--- a/operator/internal/controller/snapshotjob_job.go
+++ b/operator/internal/controller/snapshotjob_job.go
@@ -33,7 +33,8 @@ func buildSourceJob(sj *snapshotv1alpha1.SnapshotJob) (*batchv1.Job, error) {
 // the target is launched under cuda-checkpoint --launch-job, which the agent
 // requires to checkpoint a multi-GPU process tree. DRA claims are sized through
 // claims; an unresolvable claim counts as multi-GPU. Returns the targets that
-// carry the wrapper.
+// carry the wrapper. A template that opts into cuinterpose additionally gets
+// the shim preloaded, and every target wrapped whatever its GPU count.
 //
 // No storage is injected (spec §5.3: the agent falls back to its own config).
 func buildShapedSourceJob(
@@ -85,6 +86,13 @@ func buildShapedSourceJob(
 		claims,
 	)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := podcontract.ShapeCuinterposeCapture(
+		&job.Spec.Template,
+		sj.Spec.PodSnapshotTemplate.TargetContainers,
+		delivery,
+	); err != nil {
 		return nil, nil, err
 	}
 	return job, wrapped, nil

--- a/operator/internal/controller/snapshotjob_job_test.go
+++ b/operator/internal/controller/snapshotjob_job_test.go
@@ -294,3 +294,38 @@ func TestBuildShapedSourceJobWrapsMultiGPUTargets(t *testing.T) {
 		assert.Equal(t, []string{"worker"}, wrapped)
 	})
 }
+
+func cuinterposeSnapshotJob() *snapshotv1alpha1.SnapshotJob {
+	sj := minimalSnapshotJob()
+	sj.Spec.PodTemplate.Annotations = map[string]string{
+		podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+	}
+	sj.Spec.PodTemplate.Spec.Containers[0].Command = []string{"python3", "-m", "worker"}
+	return sj
+}
+
+func TestBuildShapedSourceJobShapesCuinterpose(t *testing.T) {
+	sj := cuinterposeSnapshotJob()
+
+	job, wrapped, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, wrapped, "a single-GPU target is wrapped by the shim's contract, not the GPU rule")
+
+	require.NoError(t, podcontract.VerifyCuinterposeCapture(&job.Spec.Template.Spec, []string{"worker"}))
+	main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
+	assert.Equal(t, []string{podcontract.CUDACheckpointPath}, main.Command,
+		"the opted-in target is launched through cuda-checkpoint even on one GPU")
+	assert.Equal(t, []string{"python3", "-m", "worker"}, main.Args[len(main.Args)-3:])
+	requireContainer(t, job.Spec.Template.Spec.InitContainers, podcontract.CUDAToolsInitContainerName)
+
+	t.Run("an opted-in SnapshotJob needs a configured agent image", func(t *testing.T) {
+		_, err := buildSourceJob(cuinterposeSnapshotJob())
+		require.Error(t, err)
+	})
+
+	t.Run("a SnapshotJob without the annotation gets no shim", func(t *testing.T) {
+		job, _, err := buildShapedSourceJob(multiGPUSnapshotJob(), testCUDAToolsDelivery(), nil)
+		require.NoError(t, err)
+		require.Error(t, podcontract.VerifyCuinterposeCapture(&job.Spec.Template.Spec, []string{"worker"}))
+	})
+}

--- a/operator/internal/controller/snapshotjob_podsnapshot.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -194,6 +195,20 @@ func buildPodSnapshot(sj *snapshotv1alpha1.SnapshotJob, pod *corev1.Pod) (*snaps
 	labels, annotations, err := podSnapshotTemplateMetadata(sj)
 	if err != nil {
 		return nil, err
+	}
+	// Record on the PodSnapshot whether the source ran with cuinterpose, so
+	// the artifact says what it was captured with.
+	cuinterposeEnabled, err := podcontract.CuinterposeEnabled(pod.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	if cuinterposeEnabled {
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[podcontract.CuinterposeAnnotation] = podcontract.CuinterposeAnnotationEnabled
+	} else {
+		delete(annotations, podcontract.CuinterposeAnnotation)
 	}
 	return &snapshotv1alpha1.PodSnapshot{
 		TypeMeta: metav1.TypeMeta{

--- a/operator/internal/controller/snapshotjob_podsnapshot_test.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -35,7 +36,14 @@ func TestBuildPodSnapshot(t *testing.T) {
 		Annotations: map[string]string{"dynamo.nvidia.com/gms-mode": "enabled"},
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "warm-worker-abcde", Namespace: "inference", UID: types.UID("pod-uid")},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-worker-abcde",
+			Namespace: "inference",
+			UID:       types.UID("pod-uid"),
+			Annotations: map[string]string{
+				podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+			},
+		},
 	}
 
 	snap, err := buildPodSnapshot(sj, pod)
@@ -54,6 +62,10 @@ func TestBuildPodSnapshot(t *testing.T) {
 	t.Run("propagates caller metadata", func(t *testing.T) {
 		assert.Equal(t, "abc123", snap.Labels["dynamo.nvidia.com/worker-generation"])
 		assert.Equal(t, "enabled", snap.Annotations["dynamo.nvidia.com/gms-mode"])
+	})
+
+	t.Run("records cuinterpose", func(t *testing.T) {
+		assert.Equal(t, podcontract.CuinterposeAnnotationEnabled, snap.Annotations[podcontract.CuinterposeAnnotation])
 	})
 
 	t.Run("pins the source pod name and UID", func(t *testing.T) {
@@ -800,4 +812,16 @@ func TestMapPodSnapshotToSnapshotJob(t *testing.T) {
 func TestSnapshotJobOwnerFromPodSnapshotObjRejectsWrongType(t *testing.T) {
 	_, err := snapshotJobOwnerFromPodSnapshotObj(&corev1.Pod{})
 	require.Error(t, err)
+}
+
+func TestBuildPodSnapshotRejectsInvalidCuinterposeAnnotation(t *testing.T) {
+	sj := minimalSnapshotJob()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "warm-worker-abcde", Namespace: "inference", UID: types.UID("pod-uid"),
+			Annotations: map[string]string{podcontract.CuinterposeAnnotation: "true"},
+		},
+	}
+	_, err := buildPodSnapshot(sj, pod)
+	require.Error(t, err, "an unrecognized value must not silently produce a PodSnapshot without the shim recorded")
 }

--- a/operator/internal/controller/snapshotjob_reconciler_test.go
+++ b/operator/internal/controller/snapshotjob_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -820,6 +821,59 @@ func TestSnapshotJobReconcileRejectsUnshapedMultiGPUJob(t *testing.T) {
 func TestSnapshotJobReconcileAdoptsShapedMultiGPUJob(t *testing.T) {
 	s := snapshotJobReconcilerScheme()
 	sj := multiGPUSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	job, _, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.CUDATools = testCUDAToolsDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	assert.Equal(t, job.UID, updated.Status.SourceJobUID, "a correctly shaped Job is adopted")
+}
+
+func TestSnapshotJobReconcileRejectsUnshapedJobWhenCuinterposeEnabled(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := cuinterposeSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	// A Job created by an operator that had no agent image: the Pod template is
+	// annotated but carries none of the capture contract.
+	plain := sj.DeepCopy()
+	delete(plain.Spec.PodTemplate.Annotations, podcontract.CuinterposeAnnotation)
+	job, err := buildSourceJob(plain)
+	require.NoError(t, err)
+	job.Spec.Template.Annotations = map[string]string{
+		podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+	}
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.CUDATools = testCUDAToolsDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	failed := meta.FindStatusCondition(updated.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
+	require.NotNil(t, failed, "adopting a Job without the shim would checkpoint without interposition")
+	assert.Equal(t, snapshotv1alpha1.ReasonJobNameConflict, failed.Reason)
+	assert.Contains(t, failed.Message, "cuinterpose capture contract")
+	assert.Empty(t, updated.Status.SourceJobUID)
+}
+
+func TestSnapshotJobReconcileAdoptsShapedJobWhenCuinterposeEnabled(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := cuinterposeSnapshotJob()
 	sj.UID = types.UID("sj-uid")
 
 	job, _, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)

--- a/operator/internal/controller/snapshotjob_source_job.go
+++ b/operator/internal/controller/snapshotjob_source_job.go
@@ -151,6 +151,19 @@ func (r *SnapshotJobReconciler) classifyExistingSourceJob(
 			}, nil
 		}
 	}
+	// The same for the shim: a Job created without it would produce a
+	// checkpoint whose PodSnapshot claims interposition that never happened.
+	if enabled, err := podcontract.CuinterposeEnabled(desired.Spec.Template.Annotations); err == nil && enabled {
+		if err := podcontract.VerifyCuinterposeCapture(
+			&job.Spec.Template.Spec,
+			sj.Spec.PodSnapshotTemplate.TargetContainers,
+		); err != nil {
+			return &snapshotJobFailure{
+				reason: snapshotv1alpha1.ReasonJobNameConflict,
+				cause:  fmt.Errorf("existing source Job %q lacks the cuinterpose capture contract: %w", job.Name, err),
+			}, nil
+		}
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION

## Summary

Part of the **cuinterpose** stack: the CUDA interposer that lets Snapshot checkpoint and restore CUDA memory shared between processes (tensor-parallel workers, NCCL, FlashInfer, PyTorch symmetric memory) and CUDA multicast objects. Nine PRs, each one component: packaging, delivery, agent orchestration, then the shim and coordinator layer by layer, then the GPU tests. The design document is held back until the code has been reviewed.

This PR is the agent's side of the contract. What to review: `agent/internal/cuda/cuinterpose.go` (detection and coordinator invocation) and the manifest fields.

- Manifest: `cuinterpose.requested` (the opt-in, read from the source Pod; drives the restore-time shim mount through `ns-bind-mount mount-cuinterpose-fd`, because CRIU re-opens file-backed mappings by path) and `cuinterpose.prepared` (the coordinator's prepare completed and wrote `cuinterpose.state`; drives the coordinator on restore). A prepared checkpoint without its state file is refused instead of silently restoring natively.
- Detection is fail-closed (`CheckCuinterposeEnablement`): a Pod that requested the shim must show a control socket for every CUDA process, a Pod that did not must show none; anything else fails the checkpoint with the processes named. Only sockets count; procfs environ is not evidence.
- Around the coordinator: stale `cuinterpose-*.sock` entries are removed before CRIU recreates the processes (a stale path makes CRIU's `bind()` fail); the coordinator binary is opened before the mount namespace changes; its `phase=… status=ok` lines are parsed and logged as structured fields; `cuinterpose_prepare` and `cuinterpose_restore` are timing phases; the restore mount is ordered before the PageBroker staging mount (which pops the last mount).
- Tests: detection truth table and socket cases; argv contract against a fake coordinator binary for prepare and restore, including failure reporting; Go constants pinned to `protocol.h` and the coordinator's flag names; restore mount ordering with a fake mounter; manifest round trip; `ns-bind-mount` destination pinned to the podcontract constant.
- Until the shim opens control sockets (lifecycle PR), an annotated Pod with CUDA processes is refused at checkpoint by the fail-closed rule.

## Origin

The Go orchestration of #155 and #110, and the detection rule of #152/#165.

<details><summary>#155 feat(agent): coordinate CUDA interposer lifecycle (Go part; the C part is quoted in the coordinator PR)</summary>

> Adds coordinator and agent orchestration for the CUDA interposer: the agent detects interposed CUDA processes by their control sockets, runs `cuinterposer-coordinator --prepare` before `cuda-checkpoint`, records the result, and runs `--restore` after the process tree is back and before the restore-complete sentinel is written.

</details>

## Review threads carried

| Old thread | Raised | Disposition |
| --- | --- | --- |
| #110 Copilot `vmm_interpose.go:121`, `cuinterpose.go:121` (empty `--proc-root` on restore) | Restore invokes the coordinator with an empty proc root. | By design: on restore the coordinator runs inside the restored container's mount namespace, where the sockets are reachable directly under the control directory; the empty proc root selects that mode (`coordinator --help`, `coordinator_test`). Covered by `TestCoordinatorArgvContractAndReports`. |
| #110 Copilot `nsrestore.go:252/255`, CodeRabbit `nsrestore.go:269`; #78 CodeRabbit `nsrestore.go:254` | The coordinator runs after `RestoreAndUnlockProcessTree`, so CUDA execution could resume before sharing is rebuilt. | Clarified, not changed: the workload is parked in its restore-complete poll loop and issues no CUDA calls until the agent writes the sentinel after the coordinator succeeds (quiescence contract). |
| #110 CodeRabbit `restore_pod.go:248` | Lines over 120 characters failed `lll`. | Fixed; `make lint` passes. |
| #78 CodeRabbit `vmm_interpose.go:38/74`, `checkpoint.go:288` | Detection inconsistencies; a counter computed but never enforced; prepare excluded from timings. | Superseded: detection is the fail-closed truth table in `CheckCuinterposeEnablement`; `cuinterpose_prepare` and `cuinterpose_restore` are timing phases. |

## Validation

- Fake-driver suites (GoogleTest, AddressSanitizer + UndefinedBehaviorSanitizer) run in the agent image build against CUDA 13.1 headers at every layer of the stack; at the top: proto 9, table 9, forward 12, coordinator 13, state 13, lifecycle 4, multicast 6, no sanitizer reports.
- `go test ./...` in `api`, `operator`, `agent` at every Go layer; `make lint`, `make helm-lint`.
- The production sources at the top of this stack are byte-identical to the tree that was built into an agent image and deployed on nscale-dev (B200, kernel driver 595.58.03); only tests and packaging were re-cut afterwards.
- GPU tests (two B200s, `cuda-checkpoint --launch-job`): POSIX round trip with seeded 256 MiB carriers per rank and a CUDA graph replayed after restore, multicast round trip with PyTorch's multimem all-reduce and a `cuMulticastBindAddr` rebind, refusal while a raw import is alive: 3 passed. Host-carrier restore phase 87 to 108 GB/s aggregate over two GPUs (pinned-copy baseline 55 GB/s per GPU).
- End to end: vLLM 0.27.1 `AsyncLLM`, Qwen3-0.6B, tensor parallel 2, FlashInfer TRT-LLM attention and fused allreduce (`trtllm` backend), PodSnapshot of a Deployment shaped with `podcontract.ShapeCuinterposeCapture`, then restore: checkpoint 52 s (CRIU dump 49 s, cuinterpose prepare 0.43 s; 4 CUDA processes, 1052 records, 382 host carriers, 2.08 GB); restore 5.7 s (cuinterpose 0.35 s: carriers 0.05 s, unicast 0.09 s, multicast 0.18 s); the restored replica answers coherently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
