### PR TITLE
feat(agent): cuinterpose shim symbol resolution and forwarding

### DIFF
--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -5,23 +5,109 @@
  */
 
 /*
- * Placeholder shim. It builds and is packaged as libcuinterpose.so so that the
- * delivery path (init container, LD_PRELOAD, restore mount) is final before
- * the interposer exists, and it intercepts nothing. The following changes
- * replace it: symbol resolution and forwarding, allocation tracking, the
- * checkpoint lifecycle, multicast objects.
+ * CUDA virtual memory management (VMM) entry points the shim replaces.
+ *
+ * This layer forwards every call to the real driver unchanged. It exists so
+ * that symbol resolution (symbols.c) can be built and tested on its own; the
+ * bookkeeping that tracks shared allocations is added on top of these
+ * wrappers in a later change.
  */
 
+#define _GNU_SOURCE
+
 #include <cuda.h>
-#include <string.h>
 
 #include "export.h"
 #include "protocol.h"
+#include "symbols.h"
 
-CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info = {CUDA_VERSION, CUINTERPOSE_VERSION};
+CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info = {
+    .cuda_version = CUDA_VERSION,
+    .protocol_version = CUINTERPOSE_VERSION,
+};
 
-CUINTERPOSE_API void
-cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
+typedef CUresult(CUDAAPI* create_fn)(
+    CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+typedef CUresult(CUDAAPI* release_fn)(CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* retain_fn)(CUmemGenericAllocationHandle*, void*);
+typedef CUresult(CUDAAPI* map_fn)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+typedef CUresult(CUDAAPI* unmap_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* access_fn)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+typedef CUresult(CUDAAPI* export_fn)(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
 {
-  memset(stats, 0, sizeof(*stats));
+  create_fn function = (create_fn)cuinterpose_lookup_real_symbol("cuMemCreate");
+
+  return function != NULL ? function(output, size, properties, flags) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemRelease(CUmemGenericAllocationHandle handle)
+{
+  release_fn function = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+
+  return function != NULL ? function(handle) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
+{
+  retain_fn function = (retain_fn)cuinterpose_lookup_real_symbol("cuMemRetainAllocationHandle");
+
+  return function != NULL ? function(output, address) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+{
+  map_fn function = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+
+  return function != NULL ? function(address, size, offset, handle, flags) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemUnmap(CUdeviceptr address, size_t size)
+{
+  unmap_fn function = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+
+  return function != NULL ? function(address, size) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  access_fn function = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+
+  return function != NULL ? function(address, size, descriptors, count) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemExportToShareableHandle(
+    void* shareable, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  export_fn function = (export_fn)cuinterpose_lookup_real_symbol("cuMemExportToShareableHandle");
+
+  return function != NULL ? function(shareable, handle, type, flags) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
+{
+  import_fn function = (import_fn)cuinterpose_lookup_real_symbol("cuMemImportFromShareableHandle");
+
+  return function != NULL ? function(output, os_handle, type) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+{
+  properties_fn function = (properties_fn)cuinterpose_lookup_real_symbol("cuMemGetAllocationPropertiesFromHandle");
+
+  return function != NULL ? function(properties, handle) : cuinterpose_unavailable();
 }

--- a/agent/cmd/cuinterpose/multicast.c
+++ b/agent/cmd/cuinterpose/multicast.c
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "multicast.h"
+
+#include <cuda.h>
+
+#include "export.h"
+#include "symbols.h"
+
+/* cuda.h maps these names to versioned entry points; the shim wraps the names. */
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+
+typedef CUresult(CUDAAPI* create_fn)(CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+typedef CUresult(CUDAAPI* add_device_fn)(CUmemGenericAllocationHandle, CUdevice);
+typedef CUresult(CUDAAPI* bind_mem_fn)(
+    CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+typedef CUresult(CUDAAPI* bind_address_fn)(CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+#if CUDA_VERSION >= 13010
+typedef CUresult(CUDAAPI* bind_mem_v2_fn)(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+typedef CUresult(CUDAAPI* bind_address_v2_fn)(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t, unsigned long long);
+#endif
+typedef CUresult(CUDAAPI* granularity_fn)(size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
+typedef CUresult(CUDAAPI* unbind_fn)(CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  create_fn function = (create_fn)cuinterpose_lookup_real_symbol("cuMulticastCreate");
+
+  return function != NULL ? function(output, properties) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+{
+  add_device_fn function = (add_device_fn)cuinterpose_lookup_real_symbol("cuMulticastAddDevice");
+
+  return function != NULL ? function(multicast, device) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastBindMem(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUmemGenericAllocationHandle memory,
+    size_t memory_offset, size_t size, unsigned long long flags)
+{
+  bind_mem_fn function = (bind_mem_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem");
+
+  return function != NULL ? function(multicast, multicast_offset, memory, memory_offset, size, flags)
+                          : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  bind_address_fn function = (bind_address_fn)cuinterpose_lookup_real_symbol("cuMulticastBindAddr");
+
+  return function != NULL ? function(multicast, multicast_offset, memory, size, flags) : cuinterpose_unavailable();
+}
+
+#if CUDA_VERSION >= 13010
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
+{
+  bind_mem_v2_fn function = (bind_mem_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem_v2");
+
+  return function != NULL ? function(multicast, device, multicast_offset, memory, memory_offset, size, flags)
+                          : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  bind_address_v2_fn function = (bind_address_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindAddr_v2");
+
+  return function != NULL ? function(multicast, device, multicast_offset, memory, size, flags)
+                          : cuinterpose_unavailable();
+}
+#endif
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastGetGranularity(
+    size_t* granularity, const CUmulticastObjectProp* properties, CUmulticastGranularity_flags option)
+{
+  granularity_fn function = (granularity_fn)cuinterpose_lookup_real_symbol("cuMulticastGetGranularity");
+
+  return function != NULL ? function(granularity, properties, option) : cuinterpose_unavailable();
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+{
+  unbind_fn function = (unbind_fn)cuinterpose_lookup_real_symbol("cuMulticastUnbind");
+
+  return function != NULL ? function(multicast, device, offset, size) : cuinterpose_unavailable();
+}

--- a/agent/cmd/cuinterpose/multicast.h
+++ b/agent/cmd/cuinterpose/multicast.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_MULTICAST_H
+#define CUINTERPOSE_MULTICAST_H
+
+/*
+ * CUDA multicast objects (cuMulticast*) let several GPUs write one buffer
+ * through NVLink. This layer forwards the entry points unchanged; tracking
+ * and checkpoint of multicast groups is added in a later change.
+ */
+
+#endif

--- a/agent/cmd/cuinterpose/posix.c
+++ b/agent/cmd/cuinterpose/posix.c
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "posix.h"
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "util/cleanup.h"
+#include "util/id.h"
+#include "util/io.h"
+#include "util/misc.h"
+
+static bool
+zero_bytes(const void* value, size_t size)
+{
+  const uint8_t* bytes = value;
+  size_t index;
+
+  for (index = 0; index < size; index++) {
+    if (bytes[index] != 0)
+      return false;
+  }
+  return true;
+}
+
+static void
+set_error(char* error, size_t error_size, const char* message)
+{
+  if (error != NULL && error_size != 0)
+    snprintf(error, error_size, "%s", message);
+}
+
+int
+cuinterpose_posix_create_ticket(const struct cuinterpose_posix_ticket* ticket, int* output)
+{
+  const int seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
+  int fd;
+
+  fd = memfd_create("cuinterpose-ticket", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (fd < 0 || write_all(fd, ticket, sizeof(*ticket)) != 0 || fcntl(fd, F_ADD_SEALS, seals) != 0) {
+    if (fd >= 0)
+      close(fd);
+    return -1;
+  }
+  *output = fd;
+  return 0;
+}
+
+int
+cuinterpose_posix_read_ticket(int fd, struct cuinterpose_posix_ticket* ticket)
+{
+  const int seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
+  struct stat status;
+
+  memset(ticket, 0, sizeof(*ticket));
+  /*
+   * A real driver fd is a character device: F_GET_SEALS fails on it, and the
+   * size check would fail too. Either mismatch means "not a ticket", which the
+   * caller treats as a raw fd to pass through.
+   */
+  if (fd < 0 || fcntl(fd, F_GET_SEALS) != seals || fstat(fd, &status) != 0 ||
+      status.st_size != (off_t)sizeof(*ticket) || pread_all(fd, ticket, sizeof(*ticket)) != 0 ||
+      ticket->magic != CUINTERPOSE_POSIX_TICKET_MAGIC || ticket->version != CUINTERPOSE_POSIX_TICKET_VERSION ||
+      !zero_bytes(ticket->reserved, sizeof(ticket->reserved)) ||
+      !is_lower_hex_id(ticket->creator_participant) ||
+      zero_bytes(ticket->allocation_id, sizeof(ticket->allocation_id)) || ticket->creator_endpoint[0] != '/' ||
+      memchr(ticket->creator_endpoint, '\0', sizeof(ticket->creator_endpoint)) == NULL ||
+      !zero_bytes(ticket->reserved_alignment, sizeof(ticket->reserved_alignment)) ||
+      (ticket->resource_kind != CUINTERPOSE_RESOURCE_UNICAST &&
+       ticket->resource_kind != CUINTERPOSE_RESOURCE_MULTICAST) ||
+      !zero_bytes(ticket->reserved_identity, sizeof(ticket->reserved_identity)))
+    return -1;
+  if (ticket->resource_kind == CUINTERPOSE_RESOURCE_UNICAST &&
+      (ticket->num_devices != 0 || ticket->allocation_size != 0 || ticket->handle_types != 0 ||
+       ticket->object_flags != 0))
+    return -1;
+  if (ticket->resource_kind == CUINTERPOSE_RESOURCE_MULTICAST &&
+      (ticket->num_devices == 0 || ticket->allocation_size == 0 ||
+       ticket->handle_types != CUINTERPOSE_POSIX_HANDLE_TYPE))
+    return -1;
+  return 0;
+}
+
+int
+cuinterpose_posix_request_export(
+    const struct cuinterpose_posix_ticket* ticket, int* output, char* error, size_t error_size)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  struct cuinterpose_header request;
+  struct cuinterpose_header response;
+  CUINTERPOSE_CLEANUP(close_fd) int client = -1;
+  CUINTERPOSE_CLEANUP(close_fd) int received = -1;
+
+  *output = -1;
+  set_error(error, error_size, "");
+  memset(&request, 0, sizeof(request));
+  request.magic = CUINTERPOSE_MAGIC;
+  request.version = CUINTERPOSE_VERSION;
+  request.operation = CUINTERPOSE_EXPORT;
+  request.resource_kind = ticket->resource_kind;
+  snprintf(request.participant_id, sizeof(request.participant_id), "%s", ticket->creator_participant);
+  memcpy(request.allocation_id, ticket->allocation_id, sizeof(request.allocation_id));
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", ticket->creator_endpoint);
+  client = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (client < 0 || set_socket_timeouts(client, cuinterpose_control_timeout_seconds()) != 0 ||
+      connect(client, (const struct sockaddr*)&address, sizeof(address)) != 0 ||
+      cuinterpose_send_header(client, &request, -1) != 0 ||
+      cuinterpose_receive_header(client, &response, &received) != 0) {
+    set_error(error, error_size, "cannot contact creator endpoint");
+    return -1;
+  }
+  if (!cuinterpose_header_strings_terminated(&response) || response.magic != CUINTERPOSE_MAGIC ||
+      response.version != CUINTERPOSE_VERSION || response.operation != CUINTERPOSE_EXPORT ||
+      response.count != 0 || response.payload_size != 0 ||
+      strcmp(response.participant_id, ticket->creator_participant) != 0 ||
+      response.resource_kind != ticket->resource_kind) {
+    set_error(error, error_size, "invalid creator export response");
+    return -1;
+  }
+  if (response.status != 0) {
+    set_error(error, error_size, response.message[0] != '\0' ? response.message : "creator export request failed");
+    return -1;
+  }
+  if (memcmp(response.allocation_id, ticket->allocation_id, sizeof(response.allocation_id)) != 0 || received < 0) {
+    set_error(error, error_size, "invalid creator export response");
+    return -1;
+  }
+  *output = take_fd(&received);
+  return 0;
+}

--- a/agent/cmd/cuinterpose/posix.h
+++ b/agent/cmd/cuinterpose/posix.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_POSIX_H
+#define CUINTERPOSE_POSIX_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/un.h>
+
+#include "protocol.h"
+
+/*
+ * Tickets. When an application exports a tracked allocation, the shim hands it
+ * a "ticket" instead of the driver's file descriptor: a sealed memfd holding
+ * this struct. The application passes the ticket to another process exactly as
+ * it would pass a real fd. When that process imports it, the shim there reads
+ * the ticket, connects to the creator's control socket named inside it, and
+ * asks for the real fd. The random allocation ID is an opaque capability:
+ * possession of the sealed ticket is what lets an importer name the allocation
+ * at the creator's private control socket.
+ */
+
+#define CUINTERPOSE_POSIX_TICKET_MAGIC 0x44564d43U
+#define CUINTERPOSE_POSIX_TICKET_VERSION 2U
+
+struct cuinterpose_posix_ticket {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t reserved[35];
+  char creator_participant[CUINTERPOSE_ID_SIZE];
+  uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  uint8_t reserved_alignment[2];
+  uint32_t resource_kind;
+  uint32_t num_devices;
+  uint64_t allocation_size;
+  uint64_t handle_types;
+  uint64_t object_flags;
+  uint8_t reserved_identity[24];
+};
+
+CUINTERPOSE_STATIC_ASSERT(sizeof(struct cuinterpose_posix_ticket) == 256, "cuinterpose POSIX ticket layout changed");
+
+/* On success, *output is a sealed memfd owned by the caller. */
+int cuinterpose_posix_create_ticket(const struct cuinterpose_posix_ticket* ticket, int* output);
+/* Validates and reads a ticket without taking ownership of fd. Returns -1 for
+ * anything that is not a well-formed ticket, including real driver fds. */
+int cuinterpose_posix_read_ticket(int fd, struct cuinterpose_posix_ticket* ticket);
+/* Asks the creator named in ticket for the real fd. On success *output is the
+ * raw driver fd owned by the caller; on failure *output is -1 and, when error
+ * is non-NULL, a short reason is written into it. */
+int cuinterpose_posix_request_export(
+    const struct cuinterpose_posix_ticket* ticket, int* output, char* error, size_t error_size);
+
+#endif

--- a/agent/cmd/cuinterpose/symbols.c
+++ b/agent/cmd/cuinterpose/symbols.c
@@ -1,0 +1,357 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * How the shim gets between an application and libcuda.
+ *
+ * Applications reach CUDA driver functions four ways, and the shim must cover
+ * all of them or a call slips past untracked:
+ *
+ *  1. Direct linking: the executable or a library has an undefined reference
+ *     to cuMemCreate. LD_PRELOAD puts this library first in the search order,
+ *     so the reference binds to the wrapper in interpose.c.
+ *  2. dlsym(): code loads libcuda.so.1 by hand and looks symbols up. The shim
+ *     replaces dlsym itself; when the looked-up symbol comes from libcuda or
+ *     libcudart and the shim has a wrapper for it, the wrapper is returned.
+ *  3. cuGetProcAddress(): the CUDA runtime (including the one statically linked
+ *     into PyTorch) resolves every driver function through this. The wrapper
+ *     asks the real driver first, then substitutes.
+ *  4. cudaGetDriverEntryPoint(): the runtime's public version of 3.
+ *
+ * To call the *real* functions the shim needs a dlsym that is not itself.
+ * dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.34") fetches glibc's, which is why the
+ * shim requires glibc 2.34 or newer and why the Makefile pins that version.
+ */
+
+#define _GNU_SOURCE
+
+#include "symbols.h"
+
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <link.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "export.h"
+
+#ifndef CUINTERPOSE_DLSYM_VERSION
+#error "CUINTERPOSE_DLSYM_VERSION must be set by the build"
+#endif
+
+/* cuda.h maps these names to versioned entry points; the shim wraps the names. */
+#undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+#undef cudaGetDriverEntryPoint
+#undef cudaGetDriverEntryPointByVersion
+
+/* Wrappers defined in interpose.c and multicast.c. */
+CUresult CUDAAPI cuMemCreate(CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+CUresult CUDAAPI cuMemRelease(CUmemGenericAllocationHandle);
+CUresult CUDAAPI cuMemRetainAllocationHandle(CUmemGenericAllocationHandle*, void*);
+CUresult CUDAAPI cuMemMap(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+CUresult CUDAAPI cuMemUnmap(CUdeviceptr, size_t);
+CUresult CUDAAPI cuMemSetAccess(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+CUresult CUDAAPI cuMemExportToShareableHandle(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+CUresult CUDAAPI cuMemImportFromShareableHandle(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+CUresult CUDAAPI cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+CUresult CUDAAPI cuMulticastCreate(CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+CUresult CUDAAPI cuMulticastAddDevice(CUmemGenericAllocationHandle, CUdevice);
+CUresult CUDAAPI cuMulticastBindMem(
+    CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+CUresult CUDAAPI cuMulticastBindAddr(CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+CUresult CUDAAPI cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t, unsigned long long);
+#endif
+CUresult CUDAAPI cuMulticastGetGranularity(size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
+CUresult CUDAAPI cuMulticastUnbind(CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+
+/* Resolver wrappers defined below. */
+CUINTERPOSE_API CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
+CUINTERPOSE_API CUresult CUDAAPI
+cuGetProcAddress_v2(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+CUINTERPOSE_API CUresult CUDAAPI
+cuGetProcAddress_v2_ptsz(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+CUINTERPOSE_API cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+CUINTERPOSE_API cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion(
+    const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+CUINTERPOSE_API cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+CUINTERPOSE_API cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion_ptsz(
+    const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+CUINTERPOSE_API void* dlsym(void*, const char*);
+
+static pthread_once_t real_dlsym_once = PTHREAD_ONCE_INIT;
+static void* (*real_dlsym_function)(void*, const char*);
+/*
+ * Handles the application used to load libcuda/libcudart with dlopen(). When
+ * a library is loaded RTLD_LOCAL (the CUDA runtime does this), RTLD_NEXT
+ * cannot see its symbols, so the shim remembers the handle it saw in dlsym()
+ * and falls back to it.
+ */
+static _Atomic(uintptr_t) explicit_libcuda_handle;
+static _Atomic(uintptr_t) explicit_libcudart_handle;
+static _Atomic(uintptr_t) explicit_cu_get_proc_address;
+static _Atomic(uintptr_t) explicit_cu_get_proc_address_v2;
+
+static void* replacement(const char*, int);
+
+CUresult
+cuinterpose_unavailable(void)
+{
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+static void
+initialize_real_dlsym(void)
+{
+  real_dlsym_function = (void* (*)(void*, const char*))dlvsym(RTLD_NEXT, "dlsym", CUINTERPOSE_DLSYM_VERSION);
+}
+
+static void*
+real_dlsym(void* handle, const char* name)
+{
+  if (pthread_once(&real_dlsym_once, initialize_real_dlsym) != 0 || real_dlsym_function == NULL)
+    return NULL;
+  return real_dlsym_function(handle, name);
+}
+
+void*
+cuinterpose_lookup_real_symbol(const char* name)
+{
+  void* symbol = real_dlsym(RTLD_NEXT, name);
+  void* handle;
+
+  if (symbol != NULL)
+    return symbol;
+  handle = (void*)atomic_load(&explicit_libcuda_handle);
+  if (handle != NULL && (symbol = real_dlsym(handle, name)) != NULL)
+    return symbol;
+  handle = (void*)atomic_load(&explicit_libcudart_handle);
+  return handle == NULL ? NULL : real_dlsym(handle, name);
+}
+
+/* True when `symbol` was defined by libcuda.so* or libcudart.so*. */
+static bool
+is_cuda_library(void* handle, void* symbol, const char** library)
+{
+  struct link_map* map;
+  Dl_info info;
+  const char* provider;
+  const char* requested;
+
+  if (dladdr(symbol, &info) == 0)
+    return false;
+  provider = strrchr(info.dli_fname, '/');
+  provider = provider == NULL ? info.dli_fname : provider + 1;
+  if (strncmp(provider, "libcuda.so", 10) != 0 && strncmp(provider, "libcudart.so", 12) != 0)
+    return false;
+  *library = provider;
+  if (handle == NULL || handle == RTLD_NEXT)
+    return true;
+  if (dlinfo(handle, RTLD_DI_LINKMAP, &map) != 0 || map == NULL)
+    return false;
+  requested = strrchr(map->l_name, '/');
+  requested = requested == NULL ? map->l_name : requested + 1;
+  return (strncmp(requested, "libcuda.so", 10) == 0 && strncmp(provider, "libcuda.so", 10) == 0) ||
+         (strncmp(requested, "libcudart.so", 12) == 0 && strncmp(provider, "libcudart.so", 12) == 0);
+}
+
+CUINTERPOSE_API void*
+dlsym(void* handle, const char* name)
+{
+  void* symbol = real_dlsym(handle, name);
+  void* entry;
+  const char* library;
+
+  if (symbol == NULL || !is_cuda_library(handle, symbol, &library))
+    return symbol;
+  if (strncmp(library, "libcuda.so", 10) == 0) {
+    if (handle != NULL && handle != RTLD_NEXT)
+      atomic_store(&explicit_libcuda_handle, (uintptr_t)handle);
+    if (strcmp(name, "cuGetProcAddress") == 0)
+      atomic_store(&explicit_cu_get_proc_address, (uintptr_t)symbol);
+    if (strcmp(name, "cuGetProcAddress_v2") == 0)
+      atomic_store(&explicit_cu_get_proc_address_v2, (uintptr_t)symbol);
+  } else if (handle != NULL && handle != RTLD_NEXT) {
+    atomic_store(&explicit_libcudart_handle, (uintptr_t)handle);
+  }
+  entry = replacement(name, 0);
+  return entry == NULL || entry == symbol ? symbol : entry;
+}
+
+static cudaError_t
+runtime_driver_entry_point(
+    const char* resolver, const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  cudaError_t result;
+  void* entry;
+
+  if (strcmp(resolver, "cudaGetDriverEntryPoint") == 0 || strcmp(resolver, "cudaGetDriverEntryPoint_ptsz") == 0) {
+    typedef cudaError_t(CUDARTAPI * function_type)(
+        const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+    function_type function = (function_type)cuinterpose_lookup_real_symbol(resolver);
+    result = function != NULL ? function(symbol, output, flags, status) : cudaErrorInitializationError;
+  } else {
+    typedef cudaError_t(CUDARTAPI * function_type)(
+        const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+    function_type function = (function_type)cuinterpose_lookup_real_symbol(resolver);
+    result = function != NULL ? function(symbol, output, version, flags, status) : cudaErrorInitializationError;
+  }
+  /* Only substitute after the real resolver succeeded: the shim never invents entry points. */
+  if (result == cudaSuccess && output != NULL && *output != NULL &&
+      (status == NULL || *status == cudaDriverEntryPointSuccess) &&
+      (entry = replacement(symbol, version == 0 ? CUDA_VERSION : (int)version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUINTERPOSE_API cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(
+    const char* symbol, void** output, unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPoint", symbol, output, 0, flags, status);
+}
+
+CUINTERPOSE_API cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(
+    const char* symbol, void** output, unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPoint_ptsz", symbol, output, 0, flags, status);
+}
+
+CUINTERPOSE_API cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPointByVersion", symbol, output, version, flags, status);
+}
+
+CUINTERPOSE_API cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion_ptsz(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPointByVersion_ptsz", symbol, output, version, flags, status);
+}
+
+/*
+ * The replacement table. `version` is the CUDA version the caller asked the
+ * resolver for; it selects the ABI when a function has more than one.
+ */
+static void*
+replacement(const char* symbol, int version)
+{
+#define ENTRY(name)               \
+  if (strcmp(symbol, #name) == 0) \
+  return (void*)&name
+  if (symbol == NULL)
+    return NULL;
+#if CUDA_VERSION >= 13010
+  /* CUDA 13.1 added device-explicit bind entry points; a 13.1+ caller gets them. */
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindMem") == 0)
+    return (void*)&cuMulticastBindMem_v2;
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindAddr") == 0)
+    return (void*)&cuMulticastBindAddr_v2;
+#endif
+  ENTRY(cuMemCreate);
+  ENTRY(cuMemRelease);
+  ENTRY(cuMemRetainAllocationHandle);
+  ENTRY(cuMemMap);
+  ENTRY(cuMemUnmap);
+  ENTRY(cuMemSetAccess);
+  ENTRY(cuMemExportToShareableHandle);
+  ENTRY(cuMemImportFromShareableHandle);
+  ENTRY(cuMemGetAllocationPropertiesFromHandle);
+  ENTRY(cuMulticastCreate);
+  ENTRY(cuMulticastAddDevice);
+  ENTRY(cuMulticastBindMem);
+#if CUDA_VERSION >= 13010
+  ENTRY(cuMulticastBindMem_v2);
+#endif
+  ENTRY(cuMulticastBindAddr);
+#if CUDA_VERSION >= 13010
+  ENTRY(cuMulticastBindAddr_v2);
+#endif
+  ENTRY(cuMulticastGetGranularity);
+  ENTRY(cuMulticastUnbind);
+  ENTRY(cuGetProcAddress_v2);
+  ENTRY(cuGetProcAddress_v2_ptsz);
+  ENTRY(cudaGetDriverEntryPoint);
+  ENTRY(cudaGetDriverEntryPoint_ptsz);
+  ENTRY(cudaGetDriverEntryPointByVersion);
+  ENTRY(cudaGetDriverEntryPointByVersion_ptsz);
+#undef ENTRY
+  if (strcmp(symbol, "cuGetProcAddress") == 0)
+    return version >= 12000 ? (void*)&cuGetProcAddress_v2 : (void*)&cuGetProcAddress;
+  return NULL;
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address);
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)cuinterpose_lookup_real_symbol("cuGetProcAddress");
+  result = function != NULL ? function(symbol, output, version, flags) : cuinterpose_unavailable();
+  if (result == CUDA_SUCCESS && output != NULL && *output != NULL && (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuGetProcAddress_v2(
+    const char* symbol, void** output, int version, cuuint64_t flags, CUdriverProcAddressQueryResult* status)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address_v2);
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)cuinterpose_lookup_real_symbol("cuGetProcAddress_v2");
+  result = function != NULL ? function(symbol, output, version, flags, status) : cuinterpose_unavailable();
+  if (result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (status == NULL || *status == CU_GET_PROC_ADDRESS_SUCCESS) && (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUINTERPOSE_API CUresult CUDAAPI
+cuGetProcAddress_v2_ptsz(
+    const char* symbol, void** output, int version, cuuint64_t flags, CUdriverProcAddressQueryResult* status)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address_v2);
+  const cuuint64_t stream_flags = CU_GET_PROC_ADDRESS_LEGACY_STREAM | CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)cuinterpose_lookup_real_symbol("cuGetProcAddress_v2");
+  if ((flags & stream_flags) == 0)
+    flags |= CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
+  result = function != NULL ? function(symbol, output, version, flags, status) : cuinterpose_unavailable();
+  if (result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (status == NULL || *status == CU_GET_PROC_ADDRESS_SUCCESS) && (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}

--- a/agent/cmd/cuinterpose/symbols.h
+++ b/agent/cmd/cuinterpose/symbols.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_SYMBOLS_H
+#define CUINTERPOSE_SYMBOLS_H
+
+#include <cuda.h>
+
+/* Returned by a wrapper when the real CUDA entry point cannot be found. */
+CUresult cuinterpose_unavailable(void);
+/* The real driver (or runtime) function behind `name`, or NULL. */
+void* cuinterpose_lookup_real_symbol(const char* name);
+
+#endif

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -1,0 +1,456 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "fake_cuda.h"
+
+#include <string.h>
+
+#undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+
+CUresult CUDAAPI fakeCuGetProcAddress(const char*, void**, int, cuuint64_t);
+
+static struct fake_last_call last;
+
+void
+fakeReset(void)
+{
+  memset(&last, 0, sizeof(last));
+}
+
+const struct fake_last_call*
+fakeLastCall(void)
+{
+  return &last;
+}
+
+int
+fakeDriverVersion(void)
+{
+  return CUDA_VERSION;
+}
+
+static void
+record(const char* function)
+{
+  memset(&last, 0, sizeof(last));
+  last.function = function;
+}
+
+/*
+ * Each entry point exists twice: the exported CUDA name, and a fakeXxx alias
+ * that cuGetProcAddress hands out. The alias lets a test tell "the shim's
+ * wrapper" apart from "the driver's own function".
+ */
+
+CUresult CUDAAPI
+fakeCuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
+{
+  record("cuMemCreate");
+  last.size = size;
+  last.flags = flags;
+  last.handle_type = properties != NULL ? (int)properties->requestedHandleTypes : -1;
+  if (output != NULL)
+    *output = 0xabc;
+  return (CUresult)FAKE_RESULT_CREATE;
+}
+CUresult CUDAAPI
+cuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
+{
+  return fakeCuMemCreate(output, size, properties, flags);
+}
+
+CUresult CUDAAPI
+fakeCuMemRelease(CUmemGenericAllocationHandle handle)
+{
+  record("cuMemRelease");
+  last.handle = handle;
+  return (CUresult)FAKE_RESULT_RELEASE;
+}
+CUresult CUDAAPI
+cuMemRelease(CUmemGenericAllocationHandle handle)
+{
+  return fakeCuMemRelease(handle);
+}
+
+CUresult CUDAAPI
+fakeCuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
+{
+  record("cuMemRetainAllocationHandle");
+  last.pointer = address;
+  if (output != NULL)
+    *output = 0xdef;
+  return (CUresult)FAKE_RESULT_RETAIN;
+}
+CUresult CUDAAPI
+cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
+{
+  return fakeCuMemRetainAllocationHandle(output, address);
+}
+
+CUresult CUDAAPI
+fakeCuMemMap(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+{
+  record("cuMemMap");
+  last.address = address;
+  last.size = size;
+  last.offset = offset;
+  last.handle = handle;
+  last.flags = flags;
+  return (CUresult)FAKE_RESULT_MAP;
+}
+CUresult CUDAAPI
+cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+{
+  return fakeCuMemMap(address, size, offset, handle, flags);
+}
+
+CUresult CUDAAPI
+fakeCuMemUnmap(CUdeviceptr address, size_t size)
+{
+  record("cuMemUnmap");
+  last.address = address;
+  last.size = size;
+  return (CUresult)FAKE_RESULT_UNMAP;
+}
+CUresult CUDAAPI
+cuMemUnmap(CUdeviceptr address, size_t size)
+{
+  return fakeCuMemUnmap(address, size);
+}
+
+CUresult CUDAAPI
+fakeCuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  record("cuMemSetAccess");
+  last.address = address;
+  last.size = size;
+  last.count = count;
+  last.pointer = (void*)descriptors;
+  return (CUresult)FAKE_RESULT_ACCESS;
+}
+CUresult CUDAAPI
+cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  return fakeCuMemSetAccess(address, size, descriptors, count);
+}
+
+CUresult CUDAAPI
+fakeCuMemExportToShareableHandle(
+    void* output, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  record("cuMemExportToShareableHandle");
+  last.pointer = output;
+  last.handle = handle;
+  last.handle_type = (int)type;
+  last.flags = flags;
+  return (CUresult)FAKE_RESULT_EXPORT;
+}
+CUresult CUDAAPI
+cuMemExportToShareableHandle(
+    void* output, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  return fakeCuMemExportToShareableHandle(output, handle, type, flags);
+}
+
+CUresult CUDAAPI
+fakeCuMemImportFromShareableHandle(
+    CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
+{
+  record("cuMemImportFromShareableHandle");
+  last.pointer = os_handle;
+  last.handle_type = (int)type;
+  if (output != NULL)
+    *output = 0x123;
+  return (CUresult)FAKE_RESULT_IMPORT;
+}
+CUresult CUDAAPI
+cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
+{
+  return fakeCuMemImportFromShareableHandle(output, os_handle, type);
+}
+
+CUresult CUDAAPI
+fakeCuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+{
+  record("cuMemGetAllocationPropertiesFromHandle");
+  last.pointer = properties;
+  last.handle = handle;
+  return (CUresult)FAKE_RESULT_PROPERTIES;
+}
+CUresult CUDAAPI
+cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+{
+  return fakeCuMemGetAllocationPropertiesFromHandle(properties, handle);
+}
+
+CUresult CUDAAPI
+fakeCuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  record("cuMulticastCreate");
+  last.pointer = (void*)properties;
+  last.size = properties != NULL ? properties->size : 0;
+  if (output != NULL)
+    *output = 0x456;
+  return (CUresult)FAKE_RESULT_MULTICAST_CREATE;
+}
+CUresult CUDAAPI
+cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  return fakeCuMulticastCreate(output, properties);
+}
+
+CUresult CUDAAPI
+fakeCuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+{
+  record("cuMulticastAddDevice");
+  last.handle = multicast;
+  last.device = device;
+  last.has_device = 1;
+  return (CUresult)FAKE_RESULT_MULTICAST_ADD_DEVICE;
+}
+CUresult CUDAAPI
+cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+{
+  return fakeCuMulticastAddDevice(multicast, device);
+}
+
+CUresult CUDAAPI
+fakeCuMulticastBindMem(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUmemGenericAllocationHandle memory,
+    size_t memory_offset, size_t size, unsigned long long flags)
+{
+  record("cuMulticastBindMem");
+  last.handle = multicast;
+  last.offset = multicast_offset;
+  last.memory = memory;
+  last.memory_offset = memory_offset;
+  last.size = size;
+  last.flags = flags;
+  return (CUresult)FAKE_RESULT_MULTICAST_BIND_MEM;
+}
+CUresult CUDAAPI
+cuMulticastBindMem(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUmemGenericAllocationHandle memory,
+    size_t memory_offset, size_t size, unsigned long long flags)
+{
+  return fakeCuMulticastBindMem(multicast, multicast_offset, memory, memory_offset, size, flags);
+}
+
+CUresult CUDAAPI
+fakeCuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  record("cuMulticastBindAddr");
+  last.handle = multicast;
+  last.offset = multicast_offset;
+  last.address = memory;
+  last.size = size;
+  last.flags = flags;
+  return (CUresult)FAKE_RESULT_MULTICAST_BIND_ADDRESS;
+}
+CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  return fakeCuMulticastBindAddr(multicast, multicast_offset, memory, size, flags);
+}
+
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI
+fakeCuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
+{
+  record("cuMulticastBindMem_v2");
+  last.handle = multicast;
+  last.device = device;
+  last.has_device = 1;
+  last.offset = multicast_offset;
+  last.memory = memory;
+  last.memory_offset = memory_offset;
+  last.size = size;
+  last.flags = flags;
+  return (CUresult)FAKE_RESULT_MULTICAST_BIND_MEM_V2;
+}
+CUresult CUDAAPI
+cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
+{
+  return fakeCuMulticastBindMem_v2(multicast, device, multicast_offset, memory, memory_offset, size, flags);
+}
+
+CUresult CUDAAPI
+fakeCuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  record("cuMulticastBindAddr_v2");
+  last.handle = multicast;
+  last.device = device;
+  last.has_device = 1;
+  last.offset = multicast_offset;
+  last.address = memory;
+  last.size = size;
+  last.flags = flags;
+  return (CUresult)FAKE_RESULT_MULTICAST_BIND_ADDRESS_V2;
+}
+CUresult CUDAAPI
+cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  return fakeCuMulticastBindAddr_v2(multicast, device, multicast_offset, memory, size, flags);
+}
+#endif
+
+CUresult CUDAAPI
+fakeCuMulticastGetGranularity(
+    size_t* granularity, const CUmulticastObjectProp* properties, CUmulticastGranularity_flags option)
+{
+  record("cuMulticastGetGranularity");
+  last.pointer = (void*)properties;
+  last.flags = (unsigned long long)option;
+  if (granularity != NULL)
+    *granularity = 4096;
+  return (CUresult)FAKE_RESULT_MULTICAST_GRANULARITY;
+}
+CUresult CUDAAPI
+cuMulticastGetGranularity(
+    size_t* granularity, const CUmulticastObjectProp* properties, CUmulticastGranularity_flags option)
+{
+  return fakeCuMulticastGetGranularity(granularity, properties, option);
+}
+
+CUresult CUDAAPI
+fakeCuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+{
+  record("cuMulticastUnbind");
+  last.handle = multicast;
+  last.device = device;
+  last.has_device = 1;
+  last.offset = offset;
+  last.size = size;
+  return (CUresult)FAKE_RESULT_MULTICAST_UNBIND;
+}
+CUresult CUDAAPI
+cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+{
+  return fakeCuMulticastUnbind(multicast, device, offset, size);
+}
+
+CUresult CUDAAPI
+cuCtxGetCurrent(CUcontext* context)
+{
+  *context = (CUcontext)(uintptr_t)1;
+  return CUDA_SUCCESS;
+}
+
+/*
+ * cuGetProcAddress in the real driver returns the entry point for the ABI the
+ * caller asked for. This fake does the same for the two functions that have a
+ * second ABI, and refuses versions newer than itself, like the real driver.
+ */
+void*
+fakeOriginalForVersion(const char* symbol, int version)
+{
+  static const struct {
+    const char* name;
+    void* function;
+  } table[] = {
+      {"cuMemCreate", (void*)&fakeCuMemCreate},
+      {"cuMemRelease", (void*)&fakeCuMemRelease},
+      {"cuMemRetainAllocationHandle", (void*)&fakeCuMemRetainAllocationHandle},
+      {"cuMemMap", (void*)&fakeCuMemMap},
+      {"cuMemUnmap", (void*)&fakeCuMemUnmap},
+      {"cuMemSetAccess", (void*)&fakeCuMemSetAccess},
+      {"cuMemExportToShareableHandle", (void*)&fakeCuMemExportToShareableHandle},
+      {"cuMemImportFromShareableHandle", (void*)&fakeCuMemImportFromShareableHandle},
+      {"cuMemGetAllocationPropertiesFromHandle", (void*)&fakeCuMemGetAllocationPropertiesFromHandle},
+      {"cuMulticastCreate", (void*)&fakeCuMulticastCreate},
+      {"cuMulticastAddDevice", (void*)&fakeCuMulticastAddDevice},
+      {"cuMulticastBindMem", (void*)&fakeCuMulticastBindMem},
+      {"cuMulticastBindAddr", (void*)&fakeCuMulticastBindAddr},
+#if CUDA_VERSION >= 13010
+      {"cuMulticastBindMem_v2", (void*)&fakeCuMulticastBindMem_v2},
+      {"cuMulticastBindAddr_v2", (void*)&fakeCuMulticastBindAddr_v2},
+#endif
+      {"cuMulticastGetGranularity", (void*)&fakeCuMulticastGetGranularity},
+      {"cuMulticastUnbind", (void*)&fakeCuMulticastUnbind},
+      {"cuCtxGetCurrent", (void*)&cuCtxGetCurrent},
+      /* A local alias: a reference to the global name would bind to the shim. */
+      {"cuGetProcAddress", (void*)&fakeCuGetProcAddress},
+  };
+  size_t index;
+
+#if CUDA_VERSION >= 13010
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindMem") == 0)
+    return (void*)&fakeCuMulticastBindMem_v2;
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindAddr") == 0)
+    return (void*)&fakeCuMulticastBindAddr_v2;
+#else
+  (void)version;
+#endif
+  for (index = 0; index < sizeof(table) / sizeof(table[0]); index++) {
+    if (strcmp(symbol, table[index].name) == 0)
+      return table[index].function;
+  }
+  return NULL;
+}
+
+void*
+fakeOriginal(const char* symbol)
+{
+  return fakeOriginalForVersion(symbol, CUDA_VERSION);
+}
+
+CUresult CUDAAPI
+fakeCuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flags)
+{
+  (void)flags;
+  if (version > CUDA_VERSION) {
+    *output = NULL;
+    return CUDA_ERROR_NOT_FOUND;
+  }
+  *output = fakeOriginalForVersion(symbol, version);
+  return *output == NULL ? CUDA_ERROR_NOT_FOUND : CUDA_SUCCESS;
+}
+CUresult CUDAAPI
+cuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flags)
+{
+  return fakeCuGetProcAddress(symbol, output, version, flags);
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2(
+    const char* symbol, void** output, int version, cuuint64_t flags, CUdriverProcAddressQueryResult* status)
+{
+  CUresult result = fakeCuGetProcAddress(symbol, output, version, flags);
+  if (status != NULL) {
+    if (result == CUDA_SUCCESS)
+      *status = CU_GET_PROC_ADDRESS_SUCCESS;
+    else
+      *status = version > CUDA_VERSION ? CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT
+                                       : CU_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND;
+  }
+  return result;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2_ptsz(
+    const char* symbol, void** output, int version, cuuint64_t flags, CUdriverProcAddressQueryResult* status)
+{
+  return cuGetProcAddress_v2(symbol, output, version, flags, status);
+}

--- a/agent/cmd/cuinterpose/tests/fake_cuda.h
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_FAKE_CUDA_H
+#define CUINTERPOSE_FAKE_CUDA_H
+
+/*
+ * A stand-in libcuda.so.1 for unit tests. Every entry point records the
+ * arguments it was called with and returns a distinct, recognizable error code,
+ * so a test can prove that the shim forwarded the call and its arguments
+ * unchanged. There is no GPU behind it.
+ */
+
+#include <cuda.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Return codes, one per entry point, chosen far away from real CUresults. */
+enum fake_result {
+  FAKE_RESULT_CREATE = 101,
+  FAKE_RESULT_RELEASE,
+  FAKE_RESULT_RETAIN,
+  FAKE_RESULT_MAP,
+  FAKE_RESULT_UNMAP,
+  FAKE_RESULT_ACCESS,
+  FAKE_RESULT_EXPORT,
+  FAKE_RESULT_IMPORT,
+  FAKE_RESULT_PROPERTIES,
+  FAKE_RESULT_MULTICAST_CREATE,
+  FAKE_RESULT_MULTICAST_ADD_DEVICE,
+  FAKE_RESULT_MULTICAST_BIND_MEM,
+  FAKE_RESULT_MULTICAST_BIND_ADDRESS,
+  FAKE_RESULT_MULTICAST_BIND_MEM_V2,
+  FAKE_RESULT_MULTICAST_BIND_ADDRESS_V2,
+  FAKE_RESULT_MULTICAST_GRANULARITY,
+  FAKE_RESULT_MULTICAST_UNBIND,
+};
+
+/* The most recent call's arguments, flattened. */
+struct fake_last_call {
+  const char* function; /* entry point name, or NULL after fakeReset */
+  CUmemGenericAllocationHandle handle;
+  CUmemGenericAllocationHandle memory;
+  CUdeviceptr address;
+  size_t size;
+  size_t offset;
+  size_t memory_offset;
+  unsigned long long flags;
+  CUdevice device;
+  int has_device; /* set by the entry points that take a device */
+  int handle_type;
+  size_t count;
+  void* pointer;
+};
+
+void fakeReset(void);
+const struct fake_last_call* fakeLastCall(void);
+/* The fake's own implementation of `symbol`, bypassing any interposer. */
+void* fakeOriginal(const char* symbol);
+/* Same, for a caller that asked for a specific CUDA version. */
+void* fakeOriginalForVersion(const char* symbol, int version);
+/* CUDA version the fake pretends to be; cuGetProcAddress refuses newer requests. */
+int fakeDriverVersion(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/agent/cmd/cuinterpose/tests/fake_cudart.c
+++ b/agent/cmd/cuinterpose/tests/fake_cudart.c
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* A stand-in libcudart.so.13: only the driver entry point resolvers. */
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include "fake_cuda.h"
+
+#undef cudaGetDriverEntryPoint
+#undef cudaGetDriverEntryPointByVersion
+
+static cudaError_t
+resolve(const char* symbol, void** output, unsigned int version, enum cudaDriverEntryPointQueryResult* status)
+{
+  *output = fakeOriginalForVersion(symbol, version == 0 ? CUDA_VERSION : (int)version);
+  if (status != NULL)
+    *status = *output != NULL ? cudaDriverEntryPointSuccess : cudaDriverEntryPointSymbolNotFound;
+  return *output != NULL ? cudaSuccess : cudaErrorSymbolNotFound;
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(
+    const char* symbol, void** output, unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  (void)flags;
+  return resolve(symbol, output, 0, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(
+    const char* symbol, void** output, unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  return cudaGetDriverEntryPoint(symbol, output, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  (void)flags;
+  return resolve(symbol, output, version, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion_ptsz(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return cudaGetDriverEntryPointByVersion(symbol, output, version, flags, status);
+}

--- a/agent/cmd/cuinterpose/tests/forward_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/forward_preload_test.cc
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Runs with LD_PRELOAD=libcuinterpose.so against the fake libcuda.so.1 and
+// libcudart.so.13 in the same directory. Proves that every CUDA entry point the
+// shim replaces is reached through all four resolution paths and that the call
+// arrives at the driver with its arguments unchanged.
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+#include "../export.h"
+#include "fake_cuda.h"
+
+#undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+#undef cudaGetDriverEntryPoint
+#undef cudaGetDriverEntryPointByVersion
+
+extern "C" {
+CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
+CUresult CUDAAPI cuGetProcAddress_v2(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+CUresult CUDAAPI cuGetProcAddress_v2_ptsz(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPoint(const char*, void**, unsigned long long, cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion(
+    const char*, void**, unsigned int, unsigned long long, cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPoint_ptsz(
+    const char*, void**, unsigned long long, cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion_ptsz(
+    const char*, void**, unsigned int, unsigned long long, cudaDriverEntryPointQueryResult*);
+CUresult CUDAAPI cuMulticastBindMem(
+    CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+CUresult CUDAAPI cuMulticastBindAddr(CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+CUresult CUDAAPI cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t, unsigned long long);
+#endif
+}
+
+namespace {
+
+// The shim's own copy of a wrapper, as seen from this executable. Direct calls
+// in this file bind to the same address because LD_PRELOAD comes first.
+void* shim(const char* name) { return dlsym(RTLD_DEFAULT, name); }
+
+class Forwarding : public ::testing::Test {
+ protected:
+  void SetUp() override { fakeReset(); }
+  const fake_last_call& last() const { return *fakeLastCall(); }
+};
+
+TEST_F(Forwarding, ShimIsLoadedAheadOfTheDriver) {
+  ASSERT_NE(shim("cuMemCreate"), nullptr);
+  EXPECT_NE(shim("cuMemCreate"), fakeOriginal("cuMemCreate")) << "LD_PRELOAD did not put the shim first";
+  auto* info = static_cast<const struct cuinterpose_build_info*>(dlsym(RTLD_DEFAULT, "cuinterpose_build_info"));
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->cuda_version, static_cast<uint32_t>(CUDA_VERSION));
+}
+
+TEST_F(Forwarding, UnicastEntryPointsForwardArguments) {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  CUmemGenericAllocationHandle handle = 0;
+  EXPECT_EQ(cuMemCreate(&handle, 4096, &prop, 7), static_cast<CUresult>(FAKE_RESULT_CREATE));
+  EXPECT_STREQ(last().function, "cuMemCreate");
+  EXPECT_EQ(last().size, 4096u);
+  EXPECT_EQ(last().flags, 7u);
+  EXPECT_EQ(last().handle_type, static_cast<int>(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+  EXPECT_EQ(handle, 0xabcu) << "the driver's handle must reach the caller unchanged";
+
+  EXPECT_EQ(cuMemRelease(0x77), static_cast<CUresult>(FAKE_RESULT_RELEASE));
+  EXPECT_EQ(last().handle, 0x77u);
+
+  CUmemGenericAllocationHandle retained = 0;
+  EXPECT_EQ(cuMemRetainAllocationHandle(&retained, reinterpret_cast<void*>(0x1000)),
+            static_cast<CUresult>(FAKE_RESULT_RETAIN));
+  EXPECT_EQ(last().pointer, reinterpret_cast<void*>(0x1000));
+  EXPECT_EQ(retained, 0xdefu);
+
+  EXPECT_EQ(cuMemMap(0x2000, 8192, 16, 0xabc, 3), static_cast<CUresult>(FAKE_RESULT_MAP));
+  EXPECT_EQ(last().address, 0x2000u);
+  EXPECT_EQ(last().size, 8192u);
+  EXPECT_EQ(last().offset, 16u);
+  EXPECT_EQ(last().handle, 0xabcu);
+  EXPECT_EQ(last().flags, 3u);
+
+  EXPECT_EQ(cuMemUnmap(0x2000, 8192), static_cast<CUresult>(FAKE_RESULT_UNMAP));
+  EXPECT_EQ(last().address, 0x2000u);
+
+  CUmemAccessDesc access[2]{};
+  EXPECT_EQ(cuMemSetAccess(0x2000, 8192, access, 2), static_cast<CUresult>(FAKE_RESULT_ACCESS));
+  EXPECT_EQ(last().count, 2u);
+  EXPECT_EQ(last().pointer, static_cast<void*>(access));
+
+  int fd = -1;
+  EXPECT_EQ(cuMemExportToShareableHandle(&fd, 0xabc, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0),
+            static_cast<CUresult>(FAKE_RESULT_EXPORT));
+  EXPECT_EQ(last().pointer, static_cast<void*>(&fd));
+  EXPECT_EQ(last().handle, 0xabcu);
+
+  CUmemGenericAllocationHandle imported = 0;
+  EXPECT_EQ(cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(42), CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            static_cast<CUresult>(FAKE_RESULT_IMPORT));
+  EXPECT_EQ(last().pointer, reinterpret_cast<void*>(42));
+  EXPECT_EQ(imported, 0x123u);
+
+  EXPECT_EQ(cuMemGetAllocationPropertiesFromHandle(&prop, 0x55), static_cast<CUresult>(FAKE_RESULT_PROPERTIES));
+  EXPECT_EQ(last().handle, 0x55u);
+}
+
+TEST_F(Forwarding, MulticastEntryPointsForwardArguments) {
+  CUmulticastObjectProp prop{};
+  prop.numDevices = 2;
+  prop.size = 1 << 20;
+  prop.handleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  CUmemGenericAllocationHandle mc = 0;
+  EXPECT_EQ(cuMulticastCreate(&mc, &prop), static_cast<CUresult>(FAKE_RESULT_MULTICAST_CREATE));
+  EXPECT_EQ(last().size, prop.size);
+  EXPECT_EQ(mc, 0x456u);
+
+  EXPECT_EQ(cuMulticastAddDevice(mc, 1), static_cast<CUresult>(FAKE_RESULT_MULTICAST_ADD_DEVICE));
+  EXPECT_EQ(last().device, 1);
+
+  EXPECT_EQ(cuMulticastBindMem(mc, 64, 0xabc, 128, 4096, 5), static_cast<CUresult>(FAKE_RESULT_MULTICAST_BIND_MEM));
+  EXPECT_STREQ(last().function, "cuMulticastBindMem");
+  EXPECT_EQ(last().offset, 64u);
+  EXPECT_EQ(last().memory, 0xabcu);
+  EXPECT_EQ(last().memory_offset, 128u);
+  EXPECT_EQ(last().size, 4096u);
+  EXPECT_EQ(last().flags, 5u);
+  EXPECT_EQ(last().has_device, 0);
+
+  EXPECT_EQ(cuMulticastBindAddr(mc, 64, 0x3000, 4096, 6), static_cast<CUresult>(FAKE_RESULT_MULTICAST_BIND_ADDRESS));
+  EXPECT_EQ(last().address, 0x3000u);
+
+#if CUDA_VERSION >= 13010
+  EXPECT_EQ(cuMulticastBindMem_v2(mc, 3, 64, 0xabc, 128, 4096, 5),
+            static_cast<CUresult>(FAKE_RESULT_MULTICAST_BIND_MEM_V2));
+  EXPECT_STREQ(last().function, "cuMulticastBindMem_v2");
+  EXPECT_EQ(last().device, 3);
+  EXPECT_EQ(last().has_device, 1);
+  EXPECT_EQ(cuMulticastBindAddr_v2(mc, 4, 64, 0x3000, 4096, 6),
+            static_cast<CUresult>(FAKE_RESULT_MULTICAST_BIND_ADDRESS_V2));
+  EXPECT_EQ(last().device, 4);
+#endif
+
+  size_t granularity = 0;
+  EXPECT_EQ(cuMulticastGetGranularity(&granularity, &prop, CU_MULTICAST_GRANULARITY_RECOMMENDED),
+            static_cast<CUresult>(FAKE_RESULT_MULTICAST_GRANULARITY));
+  EXPECT_EQ(granularity, 4096u);
+
+  EXPECT_EQ(cuMulticastUnbind(mc, 1, 64, 4096), static_cast<CUresult>(FAKE_RESULT_MULTICAST_UNBIND));
+  EXPECT_EQ(last().device, 1);
+  EXPECT_EQ(last().offset, 64u);
+}
+
+// A driver symbol the shim does not wrap goes straight through.
+TEST_F(Forwarding, UnwrappedDriverSymbolsAreUntouched) {
+  void* cuda = dlopen("libcuda.so.1", RTLD_NOW);
+  ASSERT_NE(cuda, nullptr);
+  EXPECT_EQ(dlsym(cuda, "cuCtxGetCurrent"), fakeOriginal("cuCtxGetCurrent"));
+  void* entry = nullptr;
+  EXPECT_EQ(cuGetProcAddress("cuCtxGetCurrent", &entry, CUDA_VERSION, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, fakeOriginal("cuCtxGetCurrent"));
+  // Non-CUDA lookups through the replaced dlsym are untouched too.
+  EXPECT_EQ(dlsym(RTLD_DEFAULT, "malloc"), reinterpret_cast<void*>(&malloc));
+  dlclose(cuda);
+}
+
+TEST_F(Forwarding, DlsymOnTheDriverHandleReturnsTheShim) {
+  void* cuda = dlopen("libcuda.so.1", RTLD_NOW);
+  ASSERT_NE(cuda, nullptr);
+  for (const char* name : {"cuMemCreate", "cuMemMap", "cuMemExportToShareableHandle", "cuMulticastCreate",
+                           "cuMulticastBindMem", "cuGetProcAddress"}) {
+    void* symbol = dlsym(cuda, name);
+    ASSERT_NE(symbol, nullptr) << name;
+    EXPECT_EQ(symbol, shim(name)) << name << " resolved to the driver, not the shim";
+    EXPECT_NE(symbol, fakeOriginal(name)) << name;
+  }
+  dlclose(cuda);
+}
+
+TEST_F(Forwarding, DlsymOnTheRuntimeHandleReturnsTheShim) {
+  void* cudart = dlopen("libcudart.so.13", RTLD_NOW);
+  ASSERT_NE(cudart, nullptr);
+  for (const char* name : {"cudaGetDriverEntryPoint", "cudaGetDriverEntryPointByVersion",
+                           "cudaGetDriverEntryPoint_ptsz", "cudaGetDriverEntryPointByVersion_ptsz"}) {
+    EXPECT_EQ(dlsym(cudart, name), shim(name)) << name;
+  }
+  dlclose(cudart);
+}
+
+TEST_F(Forwarding, CuGetProcAddressSubstitutesAllVersions) {
+  for (const char* name : {"cuMemCreate", "cuMemRelease", "cuMemRetainAllocationHandle", "cuMemMap", "cuMemUnmap",
+                           "cuMemSetAccess", "cuMemExportToShareableHandle", "cuMemImportFromShareableHandle",
+                           "cuMemGetAllocationPropertiesFromHandle", "cuMulticastCreate", "cuMulticastAddDevice",
+                           "cuMulticastGetGranularity", "cuMulticastUnbind"}) {
+    void* v1 = nullptr;
+    EXPECT_EQ(cuGetProcAddress(name, &v1, 12000, 0), CUDA_SUCCESS) << name;
+    EXPECT_EQ(v1, shim(name)) << name << " via cuGetProcAddress";
+
+    void* v2 = nullptr;
+    CUdriverProcAddressQueryResult status{};
+    EXPECT_EQ(cuGetProcAddress_v2(name, &v2, CUDA_VERSION, 0, &status), CUDA_SUCCESS) << name;
+    EXPECT_EQ(status, CU_GET_PROC_ADDRESS_SUCCESS);
+    EXPECT_EQ(v2, shim(name)) << name << " via cuGetProcAddress_v2";
+
+    void* ptsz = nullptr;
+    EXPECT_EQ(cuGetProcAddress_v2_ptsz(name, &ptsz, CUDA_VERSION, 0, &status), CUDA_SUCCESS) << name;
+    EXPECT_EQ(ptsz, shim(name)) << name << " via cuGetProcAddress_v2_ptsz";
+  }
+}
+
+TEST_F(Forwarding, CuGetProcAddressResolvesItself) {
+  void* entry = nullptr;
+  EXPECT_EQ(cuGetProcAddress("cuGetProcAddress", &entry, 11000, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, shim("cuGetProcAddress")) << "pre-12.0 callers get the four-argument ABI";
+  EXPECT_EQ(cuGetProcAddress("cuGetProcAddress", &entry, 12000, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, shim("cuGetProcAddress_v2")) << "12.0+ callers get the five-argument ABI";
+}
+
+TEST_F(Forwarding, CuGetProcAddressSelectsTheBindAbiByVersion) {
+  void* entry = nullptr;
+  EXPECT_EQ(cuGetProcAddress("cuMulticastBindMem", &entry, 12000, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, shim("cuMulticastBindMem"));
+  EXPECT_EQ(cuGetProcAddress("cuMulticastBindAddr", &entry, 12000, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, shim("cuMulticastBindAddr"));
+#if CUDA_VERSION >= 13010
+  EXPECT_EQ(cuGetProcAddress("cuMulticastBindMem", &entry, 13010, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, shim("cuMulticastBindMem_v2")) << "a 13.1 caller must get the device-explicit ABI";
+  EXPECT_EQ(cuGetProcAddress("cuMulticastBindAddr", &entry, 13010, 0), CUDA_SUCCESS);
+  EXPECT_EQ(entry, shim("cuMulticastBindAddr_v2"));
+  // And the substituted wrapper really has the seven-argument signature.
+  using bind_v2 = CUresult(CUDAAPI*)(CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle,
+                                     size_t, size_t, unsigned long long);
+  EXPECT_EQ(cuGetProcAddress("cuMulticastBindMem", &entry, 13010, 0), CUDA_SUCCESS);
+  EXPECT_EQ(reinterpret_cast<bind_v2>(entry)(0x456, 2, 0, 0xabc, 0, 4096, 0),
+            static_cast<CUresult>(FAKE_RESULT_MULTICAST_BIND_MEM_V2));
+  EXPECT_EQ(last().device, 2);
+#endif
+}
+
+TEST_F(Forwarding, CuGetProcAddressFailureIsNotSubstituted) {
+  void* entry = reinterpret_cast<void*>(1);
+  CUdriverProcAddressQueryResult status{};
+  EXPECT_EQ(cuGetProcAddress_v2("cuMemCreate", &entry, fakeDriverVersion() + 1000, 0, &status), CUDA_ERROR_NOT_FOUND);
+  EXPECT_EQ(status, CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT);
+  EXPECT_EQ(entry, nullptr) << "a driver error must not be turned into a shim wrapper";
+  EXPECT_EQ(cuGetProcAddress("cuDoesNotExist", &entry, CUDA_VERSION, 0), CUDA_ERROR_NOT_FOUND);
+  EXPECT_EQ(entry, nullptr);
+}
+
+TEST_F(Forwarding, RuntimeResolversSubstitute) {
+  for (const char* name : {"cuMemCreate", "cuMemMap", "cuMulticastCreate", "cuMulticastAddDevice"}) {
+    void* entry = nullptr;
+    cudaDriverEntryPointQueryResult status{};
+    EXPECT_EQ(cudaGetDriverEntryPoint(name, &entry, cudaEnableDefault, &status), cudaSuccess) << name;
+    EXPECT_EQ(status, cudaDriverEntryPointSuccess);
+    EXPECT_EQ(entry, shim(name)) << name << " via cudaGetDriverEntryPoint";
+    entry = nullptr;
+    EXPECT_EQ(cudaGetDriverEntryPoint_ptsz(name, &entry, cudaEnableDefault, &status), cudaSuccess) << name;
+    EXPECT_EQ(entry, shim(name)) << name << " via cudaGetDriverEntryPoint_ptsz";
+    entry = nullptr;
+    EXPECT_EQ(cudaGetDriverEntryPointByVersion(name, &entry, 12000, cudaEnableDefault, &status), cudaSuccess) << name;
+    EXPECT_EQ(entry, shim(name)) << name << " via cudaGetDriverEntryPointByVersion";
+    entry = nullptr;
+    EXPECT_EQ(cudaGetDriverEntryPointByVersion_ptsz(name, &entry, 12000, cudaEnableDefault, &status), cudaSuccess)
+        << name;
+    EXPECT_EQ(entry, shim(name)) << name << " via cudaGetDriverEntryPointByVersion_ptsz";
+  }
+  void* entry = reinterpret_cast<void*>(1);
+  cudaDriverEntryPointQueryResult status{};
+  EXPECT_EQ(cudaGetDriverEntryPoint("cuDoesNotExist", &entry, cudaEnableDefault, &status), cudaErrorSymbolNotFound);
+  EXPECT_EQ(status, cudaDriverEntryPointSymbolNotFound);
+  EXPECT_EQ(entry, nullptr);
+#if CUDA_VERSION >= 13010
+  EXPECT_EQ(cudaGetDriverEntryPointByVersion("cuMulticastBindMem", &entry, 13010, cudaEnableDefault, &status), cudaSuccess);
+  EXPECT_EQ(entry, shim("cuMulticastBindMem_v2"));
+#endif
+}
+
+// The substituted entry point behaves like a direct call.
+TEST_F(Forwarding, SubstitutedEntryPointForwards) {
+  using create_fn = CUresult(CUDAAPI*)(CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+  void* entry = nullptr;
+  ASSERT_EQ(cuGetProcAddress("cuMemCreate", &entry, CUDA_VERSION, 0), CUDA_SUCCESS);
+  CUmemGenericAllocationHandle handle = 0;
+  EXPECT_EQ(reinterpret_cast<create_fn>(entry)(&handle, 123, nullptr, 0), static_cast<CUresult>(FAKE_RESULT_CREATE));
+  EXPECT_EQ(last().size, 123u);
+  EXPECT_EQ(last().handle_type, -1);
+}
+
+}  // namespace

--- a/agent/cmd/cuinterpose/tests/proto_unit_test.cc
+++ b/agent/cmd/cuinterpose/tests/proto_unit_test.cc
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the ticket format and the control-socket helpers. These need
+// no CUDA headers and no LD_PRELOAD: util.c and posix.c are linked in.
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+extern "C" {
+#include "../posix.h"
+#include "../protocol.h"
+#include "util/io.h"
+#include "util/misc.h"
+}
+
+namespace {
+
+int open_fds() {
+  int count = 0;
+  DIR* dir = opendir("/proc/self/fd");
+  if (dir == nullptr) return -1;
+  while (readdir(dir) != nullptr) count++;
+  closedir(dir);
+  return count - 3;  // ".", "..", and the directory stream itself
+}
+
+cuinterpose_posix_ticket sample_ticket() {
+  cuinterpose_posix_ticket ticket{};
+  ticket.magic = CUINTERPOSE_POSIX_TICKET_MAGIC;
+  ticket.version = CUINTERPOSE_POSIX_TICKET_VERSION;
+  ticket.resource_kind = CUINTERPOSE_RESOURCE_UNICAST;
+  std::memcpy(ticket.creator_participant, "0123456789abcdef0123456789abcdef", 33);
+  for (size_t i = 0; i < sizeof(ticket.allocation_id); i++) ticket.allocation_id[i] = static_cast<uint8_t>(i + 1);
+  std::strcpy(ticket.creator_endpoint, "/snapshot-control/cuinterpose-42.sock");
+  return ticket;
+}
+
+TEST(Util, BoundedSecondsParsing) {
+  EXPECT_EQ(bounded_seconds(nullptr, 7), 7u);
+  EXPECT_EQ(bounded_seconds("", 7), 7u);
+  EXPECT_EQ(bounded_seconds("30", 7), 30u);
+  EXPECT_EQ(bounded_seconds(" 30\n", 7), 30u);
+  EXPECT_EQ(bounded_seconds("3x", 7), 7u) << "trailing garbage must not arm a shorter timeout";
+  EXPECT_EQ(bounded_seconds("0", 7), 7u);
+  EXPECT_EQ(bounded_seconds("-5", 7), 7u);
+  EXPECT_EQ(bounded_seconds("86401", 7), 7u);
+  EXPECT_EQ(bounded_seconds("86400", 7), 86400u);
+}
+
+TEST(Util, HeaderRoundTripWithDescriptor) {
+  int pair[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pair), 0);
+  int passed = memfd_create("payload", MFD_CLOEXEC);
+  ASSERT_GE(passed, 0);
+  ASSERT_EQ(write(passed, "hi", 2), 2);
+
+  cuinterpose_header out{};
+  out.magic = CUINTERPOSE_MAGIC;
+  out.version = CUINTERPOSE_VERSION;
+  out.operation = CUINTERPOSE_EXPORT;
+  std::strcpy(out.participant_id, "0123456789abcdef0123456789abcdef");
+  ASSERT_EQ(cuinterpose_send_header(pair[0], &out, passed), 0);
+
+  cuinterpose_header in{};
+  int received = -1;
+  ASSERT_EQ(cuinterpose_receive_header(pair[1], &in, &received), 0);
+  EXPECT_EQ(in.magic, CUINTERPOSE_MAGIC);
+  EXPECT_EQ(in.operation, CUINTERPOSE_EXPORT);
+  EXPECT_STREQ(in.participant_id, out.participant_id);
+  ASSERT_GE(received, 0);
+  EXPECT_NE(received, passed);
+  char buffer[3] = {};
+  EXPECT_EQ(pread(received, buffer, 2, 0), 2);
+  EXPECT_STREQ(buffer, "hi");
+  // The received descriptor is close-on-exec so an exec'd child cannot inherit it.
+  EXPECT_NE(fcntl(received, F_GETFD) & FD_CLOEXEC, 0);
+  close(received);
+
+  // Without a descriptor, *passed_fd is -1.
+  ASSERT_EQ(cuinterpose_send_header(pair[0], &out, -1), 0);
+  received = 99;
+  ASSERT_EQ(cuinterpose_receive_header(pair[1], &in, &received), 0);
+  EXPECT_EQ(received, -1);
+
+  close(passed);
+  close(pair[0]);
+  close(pair[1]);
+}
+
+// A peer that sends two descriptors, or a short message, must not leak fds
+// into this process.
+TEST(Util, ReceiveHeaderClosesDescriptorsOnMalformedMessages) {
+  int pair[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pair), 0);
+  int a = memfd_create("a", MFD_CLOEXEC);
+  int b = memfd_create("b", MFD_CLOEXEC);
+  ASSERT_GE(a, 0);
+  ASSERT_GE(b, 0);
+  const int before = open_fds();
+
+  {
+    cuinterpose_header out{};
+    out.magic = CUINTERPOSE_MAGIC;
+    char control[CMSG_SPACE(sizeof(int) * 2)] = {};
+    iovec vector{&out, sizeof(out)};
+    msghdr message{};
+    message.msg_iov = &vector;
+    message.msg_iovlen = 1;
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    cmsghdr* item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(int) * 2);
+    int fds[2] = {a, b};
+    std::memcpy(CMSG_DATA(item), fds, sizeof(fds));
+    ASSERT_EQ(sendmsg(pair[0], &message, MSG_NOSIGNAL), static_cast<ssize_t>(sizeof(out)));
+  }
+  cuinterpose_header in{};
+  int received = 5;
+  EXPECT_EQ(cuinterpose_receive_header(pair[1], &in, &received), -1) << "two descriptors is a protocol violation";
+  EXPECT_EQ(received, -1);
+  EXPECT_EQ(open_fds(), before) << "the rejected descriptors must have been closed";
+
+  {
+    // Short message carrying one descriptor: rejected, descriptor closed.
+    char control[CMSG_SPACE(sizeof(int))] = {};
+    char short_payload[8] = {};
+    iovec vector{short_payload, sizeof(short_payload)};
+    msghdr message{};
+    message.msg_iov = &vector;
+    message.msg_iovlen = 1;
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    cmsghdr* item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(int));
+    std::memcpy(CMSG_DATA(item), &a, sizeof(a));
+    ASSERT_EQ(sendmsg(pair[0], &message, MSG_NOSIGNAL), static_cast<ssize_t>(sizeof(short_payload)));
+    close(pair[0]);  // so MSG_WAITALL returns short
+  }
+  received = 5;
+  EXPECT_EQ(cuinterpose_receive_header(pair[1], &in, &received), -1);
+  EXPECT_EQ(received, -1);
+  EXPECT_EQ(open_fds(), before - 1) << "only pair[0] was closed by the test itself";
+
+  close(a);
+  close(b);
+  close(pair[1]);
+}
+
+TEST(Util, SendAllToClosedPeerFailsWithoutSignal) {
+  int pair[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pair), 0);
+  close(pair[1]);
+  char buffer[64] = {};
+  // Would raise SIGPIPE with plain write(); MSG_NOSIGNAL turns it into EPIPE.
+  EXPECT_EQ(send_all(pair[0], buffer, sizeof(buffer)), -1);
+  close(pair[0]);
+}
+
+TEST(Ticket, RoundTrip) {
+  cuinterpose_posix_ticket ticket = sample_ticket();
+  int fd = -1;
+  ASSERT_EQ(cuinterpose_posix_create_ticket(&ticket, &fd), 0);
+  ASSERT_GE(fd, 0);
+  cuinterpose_posix_ticket read{};
+  EXPECT_EQ(cuinterpose_posix_read_ticket(fd, &read), 0);
+  EXPECT_EQ(std::memcmp(&read, &ticket, sizeof(ticket)), 0);
+  // Sealed: nobody can alter a ticket after it is handed out.
+  EXPECT_EQ(write(fd, "x", 1), -1);
+  EXPECT_EQ(ftruncate(fd, 0), -1);
+  close(fd);
+}
+
+TEST(Ticket, RejectsThingsThatAreNotTickets) {
+  cuinterpose_posix_ticket read{};
+  EXPECT_EQ(cuinterpose_posix_read_ticket(-1, &read), -1);
+
+  int plain = memfd_create("plain", MFD_CLOEXEC);
+  ASSERT_GE(plain, 0);
+  cuinterpose_posix_ticket ticket = sample_ticket();
+  ASSERT_EQ(write(plain, &ticket, sizeof(ticket)), static_cast<ssize_t>(sizeof(ticket)));
+  EXPECT_EQ(cuinterpose_posix_read_ticket(plain, &read), -1) << "an unsealed memfd is not a ticket";
+  close(plain);
+
+  int devnull = open("/dev/null", O_RDONLY | O_CLOEXEC);
+  ASSERT_GE(devnull, 0);
+  EXPECT_EQ(cuinterpose_posix_read_ticket(devnull, &read), -1) << "a character device is a raw fd";
+  close(devnull);
+
+  auto rejects = [&](void (*mutate)(cuinterpose_posix_ticket&), const char* why) {
+    cuinterpose_posix_ticket bad = sample_ticket();
+    mutate(bad);
+    int fd = -1;
+    ASSERT_EQ(cuinterpose_posix_create_ticket(&bad, &fd), 0);
+    EXPECT_EQ(cuinterpose_posix_read_ticket(fd, &read), -1) << why;
+    close(fd);
+  };
+  rejects([](cuinterpose_posix_ticket& t) { t.magic = 0; }, "bad magic");
+  rejects([](cuinterpose_posix_ticket& t) { t.version = 1; }, "old version");
+  rejects([](cuinterpose_posix_ticket& t) { t.creator_participant[0] = 'X'; }, "participant not hex");
+  rejects([](cuinterpose_posix_ticket& t) { std::memset(t.allocation_id, 0, sizeof(t.allocation_id)); }, "no allocation");
+  rejects([](cuinterpose_posix_ticket& t) { t.creator_endpoint[0] = 'r'; }, "relative endpoint");
+  rejects([](cuinterpose_posix_ticket& t) { t.resource_kind = 9; }, "unknown resource kind");
+  rejects([](cuinterpose_posix_ticket& t) { t.allocation_size = 1; }, "unicast ticket with multicast fields");
+  rejects([](cuinterpose_posix_ticket& t) { t.reserved[0] = 1; }, "reserved bytes must be zero");
+}
+
+// A fake creator endpoint: accepts one connection and answers as told.
+struct Creator {
+  std::string path;
+  int listener = -1;
+  cuinterpose_header reply{};
+  int reply_fd = -1;
+  bool garbage = false;
+  cuinterpose_header request{};
+  pthread_t thread{};
+
+  explicit Creator(const std::string& dir) : path(dir + "/cuinterpose-1.sock") {
+    listener = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    sockaddr_un address{};
+    address.sun_family = AF_UNIX;
+    std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+    if (bind(listener, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0 || listen(listener, 1) != 0) {
+      close(listener);
+      listener = -1;
+    }
+  }
+  static void* run(void* arg) {
+    auto* self = static_cast<Creator*>(arg);
+    int client = accept4(self->listener, nullptr, nullptr, SOCK_CLOEXEC);
+    if (client < 0) return nullptr;
+    int passed = -1;
+    if (cuinterpose_receive_header(client, &self->request, &passed) == 0) {
+      if (self->garbage) {
+        (void)send_all(client, "junk", 4);
+      } else {
+        (void)cuinterpose_send_header(client, &self->reply, self->reply_fd);
+      }
+    }
+    if (passed >= 0) close(passed);
+    close(client);
+    return nullptr;
+  }
+  void start() { pthread_create(&thread, nullptr, run, this); }
+  void join() { pthread_join(thread, nullptr); }
+  ~Creator() {
+    if (listener >= 0) close(listener);
+    unlink(path.c_str());
+  }
+};
+
+class RequestExport : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    char tmpl[] = "/tmp/cuinterpose-test-XXXXXX";
+    ASSERT_NE(mkdtemp(tmpl), nullptr);
+    dir = tmpl;
+    ticket = sample_ticket();
+  }
+  void TearDown() override { rmdir(dir.c_str()); }
+  cuinterpose_header good_reply(const Creator& creator) const {
+    cuinterpose_header reply{};
+    reply.magic = CUINTERPOSE_MAGIC;
+    reply.version = CUINTERPOSE_VERSION;
+    reply.operation = CUINTERPOSE_EXPORT;
+    reply.resource_kind = ticket.resource_kind;
+    std::strcpy(reply.participant_id, ticket.creator_participant);
+    std::memcpy(reply.allocation_id, ticket.allocation_id, sizeof(reply.allocation_id));
+    (void)creator;
+    return reply;
+  }
+  std::string dir;
+  cuinterpose_posix_ticket ticket;
+};
+
+TEST_F(RequestExport, ReturnsTheCreatorsDescriptor) {
+  Creator creator(dir);
+  ASSERT_GE(creator.listener, 0);
+  std::strcpy(ticket.creator_endpoint, creator.path.c_str());
+  creator.reply = good_reply(creator);
+  creator.reply_fd = memfd_create("real", MFD_CLOEXEC);
+  ASSERT_EQ(write(creator.reply_fd, "gpu", 3), 3);
+  creator.start();
+
+  int fd = -1;
+  char error[96] = {};
+  EXPECT_EQ(cuinterpose_posix_request_export(&ticket, &fd, error, sizeof(error)), 0) << error;
+  creator.join();
+  ASSERT_GE(fd, 0);
+  char buffer[4] = {};
+  EXPECT_EQ(pread(fd, buffer, 3, 0), 3);
+  EXPECT_STREQ(buffer, "gpu");
+  close(fd);
+  close(creator.reply_fd);
+  // The creator saw an EXPORT request carrying the ticket's allocation identity.
+  EXPECT_EQ(creator.request.operation, CUINTERPOSE_EXPORT);
+  EXPECT_STREQ(creator.request.participant_id, ticket.creator_participant);
+  EXPECT_EQ(std::memcmp(creator.request.allocation_id, ticket.allocation_id, sizeof(ticket.allocation_id)), 0);
+}
+
+TEST_F(RequestExport, ClosesADescriptorAttachedToABadReply) {
+  Creator creator(dir);
+  ASSERT_GE(creator.listener, 0);
+  std::strcpy(ticket.creator_endpoint, creator.path.c_str());
+  creator.reply = good_reply(creator);
+  creator.reply.allocation_id[0] ^= 0xff;  // wrong allocation
+  creator.reply_fd = memfd_create("real", MFD_CLOEXEC);
+  const int before = open_fds();
+  creator.start();
+  int fd = -1;
+  char error[96] = {};
+  EXPECT_EQ(cuinterpose_posix_request_export(&ticket, &fd, error, sizeof(error)), -1);
+  creator.join();
+  EXPECT_EQ(fd, -1);
+  EXPECT_STREQ(error, "invalid creator export response");
+  EXPECT_EQ(open_fds(), before) << "the descriptor on a rejected reply must be closed";
+  close(creator.reply_fd);
+}
+
+TEST_F(RequestExport, HandlesGarbageAndAbsentCreators) {
+  {
+    Creator creator(dir);
+    ASSERT_GE(creator.listener, 0);
+    std::strcpy(ticket.creator_endpoint, creator.path.c_str());
+    creator.garbage = true;
+    creator.start();
+    int fd = -1;
+    char error[96] = {};
+    EXPECT_EQ(cuinterpose_posix_request_export(&ticket, &fd, error, sizeof(error)), -1);
+    creator.join();
+    EXPECT_EQ(fd, -1);
+    EXPECT_STREQ(error, "cannot contact creator endpoint");
+  }
+  std::strcpy(ticket.creator_endpoint, (dir + "/nobody.sock").c_str());
+  int fd = -1;
+  char error[96] = {};
+  EXPECT_EQ(cuinterpose_posix_request_export(&ticket, &fd, error, sizeof(error)), -1);
+  EXPECT_EQ(fd, -1);
+  EXPECT_STREQ(error, "cannot contact creator endpoint");
+  // A NULL error buffer is fine.
+  EXPECT_EQ(cuinterpose_posix_request_export(&ticket, &fd, nullptr, 0), -1);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Layer 5 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293). Closed PR #214 is intentionally not in the active stack.

This PR replaces the inert shim with transparent CUDA forwarding and defines the POSIX ticket primitives later tracking layers use. No allocation or multicast state is tracked at this layer.

Cuinterpose intercepts all four ways an application can reach a driver entry point: direct ELF binding, `dlsym`, the `cuGetProcAddress*` family, and the CUDA runtime's `cudaGetDriverEntryPoint*` family. Resolver wrappers call the real resolver first and substitute only successful CUDA results, so the shim never invents APIs unsupported by the installed driver. CUDA 13.1 requests select the device-explicit multicast bind ABI.

The intercepted surface covers CUDA VMM create/release/retain/map/unmap/access/export/import/property APIs and the corresponding multicast operations. Every wrapper checks symbol availability and forwards arguments/results unchanged in this PR.

`posix.c` defines the sealed 256-byte memfd ticket used in later layers. A ticket names the original creator participant and endpoint, resource kind, and random 128-bit allocation ID. The allocation ID is the opaque resource identity and export-cache key. An importer sends an `EXPORT` request carrying the participant, resource kind, and allocation identity needed for lookup. The creator rejects unknown IDs and returns a fresh real CUDA descriptor over `SCM_RIGHTS` for a known cached resource. Both peer traffic and coordinator traffic terminate on the same owner-only per-process Unix socket once #217 starts it. The peer request path uses scoped descriptor ownership and direct error returns; it has no `goto` cleanup path.

Tests cover direct and resolver forwarding, ABI selection, ticket validation, descriptor passing, malformed ancillary data, unavailable symbols, and the rule that resolver failure is not substituted.

## Stack boundary

Based on #223. #216 implements coordinator orchestration and global validation. #217 turns the forwarding wrappers into active POSIX-FD tracking and starts the per-process listener.

## Validation

On the final stack, `make test` passes in all Go modules. The pinned CUDA 13.1 builder compiles the production shim and coordinator with `-Werror`; the forwarding suite passes 12 tests, and the protocol suite passes 9 tests, with ASan/UBSan enabled. The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its physical-GPU suite passed all 3 tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.




