### PR TITLE
feat(agent): track POSIX CUDA VMM state

### DIFF
--- a/agent/cmd/cuinterpose/export_cache.c
+++ b/agent/cmd/cuinterpose/export_cache.c
@@ -1,0 +1,219 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "export_cache.h"
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "util/table.h"
+
+struct entry {
+  int fd;
+  unsigned in_flight; /* requests that duplicated fd and have not finished */
+  bool draining; /* no new requests; waiting for in_flight to reach zero */
+};
+
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t idle = PTHREAD_COND_INITIALIZER;
+static struct table entries;
+static bool accepting = true;
+
+/* Caller holds lock. Waits until nobody is using the entry, then closes it. */
+static void
+retire_locked(struct key key, struct entry* entry)
+{
+  entry->draining = true;
+  while (entry->in_flight != 0)
+    pthread_cond_wait(&idle, &lock);
+  table_remove(&entries, key);
+  close(entry->fd);
+  free(entry);
+}
+
+int
+cuinterpose_export_cache_put(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE], int fd)
+{
+  struct key key = key_bytes(id);
+  struct entry* entry = calloc(1, sizeof(*entry));
+  struct entry* existing;
+
+  if (entry == NULL)
+    return -1;
+  entry->fd = fd;
+  pthread_mutex_lock(&lock);
+  existing = table_get(&entries, key);
+  if (existing != NULL)
+    retire_locked(key, existing);
+  if (table_put(&entries, key, entry) != 0) {
+    pthread_mutex_unlock(&lock);
+    free(entry);
+    return -1;
+  }
+  pthread_mutex_unlock(&lock);
+  return 0;
+}
+
+bool
+cuinterpose_export_cache_has(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  bool present;
+
+  pthread_mutex_lock(&lock);
+  present = table_get(&entries, key_bytes(id)) != NULL;
+  pthread_mutex_unlock(&lock);
+  return present;
+}
+
+int
+cuinterpose_export_cache_begin(
+    const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE], int* dup, const char** reason)
+{
+  struct entry* entry;
+  int result = -1;
+
+  *dup = -1;
+  pthread_mutex_lock(&lock);
+  entry = table_get(&entries, key_bytes(id));
+  if (!accepting || entry == NULL || entry->draining) {
+    *reason = "creator resource is unavailable";
+  } else {
+    *dup = fcntl(entry->fd, F_DUPFD_CLOEXEC, 0);
+    if (*dup < 0) {
+      *reason = "cannot duplicate creator descriptor";
+    } else {
+      entry->in_flight++;
+      result = 0;
+    }
+  }
+  pthread_mutex_unlock(&lock);
+  return result;
+}
+
+void
+cuinterpose_export_cache_end(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  struct entry* entry;
+
+  pthread_mutex_lock(&lock);
+  entry = table_get(&entries, key_bytes(id));
+  if (entry != NULL && entry->in_flight != 0) {
+    entry->in_flight--;
+    if (entry->in_flight == 0)
+      pthread_cond_broadcast(&idle);
+  }
+  pthread_mutex_unlock(&lock);
+}
+
+void
+cuinterpose_export_cache_drop(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  struct key key = key_bytes(id);
+  struct entry* entry;
+
+  pthread_mutex_lock(&lock);
+  entry = table_get(&entries, key);
+  if (entry != NULL)
+    retire_locked(key, entry);
+  pthread_mutex_unlock(&lock);
+}
+
+struct collect {
+  struct key* keys;
+  size_t count;
+};
+
+static int
+collect_key(struct key key, void* value, void* arg)
+{
+  struct collect* collect = arg;
+
+  (void)value;
+  collect->keys[collect->count++] = key;
+  return 0;
+}
+
+void
+cuinterpose_export_cache_quiesce(void)
+{
+  struct collect collect = {NULL, 0};
+  size_t index;
+
+  pthread_mutex_lock(&lock);
+  accepting = false;
+  collect.keys = calloc(entries.count == 0 ? 1 : entries.count, sizeof(*collect.keys));
+  if (collect.keys != NULL) {
+    table_each(&entries, collect_key, &collect);
+    for (index = 0; index < collect.count; index++) {
+      struct entry* entry = table_get(&entries, collect.keys[index]);
+      if (entry != NULL)
+        retire_locked(collect.keys[index], entry);
+    }
+    free(collect.keys);
+  }
+  pthread_mutex_unlock(&lock);
+}
+
+void
+cuinterpose_export_cache_resume(void)
+{
+  pthread_mutex_lock(&lock);
+  accepting = true;
+  pthread_mutex_unlock(&lock);
+}
+
+size_t
+cuinterpose_export_cache_count(void)
+{
+  size_t count;
+
+  pthread_mutex_lock(&lock);
+  count = entries.count;
+  pthread_mutex_unlock(&lock);
+  return count;
+}
+
+void
+cuinterpose_export_cache_fork_prepare(void)
+{
+  pthread_mutex_lock(&lock);
+}
+
+void
+cuinterpose_export_cache_fork_parent(void)
+{
+  pthread_mutex_unlock(&lock);
+}
+
+static int
+close_entry(struct key key, void* value, void* arg)
+{
+  struct entry* entry = value;
+
+  (void)key;
+  (void)arg;
+  close(entry->fd);
+  free(entry);
+  return 0;
+}
+
+void
+cuinterpose_export_cache_fork_child(void)
+{
+  /* Inherited descriptors belong to the parent's allocations; the child owns
+   * no shared memory yet. Locks are re-initialized because the other threads
+   * that might have held them do not exist in the child. */
+  table_each(&entries, close_entry, NULL);
+  table_clear(&entries);
+  accepting = true;
+  pthread_mutex_init(&lock, NULL);
+  pthread_cond_init(&idle, NULL);
+}

--- a/agent/cmd/cuinterpose/export_cache.h
+++ b/agent/cmd/cuinterpose/export_cache.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_EXPORT_CACHE_H
+#define CUINTERPOSE_EXPORT_CACHE_H
+
+/*
+ * The export cache holds, for every shared allocation this process created,
+ * the real file descriptor the driver produced when the allocation was first
+ * exported. The listener thread answers a peer's request by duplicating that
+ * descriptor. It never calls into the driver and never takes the shim's main
+ * lock, so a creator that is busy inside a long driver call cannot make its
+ * peers wait.
+ *
+ * Lock order is state_lock (interpose.c) -> the cache's own lock. The listener
+ * takes only the cache lock. A descriptor is closed only after every in-flight
+ * request that duplicated it has finished, so a request can never duplicate a
+ * descriptor number that has been closed and reused for something else.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "protocol.h"
+
+/* Store fd (ownership passes to the cache) for the allocation. Replaces an
+ * earlier entry for the same id after draining requests that use it. */
+int cuinterpose_export_cache_put(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE], int fd);
+/* Does the cache hold a descriptor for this allocation? */
+bool cuinterpose_export_cache_has(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE]);
+/*
+ * Begin serving a peer: on success *dup is a fresh close-on-exec duplicate the
+ * caller must close, and the entry is pinned until cuinterpose_export_cache_end.
+ * Returns -1 with a short reason when the allocation ID is unknown or the
+ * cache is not accepting requests.
+ */
+int cuinterpose_export_cache_begin(
+    const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE], int* dup, const char** reason);
+void cuinterpose_export_cache_end(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE]);
+/* Drop one allocation's descriptor, waiting for its in-flight requests. */
+void cuinterpose_export_cache_drop(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE]);
+/* Stop accepting requests, wait for all in flight, close every descriptor. */
+void cuinterpose_export_cache_quiesce(void);
+/* Accept requests again (after restore has refilled the cache). */
+void cuinterpose_export_cache_resume(void);
+size_t cuinterpose_export_cache_count(void);
+
+/* pthread_atfork hooks: the parent holds the lock across fork; the child owns
+ * none of the inherited descriptors and starts empty. */
+void cuinterpose_export_cache_fork_prepare(void);
+void cuinterpose_export_cache_fork_parent(void);
+void cuinterpose_export_cache_fork_child(void);
+
+#endif

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -5,21 +5,57 @@
  */
 
 /*
- * CUDA virtual memory management (VMM) entry points the shim replaces.
+ * Tracking of CUDA virtual-memory-management (VMM) allocations that are
+ * shared between processes.
  *
- * This layer forwards every call to the real driver unchanged. It exists so
- * that symbol resolution (symbols.c) can be built and tested on its own; the
- * bookkeeping that tracks shared allocations is added on top of these
- * wrappers in a later change.
+ * The application sees "logical handles": 64-bit values with a fixed tag in
+ * the top 16 bits that the shim mints. Behind each logical handle is a tracked
+ * allocation and, per process, exactly one real driver handle. Repeated
+ * imports of the same allocation, or cuMemRetainAllocationHandle on one of its
+ * mappings, produce new logical handles that share that one driver handle; the
+ * driver handle is released when the last logical handle goes and the
+ * allocation record is freed when no handle and no mapping remains.
+ *
+ * Sharing works through tickets (posix.c): an export hands the application a
+ * sealed memfd instead of the driver's descriptor, and an import of a ticket
+ * asks the creator process for the real descriptor over its control socket.
+ * The creator answers from its export cache (export_cache.c) without touching
+ * the driver.
+ *
+ * Everything the application touches is protected by state_lock. The listener
+ * thread that serves peers takes only the export cache's lock.
  */
 
 #define _GNU_SOURCE
 
-#include <cuda.h>
+#include "interpose.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #include "export.h"
+#include "export_cache.h"
+#include "posix.h"
 #include "protocol.h"
 #include "symbols.h"
+#include "util/table.h"
+#include "util/io.h"
+#include "util/id.h"
+#include "util/misc.h"
+
+#define LOGICAL_HANDLE_TAG UINT64_C(0xd94d000000000000)
+#define LOGICAL_HANDLE_TAG_MASK UINT64_C(0xffff000000000000)
+#define LOGICAL_HANDLE_VALUE_MASK UINT64_C(0x0000ffffffffffff)
 
 CUINTERPOSE_API const struct cuinterpose_build_info cuinterpose_build_info = {
     .cuda_version = CUDA_VERSION,
@@ -37,77 +73,1138 @@ typedef CUresult(CUDAAPI* export_fn)(
     void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
 typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
 typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+
+struct allocation {
+  uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  char creator_participant[CUINTERPOSE_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  size_t size; /* known to the creator; importers learn it only from the coordinator */
+  CUmemAllocationProp properties;
+  CUcontext context; /* the CUDA context the allocation was created or imported in */
+  CUmemGenericAllocationHandle driver; /* the one backing driver handle, 0 when released */
+  bool creator;
+  bool shared; /* a ticket was issued (creator) or imported (importer) */
+  unsigned live_handles;
+  unsigned live_mappings;
+};
+
+struct handle {
+  CUmemGenericAllocationHandle logical;
+  struct allocation* allocation;
+};
+
+struct mapping {
+  CUdeviceptr address;
+  size_t size;
+  size_t offset;
+  struct allocation* allocation;
+  CUmemAccessDesc access[CUINTERPOSE_MAX_ACCESS];
+  size_t access_count;
+  bool access_unknown; /* a driver access call failed part-way; replay cannot be trusted */
+};
+
+enum phase {
+  PHASE_ACTIVE,
+  PHASE_FAILED,
+};
+
+static pthread_mutex_t state_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct table allocations; /* allocation id -> struct allocation* */
+static struct table handles; /* logical handle -> struct handle* */
+static struct ranges mappings; /* address range -> struct mapping* */
+static struct table raw_imports; /* driver handle of an untracked import -> marker */
+static enum phase current_phase = PHASE_ACTIVE;
+static char failure[96];
+static char participant_id[CUINTERPOSE_ID_SIZE];
+static char control_directory[sizeof(((struct sockaddr_un*)0)->sun_path)];
+static char socket_path[sizeof(((struct sockaddr_un*)0)->sun_path)];
+static int listener = -1;
+static bool endpoint_needs_initialization;
+static uint64_t next_logical_handle = 1;
+static _Atomic uint32_t live_raw_imports;
+static _Atomic uint32_t unsupported_exportable_creations;
+static _Atomic bool fabric_passthrough_logged;
+
+static void
+set_failure(const char* message)
+{
+  current_phase = PHASE_FAILED;
+  snprintf(failure, sizeof(failure), "%s", message);
+}
+
+static void
+warn(const char* message)
+{
+  fprintf(stderr, "cuinterpose: %s\n", message);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Bookkeeping helpers. Caller holds state_lock.                              */
+/* ------------------------------------------------------------------------- */
+
+static bool
+is_logical_handle(CUmemGenericAllocationHandle handle)
+{
+  return ((uint64_t)handle & LOGICAL_HANDLE_TAG_MASK) == LOGICAL_HANDLE_TAG;
+}
+
+static struct handle*
+find_handle(CUmemGenericAllocationHandle logical)
+{
+  if (!is_logical_handle(logical))
+    return NULL;
+  return table_get(&handles, key_u64((uint64_t)logical));
+}
+
+static struct allocation*
+find_allocation(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  return table_get(&allocations, key_bytes(id));
+}
+
+static struct mapping*
+mapping_at(CUdeviceptr address)
+{
+  struct range* range = ranges_at(&mappings, (uint64_t)address);
+
+  return range == NULL ? NULL : range->value;
+}
+
+/* Mint a logical handle for allocation. Returns 0 and sets *logical. */
+static int
+add_handle(struct allocation* allocation, CUmemGenericAllocationHandle* logical)
+{
+  struct handle* handle;
+
+  if (next_logical_handle > LOGICAL_HANDLE_VALUE_MASK)
+    return -1;
+  handle = calloc(1, sizeof(*handle));
+  if (handle == NULL)
+    return -1;
+  handle->logical = (CUmemGenericAllocationHandle)(LOGICAL_HANDLE_TAG | next_logical_handle);
+  handle->allocation = allocation;
+  if (table_put(&handles, key_u64((uint64_t)handle->logical), handle) != 0) {
+    free(handle);
+    return -1;
+  }
+  next_logical_handle++;
+  allocation->live_handles++;
+  *logical = handle->logical;
+  return 0;
+}
+
+/*
+ * Called when an allocation lost a handle or a mapping. Releases the driver
+ * handle once no logical handle refers to it (the driver keeps the memory
+ * alive for any remaining mappings, as it would for the application), and
+ * frees the record once nothing refers to it at all.
+ */
+static CUresult
+settle_allocation(struct allocation* allocation)
+{
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  CUresult result = CUDA_SUCCESS;
+
+  if (allocation->live_handles == 0 && allocation->driver != 0) {
+    result = release != NULL ? release(allocation->driver) : cuinterpose_unavailable();
+    allocation->driver = 0;
+  }
+  if (allocation->live_handles == 0 && allocation->live_mappings == 0) {
+    /* No local reference is left, so any ticket for this allocation is dead. */
+    cuinterpose_export_cache_drop(allocation->id);
+    table_remove(&allocations, key_bytes(allocation->id));
+    free(allocation);
+  }
+  return result;
+}
+
+static int
+current_context(CUcontext* context)
+{
+  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
+
+  return get_current != NULL && get_current(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
+}
+
+/*
+ * Returns a driver handle that is not a logical one, or releases it and fails:
+ * the tag is reserved for the shim, and a real handle in that range would be
+ * indistinguishable from a logical one.
+ */
+static CUresult
+passthrough_handle(CUresult result, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* output)
+{
+  if (result != CUDA_SUCCESS)
+    return result;
+  if (is_logical_handle(driver)) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    warn("driver returned a handle in the reserved logical range; refusing it");
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  *output = driver;
+  return CUDA_SUCCESS;
+}
+
+bool
+cuinterpose_translate_handle(CUmemGenericAllocationHandle logical, CUmemGenericAllocationHandle* driver)
+{
+  struct handle* handle;
+  bool found = false;
+
+  if (!is_logical_handle(logical))
+    return false;
+  pthread_mutex_lock(&state_lock);
+  handle = find_handle(logical);
+  if (handle != NULL && handle->allocation->driver != 0) {
+    *driver = handle->allocation->driver;
+    found = true;
+  }
+  pthread_mutex_unlock(&state_lock);
+  return found;
+}
+
+void
+cuinterpose_note_unsupported_exportable_creation(uint64_t handle_types)
+{
+  atomic_fetch_add(&unsupported_exportable_creations, 1);
+  if ((handle_types & CU_MEM_HANDLE_TYPE_FABRIC) != 0 &&
+      !atomic_exchange(&fabric_passthrough_logged, true))
+    warn("a CUDA resource with the FABRIC handle type passed through untracked; "
+         "checkpoint will be refused");
+}
+
+/* ------------------------------------------------------------------------- */
+/* Debug statistics for tests and operators.                                  */
+/* ------------------------------------------------------------------------- */
+
+CUINTERPOSE_API void
+cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
+{
+  memset(stats, 0, sizeof(*stats));
+  pthread_mutex_lock(&state_lock);
+  stats->allocations = allocations.count;
+  stats->handles = handles.count;
+  stats->mappings = mappings.count;
+  stats->live_raw_imports = atomic_load(&live_raw_imports);
+  stats->unsupported_exportable_creations = atomic_load(&unsupported_exportable_creations);
+  stats->phase = current_phase == PHASE_ACTIVE ? CUINTERPOSE_PHASE_ACTIVE : CUINTERPOSE_PHASE_FAILED;
+  pthread_mutex_unlock(&state_lock);
+  stats->cached_exports = cuinterpose_export_cache_count();
+}
+
+/* ------------------------------------------------------------------------- */
+/* Control socket: the listener thread and the requests it serves.            */
+/* ------------------------------------------------------------------------- */
+
+static uint8_t
+phase_code(void)
+{
+  return current_phase == PHASE_ACTIVE ? CUINTERPOSE_PHASE_ACTIVE : CUINTERPOSE_PHASE_FAILED;
+}
+
+static void
+serve(int client)
+{
+  struct cuinterpose_header request;
+  struct cuinterpose_header response;
+  int passed_fd = -1;
+
+  if (cuinterpose_receive_header(client, &request, &passed_fd) != 0)
+    return;
+  if (passed_fd >= 0)
+    close(passed_fd);
+  memset(&response, 0, sizeof(response));
+  response.magic = CUINTERPOSE_MAGIC;
+  response.version = CUINTERPOSE_VERSION;
+  response.operation = request.operation;
+  snprintf(response.participant_id, sizeof(response.participant_id), "%s", participant_id);
+  response.live_raw_imports = atomic_load(&live_raw_imports);
+  response.unsupported_exportable_creations = atomic_load(&unsupported_exportable_creations);
+  response.phase = phase_code();
+  if (passed_fd >= 0 || request.payload_size != 0 || !cuinterpose_header_strings_terminated(&request) ||
+      request.magic != CUINTERPOSE_MAGIC || request.version != CUINTERPOSE_VERSION || request.status != 0 ||
+      request.count != 0 ||
+      !((request.operation == CUINTERPOSE_HANDSHAKE && request.participant_id[0] == '\0') ||
+        strcmp(request.participant_id, participant_id) == 0)) {
+    cuinterpose_header_error(&response, "invalid cuinterpose control request");
+    (void)cuinterpose_send_header(client, &response, -1);
+    return;
+  }
+  switch (request.operation) {
+    case CUINTERPOSE_HANDSHAKE:
+      if (current_phase == PHASE_FAILED)
+        cuinterpose_header_error(&response, failure);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    case CUINTERPOSE_EXPORT: {
+      /* A peer holding a ticket wants the real descriptor. Served from the
+       * export cache only: no driver call, no state_lock. */
+      const char* reason = NULL;
+      int dup = -1;
+
+      if (request.resource_kind != CUINTERPOSE_RESOURCE_UNICAST) {
+        cuinterpose_header_error(&response, "creator resource is unavailable");
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      if (cuinterpose_export_cache_begin(request.allocation_id, &dup, &reason) != 0) {
+        cuinterpose_header_error(&response, reason);
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      response.resource_kind = request.resource_kind;
+      memcpy(response.allocation_id, request.allocation_id, sizeof(response.allocation_id));
+      (void)cuinterpose_send_header(client, &response, dup);
+      close(dup);
+      cuinterpose_export_cache_end(request.allocation_id);
+      break;
+    }
+    default:
+      cuinterpose_header_error(&response, "operation is not supported by this shim build");
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+  }
+}
+
+static void*
+control_connection(void* argument)
+{
+  int client = (int)(intptr_t)argument;
+
+  if (set_socket_timeouts(client, cuinterpose_control_timeout_seconds()) == 0)
+    serve(client);
+  close(client);
+  return NULL;
+}
+
+static void*
+control_agent(void* unused)
+{
+  unsigned backoff_ms = 1;
+
+  (void)unused;
+  for (;;) {
+    int client = accept4(listener, NULL, NULL, SOCK_CLOEXEC);
+    pthread_t worker;
+
+    if (client < 0) {
+      switch (errno) {
+        case EINTR:
+          continue;
+        case EMFILE:
+        case ENFILE:
+        case ENOBUFS:
+        case ENOMEM:
+        case ECONNABORTED:
+        case EAGAIN:
+          /* Transient: back off and keep listening. Giving up here would
+           * leave this process unreachable for every future checkpoint. */
+          usleep(backoff_ms * 1000);
+          if (backoff_ms < 1000)
+            backoff_ms *= 2;
+          continue;
+        default:
+          /* EBADF, EINVAL: the listener is gone (fork child, shutdown). */
+          return NULL;
+      }
+    }
+    backoff_ms = 1;
+    /* One detached thread per connection: a slow request never blocks accept. */
+    if (pthread_create(&worker, NULL, control_connection, (void*)(intptr_t)client) == 0)
+      (void)pthread_detach(worker);
+    else
+      (void)control_connection((void*)(intptr_t)client);
+  }
+}
+
+static int
+discard_control_endpoint(void)
+{
+  if (listener >= 0)
+    close(listener);
+  listener = -1;
+  if (socket_path[0] != '\0')
+    unlink(socket_path);
+  socket_path[0] = '\0';
+  return -1;
+}
+
+static int
+start_control_endpoint(void)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  pthread_t thread;
+  int count;
+
+  count = snprintf(
+      socket_path, sizeof(socket_path), "%s/%s%ld.sock", control_directory, CUINTERPOSE_SOCKET_PREFIX,
+      (long)getpid());
+  if (count < 0 || (size_t)count >= sizeof(socket_path)) {
+    socket_path[0] = '\0';
+    return -1;
+  }
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", socket_path);
+  listener = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listener < 0)
+    return discard_control_endpoint();
+  /* A stale socket from an earlier process with this PID would make bind fail. */
+  unlink(socket_path);
+  if (bind(listener, (const struct sockaddr*)&address, sizeof(address)) != 0)
+    return discard_control_endpoint();
+  /* Owner-only. This excludes processes with different filesystem credentials;
+   * mount visibility remains the boundary between same-UID containers. chmod
+   * the path because fchmod on a socket descriptor does not change the
+   * filesystem node. */
+  if (chmod(socket_path, 0600) != 0)
+    return discard_control_endpoint();
+  if (listen(listener, 16) != 0 || pthread_create(&thread, NULL, control_agent, NULL) != 0)
+    return discard_control_endpoint();
+  pthread_detach(thread);
+  return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Process lifecycle: constructor, fork, lazy endpoint in children.           */
+/* ------------------------------------------------------------------------- */
+
+static void
+fork_prepare(void)
+{
+  pthread_mutex_lock(&state_lock);
+  cuinterpose_export_cache_fork_prepare();
+}
+
+static void
+fork_parent(void)
+{
+  cuinterpose_export_cache_fork_parent();
+  pthread_mutex_unlock(&state_lock);
+}
+
+static int
+free_value(struct key key, void* value, void* arg)
+{
+  (void)key;
+  (void)arg;
+  free(value);
+  return 0;
+}
+
+static void
+fork_child(void)
+{
+  size_t index;
+
+  /*
+   * The child inherits the parent's records but none of the parent's CUDA
+   * state is usable in it (CUDA contexts do not survive fork). Drop the
+   * bookkeeping without touching the driver; the child gets its own identity
+   * and socket on its first CUDA activity.
+   */
+  if (listener >= 0)
+    close(listener);
+  listener = -1;
+  participant_id[0] = '\0';
+  socket_path[0] = '\0';
+  endpoint_needs_initialization = true;
+  table_each(&handles, free_value, NULL);
+  table_clear(&handles);
+  for (index = 0; index < mappings.count; index++)
+    free(mappings.items[index].value);
+  ranges_clear(&mappings);
+  table_each(&allocations, free_value, NULL);
+  table_clear(&allocations);
+  table_clear(&raw_imports);
+  atomic_store(&live_raw_imports, 0);
+  atomic_store(&unsupported_exportable_creations, 0);
+  next_logical_handle = 1;
+  current_phase = PHASE_ACTIVE;
+  failure[0] = '\0';
+  cuinterpose_export_cache_fork_child();
+  pthread_mutex_init(&state_lock, NULL);
+}
+
+CUresult
+cuinterpose_ensure_process_endpoint(void)
+{
+  CUresult result = CUDA_SUCCESS;
+
+  pthread_mutex_lock(&state_lock);
+  if (endpoint_needs_initialization) {
+    if (current_phase == PHASE_FAILED) {
+      result = CUDA_ERROR_NOT_INITIALIZED;
+    } else if (random_id(participant_id) != 0 || start_control_endpoint() != 0) {
+      set_failure("cannot start forked cuinterpose control endpoint");
+      result = CUDA_ERROR_NOT_INITIALIZED;
+    } else {
+      endpoint_needs_initialization = false;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+__attribute__((constructor)) static void
+initialize(void)
+{
+  const char* control;
+  const char* configured_participant;
+
+  configured_participant = getenv(CUINTERPOSE_PARTICIPANT_ID_ENV);
+  if (configured_participant != NULL && !is_lower_hex_id(configured_participant)) {
+    set_failure("invalid cuinterpose participant identity");
+    warn(failure);
+    return;
+  }
+  if (configured_participant != NULL)
+    snprintf(participant_id, sizeof(participant_id), "%s", configured_participant);
+  else if (random_id(participant_id) != 0) {
+    set_failure("cannot create cuinterpose participant identity");
+    warn(failure);
+    return;
+  }
+  control = getenv(CUINTERPOSE_CONTROL_DIR_ENV);
+  if (control == NULL || control[0] == '\0')
+    control = CUINTERPOSE_CONTROL_DIR;
+  if (control[0] != '/' || strlen(control) >= sizeof(control_directory)) {
+    set_failure("invalid cuinterpose control directory");
+    warn(failure);
+    return;
+  }
+  snprintf(control_directory, sizeof(control_directory), "%s", control);
+  if (pthread_atfork(fork_prepare, fork_parent, fork_child) != 0) {
+    set_failure("cannot register cuinterpose fork handlers");
+    warn(failure);
+    return;
+  }
+  if (start_control_endpoint() != 0) {
+    set_failure("cannot start cuinterpose control endpoint");
+    warn(failure);
+    return;
+  }
+}
+
+__attribute__((destructor)) static void
+finalize(void)
+{
+  (void)discard_control_endpoint();
+}
+
+/* ------------------------------------------------------------------------- */
+/* Peer export: the same-process shortcut and the socket path.                */
+/* ------------------------------------------------------------------------- */
+
+/* Obtain the real descriptor for a ticket. Caller must not hold state_lock. */
+static int
+request_export(const struct cuinterpose_posix_ticket* ticket, int* output, char* error, size_t error_size)
+{
+  if (strcmp(ticket->creator_participant, participant_id) == 0) {
+    const char* reason = NULL;
+    int dup = -1;
+
+    if (cuinterpose_export_cache_begin(ticket->allocation_id, &dup, &reason) != 0) {
+      if (error != NULL && error_size != 0)
+        snprintf(error, error_size, "%s", reason);
+      *output = -1;
+      return -1;
+    }
+    cuinterpose_export_cache_end(ticket->allocation_id);
+    *output = dup;
+    return 0;
+  }
+  return cuinterpose_posix_request_export(ticket, output, error, error_size);
+}
+
+/* ------------------------------------------------------------------------- */
+/* The CUDA entry points.                                                     */
+/* ------------------------------------------------------------------------- */
 
 CUINTERPOSE_API CUresult CUDAAPI
 cuMemCreate(
     CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
 {
   create_fn function = (create_fn)cuinterpose_lookup_real_symbol("cuMemCreate");
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
 
-  return function != NULL ? function(output, size, properties, flags) : cuinterpose_unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterpose_unavailable();
+  if (properties == NULL || properties->requestedHandleTypes != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    /*
+     * Only allocations created with exactly the POSIX fd handle type are
+     * tracked. Private allocations stay on the native checkpoint path.
+     * Unsupported exportable types pass through during normal execution, but
+     * make checkpoint preflight fail before cuinterpose changes driver state.
+     */
+    result = function(&driver, size, properties, flags);
+    result = passthrough_handle(result, driver, output);
+    if (result == CUDA_SUCCESS && properties != NULL && properties->requestedHandleTypes != 0)
+      cuinterpose_note_unsupported_exportable_creation(properties->requestedHandleTypes);
+    return result;
+  }
+  result = function(&driver, size, properties, flags);
+  if (result != CUDA_SUCCESS)
+    return result;
+  allocation = calloc(1, sizeof(*allocation));
+  pthread_mutex_lock(&state_lock);
+  if (allocation == NULL || current_phase != PHASE_ACTIVE ||
+      random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
+      current_context(&allocation->context) != 0 ||
+      table_put(&allocations, key_bytes(allocation->id), allocation) != 0) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+    pthread_mutex_unlock(&state_lock);
+    if (release != NULL)
+      (void)release(driver);
+    free(allocation);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  allocation->size = size;
+  allocation->properties = *properties;
+  allocation->driver = driver;
+  allocation->creator = true;
+  snprintf(allocation->creator_participant, sizeof(allocation->creator_participant), "%s", participant_id);
+  snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", socket_path);
+  if (add_handle(allocation, &logical) != 0) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+    table_remove(&allocations, key_bytes(allocation->id));
+    pthread_mutex_unlock(&state_lock);
+    if (release != NULL)
+      (void)release(driver);
+    free(allocation);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
-cuMemRelease(CUmemGenericAllocationHandle handle)
+cuMemRelease(CUmemGenericAllocationHandle application)
 {
   release_fn function = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  struct handle* handle;
+  struct allocation* allocation;
+  CUresult result;
 
-  return function != NULL ? function(handle) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = find_handle(application);
+  if (handle == NULL) {
+    if (is_logical_handle(application)) {
+      pthread_mutex_unlock(&state_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    /* An untracked import being released drops out of the raw-import count. */
+    if (table_remove(&raw_imports, key_u64((uint64_t)application)) != NULL)
+      atomic_fetch_sub(&live_raw_imports, 1);
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(application) : cuinterpose_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  allocation = handle->allocation;
+  table_remove(&handles, key_u64((uint64_t)application));
+  free(handle);
+  allocation->live_handles--;
+  result = settle_allocation(allocation);
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
 cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
 {
   retain_fn function = (retain_fn)cuinterpose_lookup_real_symbol("cuMemRetainAllocationHandle");
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  struct mapping* mapping;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
 
-  return function != NULL ? function(output, address) : cuinterpose_unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterpose_unavailable();
+  pthread_mutex_lock(&state_lock);
+  mapping = mapping_at((CUdeviceptr)(uintptr_t)address);
+  if (mapping == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    result = function(&driver, address);
+    return passthrough_handle(result, driver, output);
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = function(&driver, address);
+  if (result != CUDA_SUCCESS) {
+    pthread_mutex_unlock(&state_lock);
+    return result;
+  }
+  /*
+   * One backing driver handle per allocation: if we already hold one, the
+   * fresh reference is redundant and released right away; the new logical
+   * handle aliases the existing driver handle.
+   */
+  if (mapping->allocation->driver != 0) {
+    if (release == NULL || release(driver) != CUDA_SUCCESS) {
+      pthread_mutex_unlock(&state_lock);
+      return CUDA_ERROR_UNKNOWN;
+    }
+  } else {
+    mapping->allocation->driver = driver;
+  }
+  if (add_handle(mapping->allocation, &logical) != 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
-cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle application, unsigned long long flags)
 {
   map_fn function = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  struct handle* handle;
+  struct mapping* mapping;
+  CUresult result;
 
-  return function != NULL ? function(address, size, offset, handle, flags) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = find_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(address, size, offset, application, flags) : cuinterpose_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || handle->allocation->driver == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  if (function == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    return cuinterpose_unavailable();
+  }
+  if (size == 0 || (uint64_t)address > UINT64_MAX - size) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  mapping = calloc(1, sizeof(*mapping));
+  if (mapping == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  /* Reserve the range first so an overlap with a tracked mapping is refused
+   * before the driver is touched; two records for one address would make
+   * restore ambiguous. */
+  switch (ranges_insert(&mappings, (uint64_t)address, (uint64_t)address + size, mapping)) {
+    case 1:
+      pthread_mutex_unlock(&state_lock);
+      free(mapping);
+      return CUDA_ERROR_INVALID_VALUE;
+    case -1:
+      pthread_mutex_unlock(&state_lock);
+      free(mapping);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    default:
+      break;
+  }
+  result = function(address, size, offset, handle->allocation->driver, flags);
+  if (result != CUDA_SUCCESS) {
+    struct range* range = ranges_at(&mappings, (uint64_t)address);
+    if (range != NULL && range->value == mapping)
+      ranges_remove_at(&mappings, (size_t)(range - mappings.items));
+    free(mapping);
+    pthread_mutex_unlock(&state_lock);
+    return result;
+  }
+  mapping->address = address;
+  mapping->size = size;
+  mapping->offset = offset;
+  mapping->allocation = handle->allocation;
+  handle->allocation->live_mappings++;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
 cuMemUnmap(CUdeviceptr address, size_t size)
 {
   unmap_fn function = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  size_t first;
+  size_t last;
+  size_t index;
+  CUresult result;
 
-  return function != NULL ? function(address, size) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (size == 0 || (uint64_t)address > UINT64_MAX - size)
+    return function != NULL ? function(address, size) : cuinterpose_unavailable();
+  pthread_mutex_lock(&state_lock);
+  /*
+   * The application may unmap a range that spans several tracked mappings at
+   * once, as long as it does not cut through one. A partial cut cannot be
+   * represented in the records, so it is refused rather than passed through
+   * with a stale record left behind.
+   */
+  if (ranges_cover(&mappings, (uint64_t)address, (uint64_t)address + size, &first, &last) != 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (first == last) {
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(address, size) : cuinterpose_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = function != NULL ? function(address, size) : cuinterpose_unavailable();
+  if (result == CUDA_SUCCESS) {
+    for (index = last; index > first; index--) {
+      struct mapping* mapping = mappings.items[index - 1].value;
+      struct allocation* allocation = mapping->allocation;
+      CUresult settle;
+
+      ranges_remove_at(&mappings, index - 1);
+      free(mapping);
+      allocation->live_mappings--;
+      settle = settle_allocation(allocation);
+      if (settle != CUDA_SUCCESS)
+        result = settle;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+/*
+ * Merge `descriptors` into a mapping's recorded access set, one entry per
+ * (location type, location id). CUDA applies access per location, so a second
+ * call for another GPU adds to what the first granted; NONE removes that
+ * location. Returns -1 when the merged set would exceed the record's capacity.
+ */
+static int
+merge_access(
+    const struct mapping* mapping, const CUmemAccessDesc* descriptors, size_t count, CUmemAccessDesc* merged,
+    size_t* merged_count)
+{
+  size_t index;
+
+  memcpy(merged, mapping->access, mapping->access_count * sizeof(*merged));
+  *merged_count = mapping->access_count;
+  for (index = 0; index < count; index++) {
+    const CUmemAccessDesc* descriptor = &descriptors[index];
+    size_t slot;
+
+    for (slot = 0; slot < *merged_count; slot++) {
+      if (merged[slot].location.type == descriptor->location.type &&
+          merged[slot].location.id == descriptor->location.id)
+        break;
+    }
+    if (descriptor->flags == CU_MEM_ACCESS_FLAGS_PROT_NONE) {
+      if (slot < *merged_count) {
+        merged[slot] = merged[*merged_count - 1];
+        (*merged_count)--;
+      }
+      continue;
+    }
+    if (slot == *merged_count) {
+      if (*merged_count == CUINTERPOSE_MAX_ACCESS)
+        return -1;
+      (*merged_count)++;
+    }
+    merged[slot] = *descriptor;
+  }
+  return 0;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
 cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
 {
   access_fn function = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  CUmemAccessDesc (*merged)[CUINTERPOSE_MAX_ACCESS] = NULL;
+  size_t* merged_counts = NULL;
+  size_t first;
+  size_t last;
+  size_t index;
+  CUresult result;
 
-  return function != NULL ? function(address, size, descriptors, count) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (size == 0 || (uint64_t)address > UINT64_MAX - size || descriptors == NULL)
+    return function != NULL ? function(address, size, descriptors, count) : cuinterpose_unavailable();
+  pthread_mutex_lock(&state_lock);
+  if (ranges_cover(&mappings, (uint64_t)address, (uint64_t)address + size, &first, &last) != 0) {
+    /* Partly overlapping a tracked mapping: the driver would apply it, but the
+     * record could not say which part, and restore would replay it wrong. */
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (first == last) {
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(address, size, descriptors, count) : cuinterpose_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  if (function == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    return cuinterpose_unavailable();
+  }
+  /* Compute every merged set first; refuse before the driver is touched if
+   * any mapping would overflow. */
+  merged = calloc(last - first, sizeof(*merged));
+  merged_counts = calloc(last - first, sizeof(*merged_counts));
+  if (merged == NULL || merged_counts == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    free(merged);
+    free(merged_counts);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  for (index = first; index < last; index++) {
+    if (merge_access(mappings.items[index].value, descriptors, count, merged[index - first],
+                     &merged_counts[index - first]) != 0) {
+      pthread_mutex_unlock(&state_lock);
+      free(merged);
+      free(merged_counts);
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+  }
+  result = function(address, size, descriptors, count);
+  for (index = first; index < last; index++) {
+    struct mapping* mapping = mappings.items[index].value;
+    if (result == CUDA_SUCCESS) {
+      memcpy(mapping->access, merged[index - first], merged_counts[index - first] * sizeof(*mapping->access));
+      mapping->access_count = merged_counts[index - first];
+    } else {
+      /* The driver applies descriptors one by one and stops at the first
+       * failure, so the recorded set may no longer match the device. */
+      mapping->access_unknown = true;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  free(merged);
+  free(merged_counts);
+  return result;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
 cuMemExportToShareableHandle(
-    void* shareable, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
+    void* shareable, CUmemGenericAllocationHandle application, CUmemAllocationHandleType type, unsigned long long flags)
 {
   export_fn function = (export_fn)cuinterpose_lookup_real_symbol("cuMemExportToShareableHandle");
+  struct handle* handle;
+  struct allocation* allocation;
+  struct cuinterpose_posix_ticket ticket;
+  int ticket_fd = -1;
+  CUresult result;
 
-  return function != NULL ? function(shareable, handle, type, flags) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = find_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(shareable, application, type, flags) : cuinterpose_unavailable();
+  }
+  /* The driver's own rules for these arguments. */
+  if (shareable == NULL || flags != 0 || type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  allocation = handle->allocation;
+  if (allocation->creator && !cuinterpose_export_cache_has(allocation->id)) {
+    /*
+     * The one real export for this allocation in this process. The descriptor
+     * goes into the export cache, where the listener serves copies of it to
+     * peers; the application only ever sees tickets.
+     */
+    int real_fd = -1;
+
+    if (function == NULL || allocation->driver == 0) {
+      pthread_mutex_unlock(&state_lock);
+      return function == NULL ? cuinterpose_unavailable() : CUDA_ERROR_INVALID_HANDLE;
+    }
+    result = function(&real_fd, allocation->driver, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+    if (result != CUDA_SUCCESS) {
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
+    if (cuinterpose_export_cache_put(allocation->id, real_fd) != 0) {
+      close(real_fd);
+      pthread_mutex_unlock(&state_lock);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+  memset(&ticket, 0, sizeof(ticket));
+  ticket.magic = CUINTERPOSE_POSIX_TICKET_MAGIC;
+  ticket.version = CUINTERPOSE_POSIX_TICKET_VERSION;
+  ticket.resource_kind = CUINTERPOSE_RESOURCE_UNICAST;
+  snprintf(ticket.creator_participant, sizeof(ticket.creator_participant), "%s", allocation->creator_participant);
+  memcpy(ticket.allocation_id, allocation->id, sizeof(ticket.allocation_id));
+  snprintf(ticket.creator_endpoint, sizeof(ticket.creator_endpoint), "%s", allocation->creator_endpoint);
+  if (cuinterpose_posix_create_ticket(&ticket, &ticket_fd) != 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  allocation->shared = true;
+  *(int*)shareable = ticket_fd;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
 cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
 {
   import_fn function = (import_fn)cuinterpose_lookup_real_symbol("cuMemImportFromShareableHandle");
+  properties_fn get_properties = (properties_fn)cuinterpose_lookup_real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  struct cuinterpose_posix_ticket ticket;
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle imported = 0;
+  int raw_fd = -1;
+  CUresult result;
 
-  return function != NULL ? function(output, os_handle, type) : cuinterpose_unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterpose_unavailable();
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ||
+      cuinterpose_posix_read_ticket((int)(uintptr_t)os_handle, &ticket) != 0) {
+    /*
+     * Not one of our tickets: a real descriptor from a process without the
+     * shim, or a non-POSIX handle. It goes to the driver untouched, but the
+     * result is remembered so the coordinator can refuse to checkpoint while
+     * such an import is alive: native restore would give this process a
+     * private copy and silently break the sharing.
+     */
+    result = function(&imported, os_handle, type);
+    if (result != CUDA_SUCCESS)
+      return result;
+    result = passthrough_handle(result, imported, output);
+    if (result == CUDA_SUCCESS) {
+      pthread_mutex_lock(&state_lock);
+      if (table_put(&raw_imports, key_u64((uint64_t)imported), (void*)1) == 0)
+        atomic_fetch_add(&live_raw_imports, 1);
+      pthread_mutex_unlock(&state_lock);
+    }
+    return result;
+  }
+  if (ticket.resource_kind != CUINTERPOSE_RESOURCE_UNICAST)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (get_properties == NULL || release == NULL)
+    return cuinterpose_unavailable();
+  pthread_mutex_lock(&state_lock);
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  pthread_mutex_unlock(&state_lock);
+  if (request_export(&ticket, &raw_fd, NULL, 0) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  result = function(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  close(raw_fd);
+  if (result != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    (void)release(imported);
+    return CUDA_ERROR_NOT_READY;
+  }
+  allocation = find_allocation(ticket.allocation_id);
+  if (allocation == NULL) {
+    allocation = calloc(1, sizeof(*allocation));
+    if (allocation == NULL || get_properties(&allocation->properties, imported) != CUDA_SUCCESS ||
+        current_context(&allocation->context) != 0 ||
+        table_put(&allocations, key_bytes(ticket.allocation_id), allocation) != 0) {
+      pthread_mutex_unlock(&state_lock);
+      (void)release(imported);
+      free(allocation);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    memcpy(allocation->id, ticket.allocation_id, sizeof(allocation->id));
+    snprintf(
+        allocation->creator_participant, sizeof(allocation->creator_participant), "%s", ticket.creator_participant);
+    snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", ticket.creator_endpoint);
+    allocation->creator = false;
+    allocation->driver = imported;
+  } else if (allocation->driver != 0) {
+    /* Already imported here: alias the existing driver handle. */
+    if (release(imported) != CUDA_SUCCESS) {
+      pthread_mutex_unlock(&state_lock);
+      return CUDA_ERROR_UNKNOWN;
+    }
+  } else {
+    allocation->driver = imported;
+  }
+  allocation->shared = true;
+  if (add_handle(allocation, &logical) != 0) {
+    if (allocation->live_handles == 0 && allocation->live_mappings == 0) {
+      table_remove(&allocations, key_bytes(allocation->id));
+      (void)release(allocation->driver);
+      free(allocation);
+    }
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
-cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
+cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle application)
 {
   properties_fn function = (properties_fn)cuinterpose_lookup_real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  struct handle* handle;
+  CUmemGenericAllocationHandle driver;
+  CUresult result;
 
-  return function != NULL ? function(properties, handle) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = find_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(properties, application) : cuinterpose_unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || handle->allocation->driver == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  driver = handle->allocation->driver;
+  pthread_mutex_unlock(&state_lock);
+  return function != NULL ? function(properties, driver) : cuinterpose_unavailable();
 }

--- a/agent/cmd/cuinterpose/interpose.h
+++ b/agent/cmd/cuinterpose/interpose.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_INTERPOSE_H
+#define CUINTERPOSE_INTERPOSE_H
+
+#include <cuda.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Internal entry points shared between the shim's translation units. */
+
+/*
+ * Make sure this process has its participant identity and control socket. A
+ * child created by fork() inherits neither, so every wrapper and every
+ * resolver calls this first; the first CUDA activity in the child creates them.
+ */
+CUresult cuinterpose_ensure_process_endpoint(void);
+
+/*
+ * If `handle` is one of the shim's logical handles for a tracked allocation,
+ * store the driver handle behind it in *driver and return true. Used by the
+ * multicast wrappers, which must hand the driver a handle it recognizes.
+ */
+bool cuinterpose_translate_handle(CUmemGenericAllocationHandle handle, CUmemGenericAllocationHandle* driver);
+
+/* Record a successful exportable creation whose handle type cuinterpose cannot
+ * reconstruct. The coordinator refuses checkpoint before teardown when this
+ * counter is non-zero. Multicast uses the same process-wide diagnostic. */
+void cuinterpose_note_unsupported_exportable_creation(uint64_t handle_types);
+
+#endif

--- a/agent/cmd/cuinterpose/multicast.c
+++ b/agent/cmd/cuinterpose/multicast.c
@@ -11,6 +11,7 @@
 #include <cuda.h>
 
 #include "export.h"
+#include "interpose.h"
 #include "symbols.h"
 
 /* cuda.h maps these names to versioned entry points; the shim wraps the names. */
@@ -53,8 +54,12 @@ cuMulticastBindMem(
     size_t memory_offset, size_t size, unsigned long long flags)
 {
   bind_mem_fn function = (bind_mem_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem");
+  CUmemGenericAllocationHandle driver = memory;
 
-  return function != NULL ? function(multicast, multicast_offset, memory, memory_offset, size, flags)
+  (void)cuinterpose_ensure_process_endpoint();
+  /* The application binds by its logical handle; the driver needs its own. */
+  (void)cuinterpose_translate_handle(memory, &driver);
+  return function != NULL ? function(multicast, multicast_offset, driver, memory_offset, size, flags)
                           : cuinterpose_unavailable();
 }
 
@@ -75,8 +80,11 @@ cuMulticastBindMem_v2(
     CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
 {
   bind_mem_v2_fn function = (bind_mem_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem_v2");
+  CUmemGenericAllocationHandle driver = memory;
 
-  return function != NULL ? function(multicast, device, multicast_offset, memory, memory_offset, size, flags)
+  (void)cuinterpose_ensure_process_endpoint();
+  (void)cuinterpose_translate_handle(memory, &driver);
+  return function != NULL ? function(multicast, device, multicast_offset, driver, memory_offset, size, flags)
                           : cuinterpose_unavailable();
 }
 

--- a/agent/cmd/cuinterpose/multicast.h
+++ b/agent/cmd/cuinterpose/multicast.h
@@ -9,8 +9,9 @@
 
 /*
  * CUDA multicast objects (cuMulticast*) let several GPUs write one buffer
- * through NVLink. This layer forwards the entry points unchanged; tracking
- * and checkpoint of multicast groups is added in a later change.
+ * through NVLink. This layer forwards the entry points, translating tracked
+ * unicast handles for the bind calls; tracking and checkpoint of multicast
+ * groups is added in a later change.
  */
 
 #endif

--- a/agent/cmd/cuinterpose/symbols.c
+++ b/agent/cmd/cuinterpose/symbols.c
@@ -40,6 +40,7 @@
 #include <string.h>
 
 #include "export.h"
+#include "interpose.h"
 
 #ifndef CUINTERPOSE_DLSYM_VERSION
 #error "CUINTERPOSE_DLSYM_VERSION must be set by the build"
@@ -200,6 +201,9 @@ runtime_driver_entry_point(
   cudaError_t result;
   void* entry;
 
+  /* The CUDA runtime resolves driver functions before any VMM call, so this is
+   * the earliest point at which a fork child can announce itself. */
+  (void)cuinterpose_ensure_process_endpoint();
   if (strcmp(resolver, "cudaGetDriverEntryPoint") == 0 || strcmp(resolver, "cudaGetDriverEntryPoint_ptsz") == 0) {
     typedef cudaError_t(CUDARTAPI * function_type)(
         const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
@@ -309,6 +313,7 @@ cuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flag
   CUresult result;
   void* entry;
 
+  (void)cuinterpose_ensure_process_endpoint();
   if (function == NULL)
     function = (function_type)cuinterpose_lookup_real_symbol("cuGetProcAddress");
   result = function != NULL ? function(symbol, output, version, flags) : cuinterpose_unavailable();
@@ -326,6 +331,7 @@ cuGetProcAddress_v2(
   CUresult result;
   void* entry;
 
+  (void)cuinterpose_ensure_process_endpoint();
   if (function == NULL)
     function = (function_type)cuinterpose_lookup_real_symbol("cuGetProcAddress_v2");
   result = function != NULL ? function(symbol, output, version, flags, status) : cuinterpose_unavailable();
@@ -345,6 +351,7 @@ cuGetProcAddress_v2_ptsz(
   CUresult result;
   void* entry;
 
+  (void)cuinterpose_ensure_process_endpoint();
   if (function == NULL)
     function = (function_type)cuinterpose_lookup_real_symbol("cuGetProcAddress_v2");
   if ((flags & stream_flags) == 0)

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -8,6 +8,13 @@
 
 #include "fake_cuda.h"
 
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <string.h>
 
 #undef cuGetProcAddress
@@ -43,6 +50,171 @@ record(const char* function)
   last.function = function;
 }
 
+/* ---------------------------------------------------------------------- */
+/* Tracked mode model.                                                      */
+/* ---------------------------------------------------------------------- */
+
+#define FAKE_MAX_ALLOCATIONS 512
+#define FAKE_MAX_HANDLES 4096
+#define FAKE_MAX_MAPPINGS 4096
+#define FAKE_HANDLE_BASE 0x1000
+#define FAKE_EXPORT_MAGIC "fake-cuda-export:"
+
+struct fake_allocation {
+  int used;
+  int refs;
+  size_t size;
+  CUmemAllocationProp properties;
+};
+
+struct fake_handle {
+  int used;
+  int allocation;
+};
+
+struct fake_mapping {
+  int used;
+  CUdeviceptr address;
+  size_t size;
+  int allocation;
+};
+
+static int tracked;
+static struct fake_allocation allocations[FAKE_MAX_ALLOCATIONS];
+static struct fake_handle handles[FAKE_MAX_HANDLES];
+static struct fake_mapping mappings[FAKE_MAX_MAPPINGS];
+static int export_calls;
+static int access_calls;
+static pthread_mutex_t model_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void
+fakeEnableTrackedBehavior(void)
+{
+  tracked = 1;
+}
+
+void
+fakeResetModel(void)
+{
+  pthread_mutex_lock(&model_lock);
+  memset(allocations, 0, sizeof(allocations));
+  memset(handles, 0, sizeof(handles));
+  memset(mappings, 0, sizeof(mappings));
+  export_calls = 0;
+  access_calls = 0;
+  pthread_mutex_unlock(&model_lock);
+}
+
+static int
+handle_index(CUmemGenericAllocationHandle handle)
+{
+  if (handle < FAKE_HANDLE_BASE || handle >= FAKE_HANDLE_BASE + FAKE_MAX_HANDLES)
+    return -1;
+  return (int)(handle - FAKE_HANDLE_BASE);
+}
+
+/* Caller holds model_lock. */
+static CUmemGenericAllocationHandle
+new_handle(int allocation)
+{
+  int index;
+
+  for (index = 0; index < FAKE_MAX_HANDLES; index++) {
+    if (!handles[index].used) {
+      handles[index].used = 1;
+      handles[index].allocation = allocation;
+      allocations[allocation].refs++;
+      return (CUmemGenericAllocationHandle)(FAKE_HANDLE_BASE + index);
+    }
+  }
+  return 0;
+}
+
+/* Caller holds model_lock. Returns the allocation index or -1. */
+static int
+new_allocation(size_t size, const CUmemAllocationProp* properties)
+{
+  int index;
+
+  for (index = 0; index < FAKE_MAX_ALLOCATIONS; index++) {
+    if (!allocations[index].used) {
+      allocations[index].used = 1;
+      allocations[index].refs = 0;
+      allocations[index].size = size;
+      if (properties != NULL)
+        allocations[index].properties = *properties;
+      else
+        memset(&allocations[index].properties, 0, sizeof(allocations[index].properties));
+      return index;
+    }
+  }
+  return -1;
+}
+
+int
+fakeLiveAllocations(void)
+{
+  int index;
+  int live = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_ALLOCATIONS; index++)
+    live += allocations[index].used && allocations[index].refs > 0;
+  pthread_mutex_unlock(&model_lock);
+  return live;
+}
+
+int
+fakeAllocationRefs(CUmemGenericAllocationHandle handle)
+{
+  int index = handle_index(handle);
+  int refs = -1;
+
+  pthread_mutex_lock(&model_lock);
+  if (index >= 0 && handles[index].used)
+    refs = allocations[handles[index].allocation].refs;
+  pthread_mutex_unlock(&model_lock);
+  return refs;
+}
+
+int
+fakeSameAllocation(CUmemGenericAllocationHandle a, CUmemGenericAllocationHandle b)
+{
+  int ia = handle_index(a);
+  int ib = handle_index(b);
+  int same = 0;
+
+  pthread_mutex_lock(&model_lock);
+  same = ia >= 0 && ib >= 0 && handles[ia].used && handles[ib].used && handles[ia].allocation == handles[ib].allocation;
+  pthread_mutex_unlock(&model_lock);
+  return same;
+}
+
+int
+fakeExportCalls(void)
+{
+  return export_calls;
+}
+
+int
+fakeMappedCount(void)
+{
+  int index;
+  int count = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_MAPPINGS; index++)
+    count += mappings[index].used;
+  pthread_mutex_unlock(&model_lock);
+  return count;
+}
+
+int
+fakeAccessCalls(void)
+{
+  return access_calls;
+}
+
 /*
  * Each entry point exists twice: the exported CUDA name, and a fakeXxx alias
  * that cuGetProcAddress hands out. The alias lets a test tell "the shim's
@@ -53,6 +225,25 @@ CUresult CUDAAPI
 fakeCuMemCreate(
     CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
 {
+  if (tracked) {
+    int allocation;
+    CUmemGenericAllocationHandle handle = 0;
+    record("cuMemCreate");
+    last.size = size;
+    last.flags = flags;
+    last.handle_type = properties != NULL ? (int)properties->requestedHandleTypes : -1;
+    if (output == NULL)
+      return CUDA_ERROR_INVALID_VALUE;
+    pthread_mutex_lock(&model_lock);
+    allocation = new_allocation(size, properties);
+    if (allocation >= 0)
+      handle = new_handle(allocation);
+    pthread_mutex_unlock(&model_lock);
+    if (handle == 0)
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    *output = handle;
+    return CUDA_SUCCESS;
+  }
   record("cuMemCreate");
   last.size = size;
   last.flags = flags;
@@ -71,6 +262,21 @@ cuMemCreate(
 CUresult CUDAAPI
 fakeCuMemRelease(CUmemGenericAllocationHandle handle)
 {
+  if (tracked) {
+    int index = handle_index(handle);
+    record("cuMemRelease");
+    last.handle = handle;
+    pthread_mutex_lock(&model_lock);
+    if (index < 0 || !handles[index].used) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    handles[index].used = 0;
+    if (--allocations[handles[index].allocation].refs == 0)
+      allocations[handles[index].allocation].used = 0;
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_SUCCESS;
+  }
   record("cuMemRelease");
   last.handle = handle;
   return (CUresult)FAKE_RESULT_RELEASE;
@@ -84,6 +290,27 @@ cuMemRelease(CUmemGenericAllocationHandle handle)
 CUresult CUDAAPI
 fakeCuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
 {
+  if (tracked) {
+    int index;
+    CUmemGenericAllocationHandle handle = 0;
+    record("cuMemRetainAllocationHandle");
+    last.pointer = address;
+    if (output == NULL)
+      return CUDA_ERROR_INVALID_VALUE;
+    pthread_mutex_lock(&model_lock);
+    for (index = 0; index < FAKE_MAX_MAPPINGS; index++) {
+      if (mappings[index].used && (CUdeviceptr)(uintptr_t)address >= mappings[index].address &&
+          (CUdeviceptr)(uintptr_t)address < mappings[index].address + mappings[index].size) {
+        handle = new_handle(mappings[index].allocation);
+        break;
+      }
+    }
+    pthread_mutex_unlock(&model_lock);
+    if (handle == 0)
+      return CUDA_ERROR_INVALID_VALUE;
+    *output = handle;
+    return CUDA_SUCCESS;
+  }
   record("cuMemRetainAllocationHandle");
   last.pointer = address;
   if (output != NULL)
@@ -100,6 +327,35 @@ CUresult CUDAAPI
 fakeCuMemMap(
     CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
 {
+  if (tracked) {
+    int hindex = handle_index(handle);
+    int index;
+    record("cuMemMap");
+    last.address = address;
+    last.size = size;
+    last.offset = offset;
+    last.handle = handle;
+    last.flags = flags;
+    pthread_mutex_lock(&model_lock);
+    if (hindex < 0 || !handles[hindex].used) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    for (index = 0; index < FAKE_MAX_MAPPINGS; index++) {
+      if (!mappings[index].used) {
+        mappings[index].used = 1;
+        mappings[index].address = address;
+        mappings[index].size = size;
+        mappings[index].allocation = handles[hindex].allocation;
+        /* The mapping keeps the memory alive, like the driver does. */
+        allocations[mappings[index].allocation].refs++;
+        pthread_mutex_unlock(&model_lock);
+        return CUDA_SUCCESS;
+      }
+    }
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
   record("cuMemMap");
   last.address = address;
   last.size = size;
@@ -117,6 +373,25 @@ cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocation
 CUresult CUDAAPI
 fakeCuMemUnmap(CUdeviceptr address, size_t size)
 {
+  if (tracked) {
+    int index;
+    int found = 0;
+    record("cuMemUnmap");
+    last.address = address;
+    last.size = size;
+    pthread_mutex_lock(&model_lock);
+    for (index = 0; index < FAKE_MAX_MAPPINGS; index++) {
+      if (mappings[index].used && mappings[index].address >= address &&
+          mappings[index].address + mappings[index].size <= address + size) {
+        mappings[index].used = 0;
+        if (--allocations[mappings[index].allocation].refs == 0)
+          allocations[mappings[index].allocation].used = 0;
+        found = 1;
+      }
+    }
+    pthread_mutex_unlock(&model_lock);
+    return found ? CUDA_SUCCESS : CUDA_ERROR_INVALID_VALUE;
+  }
   record("cuMemUnmap");
   last.address = address;
   last.size = size;
@@ -131,6 +406,15 @@ cuMemUnmap(CUdeviceptr address, size_t size)
 CUresult CUDAAPI
 fakeCuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
 {
+  if (tracked) {
+    record("cuMemSetAccess");
+    last.address = address;
+    last.size = size;
+    last.count = count;
+    last.pointer = (void*)descriptors;
+    access_calls++;
+    return CUDA_SUCCESS;
+  }
   record("cuMemSetAccess");
   last.address = address;
   last.size = size;
@@ -148,6 +432,33 @@ CUresult CUDAAPI
 fakeCuMemExportToShareableHandle(
     void* output, CUmemGenericAllocationHandle handle, CUmemAllocationHandleType type, unsigned long long flags)
 {
+  if (tracked) {
+    int index = handle_index(handle);
+    char text[64];
+    int fd;
+    record("cuMemExportToShareableHandle");
+    last.pointer = output;
+    last.handle = handle;
+    last.handle_type = (int)type;
+    last.flags = flags;
+    if (output == NULL || flags != 0)
+      return CUDA_ERROR_INVALID_VALUE;
+    pthread_mutex_lock(&model_lock);
+    if (index < 0 || !handles[index].used) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    export_calls++;
+    snprintf(text, sizeof(text), FAKE_EXPORT_MAGIC "%d", handles[index].allocation);
+    /* The real driver's descriptor holds a reference until it is closed; this
+     * model cannot observe close(), so the descriptor is not counted here. */
+    pthread_mutex_unlock(&model_lock);
+    fd = memfd_create("fake-cuda-export", MFD_CLOEXEC);
+    if (fd < 0 || write(fd, text, strlen(text)) != (ssize_t)strlen(text))
+      return CUDA_ERROR_UNKNOWN;
+    *(int*)output = fd;
+    return CUDA_SUCCESS;
+  }
   record("cuMemExportToShareableHandle");
   last.pointer = output;
   last.handle = handle;
@@ -166,6 +477,31 @@ CUresult CUDAAPI
 fakeCuMemImportFromShareableHandle(
     CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
 {
+  if (tracked) {
+    char text[64] = {0};
+    int allocation = -1;
+    CUmemGenericAllocationHandle handle = 0;
+    record("cuMemImportFromShareableHandle");
+    last.pointer = os_handle;
+    last.handle_type = (int)type;
+    if (output == NULL)
+      return CUDA_ERROR_INVALID_VALUE;
+    if (pread((int)(uintptr_t)os_handle, text, sizeof(text) - 1, 0) > 0 &&
+        strncmp(text, FAKE_EXPORT_MAGIC, strlen(FAKE_EXPORT_MAGIC)) == 0)
+      allocation = atoi(text + strlen(FAKE_EXPORT_MAGIC));
+    pthread_mutex_lock(&model_lock);
+    if (allocation < 0 || allocation >= FAKE_MAX_ALLOCATIONS || !allocations[allocation].used) {
+      /* Not one of ours: model a descriptor from some other process. */
+      allocation = new_allocation(0, NULL);
+    }
+    if (allocation >= 0)
+      handle = new_handle(allocation);
+    pthread_mutex_unlock(&model_lock);
+    if (handle == 0)
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    *output = handle;
+    return CUDA_SUCCESS;
+  }
   record("cuMemImportFromShareableHandle");
   last.pointer = os_handle;
   last.handle_type = (int)type;
@@ -182,6 +518,21 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
 CUresult CUDAAPI
 fakeCuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
 {
+  if (tracked) {
+    int index = handle_index(handle);
+    record("cuMemGetAllocationPropertiesFromHandle");
+    last.pointer = properties;
+    last.handle = handle;
+    pthread_mutex_lock(&model_lock);
+    if (index < 0 || !handles[index].used) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    if (properties != NULL)
+      *properties = allocations[handles[index].allocation].properties;
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_SUCCESS;
+  }
   record("cuMemGetAllocationPropertiesFromHandle");
   last.pointer = properties;
   last.handle = handle;

--- a/agent/cmd/cuinterpose/tests/fake_cuda.h
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.h
@@ -62,6 +62,28 @@ struct fake_last_call {
 
 void fakeReset(void);
 const struct fake_last_call* fakeLastCall(void);
+
+/*
+ * Tracked mode: a small but honest model of the driver's allocation objects,
+ * enough for the shim's bookkeeping to be tested. Handles are reference counts
+ * on allocations; export produces a memfd naming the allocation; import of such
+ * a memfd adds a reference; import of any other descriptor creates a fresh
+ * "foreign" allocation; retain-by-address looks the mapping up. Calls succeed
+ * with CUDA_SUCCESS instead of returning the forwarding codes above.
+ */
+void fakeEnableTrackedBehavior(void);
+/* Forget every modeled allocation and mapping (tracked mode stays on). */
+void fakeResetModel(void);
+/* Allocations whose reference count is above zero. */
+int fakeLiveAllocations(void);
+/* Reference count of the allocation behind handle, or -1 when unknown/freed. */
+int fakeAllocationRefs(CUmemGenericAllocationHandle handle);
+/* True when two handles refer to the same modeled allocation. */
+int fakeSameAllocation(CUmemGenericAllocationHandle a, CUmemGenericAllocationHandle b);
+int fakeExportCalls(void);
+int fakeMappedCount(void);
+/* Number of cuMemSetAccess calls since the last reset. */
+int fakeAccessCalls(void);
 /* The fake's own implementation of `symbol`, bypassing any interposer. */
 void* fakeOriginal(const char* symbol);
 /* Same, for a caller that asked for a specific CUDA version. */

--- a/agent/cmd/cuinterpose/tests/forward_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/forward_preload_test.cc
@@ -76,7 +76,7 @@ TEST_F(Forwarding, UnicastEntryPointsForwardArguments) {
   EXPECT_EQ(last().size, 4096u);
   EXPECT_EQ(last().flags, 7u);
   EXPECT_EQ(last().handle_type, static_cast<int>(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
-  EXPECT_EQ(handle, 0xabcu) << "the driver's handle must reach the caller unchanged";
+  EXPECT_EQ(handle, 0u) << "on a driver error the output is left untouched";
 
   EXPECT_EQ(cuMemRelease(0x77), static_cast<CUresult>(FAKE_RESULT_RELEASE));
   EXPECT_EQ(last().handle, 0x77u);
@@ -85,7 +85,7 @@ TEST_F(Forwarding, UnicastEntryPointsForwardArguments) {
   EXPECT_EQ(cuMemRetainAllocationHandle(&retained, reinterpret_cast<void*>(0x1000)),
             static_cast<CUresult>(FAKE_RESULT_RETAIN));
   EXPECT_EQ(last().pointer, reinterpret_cast<void*>(0x1000));
-  EXPECT_EQ(retained, 0xdefu);
+  EXPECT_EQ(retained, 0u) << "on a driver error the output is left untouched";
 
   EXPECT_EQ(cuMemMap(0x2000, 8192, 16, 0xabc, 3), static_cast<CUresult>(FAKE_RESULT_MAP));
   EXPECT_EQ(last().address, 0x2000u);
@@ -112,7 +112,7 @@ TEST_F(Forwarding, UnicastEntryPointsForwardArguments) {
   EXPECT_EQ(cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(42), CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
             static_cast<CUresult>(FAKE_RESULT_IMPORT));
   EXPECT_EQ(last().pointer, reinterpret_cast<void*>(42));
-  EXPECT_EQ(imported, 0x123u);
+  EXPECT_EQ(imported, 0u) << "on a driver error the output is left untouched";
 
   EXPECT_EQ(cuMemGetAllocationPropertiesFromHandle(&prop, 0x55), static_cast<CUresult>(FAKE_RESULT_PROPERTIES));
   EXPECT_EQ(last().handle, 0x55u);

--- a/agent/cmd/cuinterpose/tests/state_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/state_preload_test.cc
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Allocation tracking, tickets, and the export cache, exercised through the
+// public CUDA entry points with the shim LD_PRELOADed over the fake driver in
+// tracked mode. SNAPSHOT_CONTROL_DIR must point at a writable directory.
+
+#include <cuda.h>
+#include <dirent.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "../export.h"
+#include "../protocol.h"
+#include "fake_cuda.h"
+
+namespace {
+
+const uint64_t kLogicalTag = 0xd94d000000000000ULL;
+const uint64_t kLogicalMask = 0xffff000000000000ULL;
+
+bool is_logical(CUmemGenericAllocationHandle handle) { return (handle & kLogicalMask) == kLogicalTag; }
+
+struct cuinterpose_debug_stats stats() {
+  using fn = void (*)(struct cuinterpose_debug_stats*);
+  static fn get = reinterpret_cast<fn>(dlsym(RTLD_DEFAULT, "cuinterpose_debug_stats"));
+  struct cuinterpose_debug_stats s{};
+  if (get != nullptr) get(&s);
+  return s;
+}
+
+int open_fds() {
+  int count = 0;
+  DIR* dir = opendir("/proc/self/fd");
+  while (readdir(dir) != nullptr) count++;
+  closedir(dir);
+  return count - 3;
+}
+
+CUmemAllocationProp posix_props() {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = 0;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+class Tracking : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { fakeEnableTrackedBehavior(); }
+  void SetUp() override {
+    fakeResetModel();
+    fakeReset();
+    struct cuinterpose_debug_stats s = stats();
+    ASSERT_EQ(s.allocations, 0u) << "a previous test leaked tracking state";
+    ASSERT_EQ(s.handles, 0u);
+    ASSERT_EQ(s.mappings, 0u);
+    ASSERT_EQ(s.cached_exports, 0u);
+    fds_before = open_fds();
+  }
+  void TearDown() override {
+    struct cuinterpose_debug_stats s = stats();
+    EXPECT_EQ(s.allocations, 0u) << "test left tracked allocations behind";
+    EXPECT_EQ(s.handles, 0u);
+    EXPECT_EQ(s.mappings, 0u);
+    EXPECT_EQ(s.cached_exports, 0u);
+    EXPECT_EQ(open_fds(), fds_before) << "descriptor leak";
+  }
+  CUmemGenericAllocationHandle create(size_t size = 1 << 20) {
+    CUmemAllocationProp prop = posix_props();
+    CUmemGenericAllocationHandle handle = 0;
+    EXPECT_EQ(cuMemCreate(&handle, size, &prop, 0), CUDA_SUCCESS);
+    EXPECT_TRUE(is_logical(handle));
+    return handle;
+  }
+  int fds_before = 0;
+};
+
+TEST_F(Tracking, CreateMapUnmapReleaseLeavesNothingBehind) {
+  CUmemGenericAllocationHandle handle = create();
+  EXPECT_EQ(stats().allocations, 1u);
+  EXPECT_EQ(stats().handles, 1u);
+  EXPECT_EQ(cuMemMap(0x10000, 1 << 20, 0, handle, 0), CUDA_SUCCESS);
+  EXPECT_EQ(stats().mappings, 1u);
+  EXPECT_EQ(fakeMappedCount(), 1);
+  EXPECT_EQ(fakeLastCall()->handle, 0x1000u) << "the driver saw its own handle, not the logical one";
+  // Releasing the handle while mapped keeps the record (the mapping is a reference).
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  EXPECT_EQ(stats().handles, 0u);
+  EXPECT_EQ(stats().allocations, 1u);
+  EXPECT_EQ(fakeLiveAllocations(), 1) << "the mapping keeps the driver allocation alive";
+  EXPECT_EQ(cuMemUnmap(0x10000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+  // A released logical handle is refused, not passed to the driver.
+  EXPECT_EQ(cuMemRelease(handle), CUDA_ERROR_INVALID_HANDLE);
+}
+
+TEST_F(Tracking, PrivateAndUnsupportedExportableHandleTypesPassThroughUntracked) {
+  for (unsigned type : {0u, static_cast<unsigned>(CU_MEM_HANDLE_TYPE_FABRIC),
+                        static_cast<unsigned>(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC)}) {
+    CUmemAllocationProp prop = posix_props();
+    prop.requestedHandleTypes = static_cast<CUmemAllocationHandleType>(type);
+    CUmemGenericAllocationHandle handle = 0;
+    ASSERT_EQ(cuMemCreate(&handle, 4096, &prop, 0), CUDA_SUCCESS) << type;
+    EXPECT_FALSE(is_logical(handle)) << "untracked allocations keep the driver's handle";
+    EXPECT_EQ(stats().allocations, 0u);
+    EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  }
+  EXPECT_EQ(stats().unsupported_exportable_creations, 2u)
+      << "private handle type 0 stays on the native path and is not checkpoint-unsupported";
+}
+
+TEST_F(Tracking, RetainAliasesOneDriverHandle) {
+  CUmemGenericAllocationHandle handle = create();
+  ASSERT_EQ(cuMemMap(0x10000, 1 << 20, 0, handle, 0), CUDA_SUCCESS);
+  CUmemGenericAllocationHandle retained = 0;
+  ASSERT_EQ(cuMemRetainAllocationHandle(&retained, reinterpret_cast<void*>(0x10800)), CUDA_SUCCESS);
+  EXPECT_TRUE(is_logical(retained));
+  EXPECT_NE(retained, handle);
+  EXPECT_EQ(stats().handles, 2u);
+  // Driver-side: create (1) + map (1) + retain (1) - alias release (1) = 2.
+  EXPECT_EQ(fakeAllocationRefs(0x1000), 2) << "the redundant driver reference was released immediately";
+  EXPECT_EQ(cuMemRelease(retained), CUDA_SUCCESS);
+  EXPECT_EQ(fakeAllocationRefs(0x1000), 2) << "releasing an alias keeps the shared backing reference";
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  EXPECT_EQ(fakeAllocationRefs(0x1000), -1) << "the last logical handle drops the driver handle";
+  EXPECT_EQ(fakeLiveAllocations(), 1) << "the mapping alone keeps the memory alive";
+  EXPECT_EQ(cuMemUnmap(0x10000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+  // Retain on an untracked address is a plain pass-through.
+  CUmemGenericAllocationHandle untracked = 0;
+  EXPECT_EQ(cuMemRetainAllocationHandle(&untracked, reinterpret_cast<void*>(0x999000)), CUDA_ERROR_INVALID_VALUE);
+}
+
+TEST_F(Tracking, MapRefusesOverlapAndUnmapIsRangeBased) {
+  CUmemGenericAllocationHandle a = create(1 << 20);
+  CUmemGenericAllocationHandle b = create(1 << 20);
+  ASSERT_EQ(cuMemMap(0x100000, 0x100000, 0, a, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x200000, 0x100000, 0, b, 0), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemMap(0x180000, 0x100000, 0, a, 0), CUDA_ERROR_INVALID_VALUE) << "overlapping a tracked mapping";
+  EXPECT_EQ(stats().mappings, 2u);
+  EXPECT_EQ(fakeMappedCount(), 2) << "the refused map never reached the driver";
+  EXPECT_EQ(cuMemUnmap(0x100000, 0x180000), CUDA_ERROR_INVALID_VALUE) << "cutting through a mapping";
+  EXPECT_EQ(cuMemUnmap(0x100000, 0x200000), CUDA_SUCCESS) << "one call covering two whole mappings";
+  EXPECT_EQ(stats().mappings, 0u);
+  EXPECT_EQ(fakeMappedCount(), 0);
+  // An unmap that touches nothing tracked passes straight through.
+  EXPECT_EQ(cuMemUnmap(0x900000, 0x1000), CUDA_ERROR_INVALID_VALUE) << "the fake driver rejects unknown ranges";
+  EXPECT_EQ(cuMemRelease(a), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(b), CUDA_SUCCESS);
+}
+
+TEST_F(Tracking, AccessIsMergedPerLocation) {
+  CUmemGenericAllocationHandle handle = create(1 << 21);
+  // PyTorch maps segments individually and sets access over the whole span.
+  ASSERT_EQ(cuMemMap(0x100000, 1 << 20, 0, handle, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x200000, 1 << 20, 1 << 20, handle, 0), CUDA_SUCCESS);
+  CUmemAccessDesc gpu0{};
+  gpu0.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  gpu0.location.id = 0;
+  gpu0.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  CUmemAccessDesc gpu1 = gpu0;
+  gpu1.location.id = 1;
+  EXPECT_EQ(cuMemSetAccess(0x100000, 1 << 21, &gpu0, 1), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemSetAccess(0x100000, 1 << 21, &gpu1, 1), CUDA_SUCCESS);
+  EXPECT_EQ(fakeAccessCalls(), 2);
+  // Partial overlap is refused before the driver sees it.
+  EXPECT_EQ(cuMemSetAccess(0x180000, 0x100000, &gpu0, 1), CUDA_ERROR_INVALID_VALUE);
+  EXPECT_EQ(fakeAccessCalls(), 2);
+  // Too many distinct locations for one record: refused, driver untouched.
+  std::vector<CUmemAccessDesc> many(CUINTERPOSE_MAX_ACCESS + 1, gpu0);
+  for (size_t i = 0; i < many.size(); i++) many[i].location.id = static_cast<int>(i + 10);
+  EXPECT_EQ(cuMemSetAccess(0x100000, 1 << 20, many.data(), many.size()), CUDA_ERROR_NOT_SUPPORTED);
+  EXPECT_EQ(fakeAccessCalls(), 2);
+  // Exactly the capacity, replacing gpu0/gpu1 through NONE first, is fine.
+  CUmemAccessDesc none0 = gpu0;
+  none0.flags = CU_MEM_ACCESS_FLAGS_PROT_NONE;
+  CUmemAccessDesc none1 = gpu1;
+  none1.flags = CU_MEM_ACCESS_FLAGS_PROT_NONE;
+  CUmemAccessDesc revoke[2] = {none0, none1};
+  EXPECT_EQ(cuMemSetAccess(0x100000, 1 << 21, revoke, 2), CUDA_SUCCESS);
+  many.pop_back();
+  EXPECT_EQ(cuMemSetAccess(0x100000, 1 << 21, many.data(), many.size()), CUDA_SUCCESS);
+  // Untracked ranges pass through.
+  EXPECT_EQ(cuMemSetAccess(0x900000, 4096, &gpu0, 1), CUDA_SUCCESS);
+  EXPECT_EQ(fakeAccessCalls(), 5);
+  EXPECT_EQ(cuMemUnmap(0x100000, 1 << 21), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+}
+
+TEST_F(Tracking, ExportMintsTicketsFromOneDriverExport) {
+  CUmemGenericAllocationHandle handle = create();
+  int ticket_a = -1, ticket_b = -1;
+  EXPECT_EQ(cuMemExportToShareableHandle(nullptr, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0),
+            CUDA_ERROR_INVALID_VALUE);
+  EXPECT_EQ(cuMemExportToShareableHandle(&ticket_a, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 1),
+            CUDA_ERROR_INVALID_VALUE) << "non-zero flags, as the driver would";
+  EXPECT_EQ(cuMemExportToShareableHandle(&ticket_a, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0), CUDA_ERROR_INVALID_VALUE);
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket_a, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket_b, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  EXPECT_EQ(fakeExportCalls(), 1) << "the driver is asked once; later exports reuse the cached descriptor";
+  EXPECT_EQ(stats().cached_exports, 1u);
+  EXPECT_NE(ticket_a, ticket_b);
+  // A ticket is a sealed memfd, not a driver descriptor.
+  EXPECT_EQ(fcntl(ticket_a, F_GET_SEALS) & F_SEAL_WRITE, F_SEAL_WRITE);
+  close(ticket_a);
+  close(ticket_b);
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  EXPECT_EQ(stats().cached_exports, 0u) << "the cached descriptor goes with the last local reference";
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+TEST_F(Tracking, ImportOfATicketInTheSameProcessAliasesTheAllocation) {
+  CUmemGenericAllocationHandle handle = create();
+  int ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  CUmemGenericAllocationHandle imported = 0;
+  ASSERT_EQ(cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  close(ticket);
+  EXPECT_TRUE(is_logical(imported));
+  EXPECT_NE(imported, handle);
+  EXPECT_EQ(stats().allocations, 1u) << "same allocation, second logical handle";
+  EXPECT_EQ(stats().handles, 2u);
+  EXPECT_EQ(fakeAllocationRefs(0x1000), 1) << "the import's driver reference was collapsed into the creator's";
+  CUmemAllocationProp props{};
+  EXPECT_EQ(cuMemGetAllocationPropertiesFromHandle(&props, imported), CUDA_SUCCESS);
+  EXPECT_EQ(props.requestedHandleTypes, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  EXPECT_EQ(cuMemRelease(imported), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+TEST_F(Tracking, RawImportsAreCountedUntilReleased) {
+  int foreign = memfd_create("foreign", MFD_CLOEXEC);
+  ASSERT_EQ(write(foreign, "x", 1), 1);
+  CUmemGenericAllocationHandle imported = 0;
+  ASSERT_EQ(cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(static_cast<intptr_t>(foreign)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  close(foreign);
+  EXPECT_FALSE(is_logical(imported)) << "a raw import stays a driver handle";
+  EXPECT_EQ(stats().live_raw_imports, 1u);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(cuMemRelease(imported), CUDA_SUCCESS);
+  EXPECT_EQ(stats().live_raw_imports, 0u);
+}
+
+// Two threads export the same allocation for the first time at once: the
+// driver must see exactly one export and both must get valid tickets.
+TEST_F(Tracking, ConcurrentFirstExportsCallTheDriverOnce) {
+  CUmemGenericAllocationHandle handle = create();
+  std::vector<std::thread> threads;
+  std::vector<int> tickets(8, -1);
+  std::atomic<int> failures{0};
+  for (int i = 0; i < 8; i++) {
+    threads.emplace_back([&, i] {
+      if (cuMemExportToShareableHandle(&tickets[i], handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) != CUDA_SUCCESS)
+        failures++;
+    });
+  }
+  for (auto& t : threads) t.join();
+  EXPECT_EQ(failures.load(), 0);
+  EXPECT_EQ(fakeExportCalls(), 1);
+  for (int fd : tickets) {
+    EXPECT_GE(fd, 0);
+    close(fd);
+  }
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+}
+
+// Peers keep importing through the listener while the creator releases and
+// recreates allocations. The sanitizers flag any use of a freed entry or a
+// closed descriptor; the assertions check that nobody ever got a wrong buffer.
+TEST_F(Tracking, ListenerServesWhileAllocationsChurn) {
+  std::atomic<bool> stop{false};
+  std::atomic<int> imports{0};
+  std::atomic<int> refusals{0};
+  CUmemGenericAllocationHandle handle = create();
+  int ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+
+  std::thread importer([&] {
+    while (!stop) {
+      CUmemGenericAllocationHandle imported = 0;
+      CUresult r = cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                                  CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+      if (r == CUDA_SUCCESS) {
+        imports++;
+        cuMemRelease(imported);
+      } else {
+        refusals++;
+      }
+    }
+  });
+  usleep(20000);
+  // Drop the creator's last reference while imports are in flight: the ticket
+  // becomes dead, imports start failing cleanly, nothing crashes.
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  usleep(20000);
+  stop = true;
+  importer.join();
+  close(ticket);
+  EXPECT_GT(imports.load(), 0);
+  EXPECT_GT(refusals.load(), 0) << "imports after the creator released must be refused";
+}
+
+// A child created by fork() gets its own identity and socket on first CUDA
+// activity, imports the parent's ticket through the parent's listener, and
+// leaves the parent's tracking untouched.
+TEST_F(Tracking, ForkedChildImportsThroughTheParentsListener) {
+  CUmemGenericAllocationHandle handle = create();
+  int ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(pipefd[0]);
+    int code = 0;
+    struct cuinterpose_debug_stats s = stats();
+    if (s.allocations != 0 || s.handles != 0) code |= 1;  // inherited records were dropped
+    CUmemGenericAllocationHandle imported = 0;
+    if (cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                       CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS)
+      code |= 2;
+    if (!is_logical(imported)) code |= 4;
+    s = stats();
+    if (s.allocations != 1 || s.handles != 1) code |= 8;
+    if (cuMemRelease(imported) != CUDA_SUCCESS) code |= 16;
+    if (write(pipefd[1], &code, sizeof(code)) != static_cast<ssize_t>(sizeof(code))) _exit(99);
+    _exit(0);
+  }
+  close(pipefd[1]);
+  int code = -1;
+  EXPECT_EQ(read(pipefd[0], &code, sizeof(code)), static_cast<ssize_t>(sizeof(code)));
+  close(pipefd[0]);
+  int status = 0;
+  waitpid(child, &status, 0);
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+  EXPECT_EQ(code, 0) << "child failure bits: " << code;
+  // The parent is unaffected by the child's activity.
+  EXPECT_EQ(stats().allocations, 1u);
+  EXPECT_EQ(stats().handles, 1u);
+  close(ticket);
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+}
+
+TEST_F(Tracking, ManyAllocationsComeAndGoWithoutGrowth) {
+  for (int round = 0; round < 10000; round++) {
+    CUmemGenericAllocationHandle handle = create(4096);
+    ASSERT_EQ(cuMemMap(0x10000000 + static_cast<CUdeviceptr>(round % 64) * 0x10000, 4096, 0, handle, 0), CUDA_SUCCESS);
+    ASSERT_EQ(cuMemUnmap(0x10000000 + static_cast<CUdeviceptr>(round % 64) * 0x10000, 4096), CUDA_SUCCESS);
+    ASSERT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+  }
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+  // TearDown asserts the tables are empty.
+}
+
+TEST_F(Tracking, DescriptorExhaustionFailsCleanly) {
+  CUmemGenericAllocationHandle handle = create();
+  rlimit before{}, low{};
+  ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &before), 0);
+  low = before;
+  low.rlim_cur = static_cast<rlim_t>(open_fds() + 3 + 4);  // room for the export and one ticket, not much more
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &low), 0);
+  std::vector<int> tickets;
+  CUresult last = CUDA_SUCCESS;
+  for (int i = 0; i < 16 && last == CUDA_SUCCESS; i++) {
+    int ticket = -1;
+    last = cuMemExportToShareableHandle(&ticket, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+    if (last == CUDA_SUCCESS) tickets.push_back(ticket);
+  }
+  EXPECT_NE(last, CUDA_SUCCESS) << "running out of descriptors must surface as an error";
+  EXPECT_FALSE(tickets.empty()) << "at least the first export succeeded";
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &before), 0);
+  for (int fd : tickets) close(fd);
+  EXPECT_EQ(cuMemRelease(handle), CUDA_SUCCESS);
+}
+
+}  // namespace

--- a/agent/cmd/cuinterpose/tests/table_unit_test.cc
+++ b/agent/cmd/cuinterpose/tests/table_unit_test.cc
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the shim's containers and the export cache. Linked into
+// proto_test; no CUDA, no LD_PRELOAD.
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstring>
+#include <set>
+#include <thread>
+#include <vector>
+
+extern "C" {
+#include "../export_cache.h"
+#include "util/table.h"
+}
+
+namespace {
+
+TEST(Table, PutGetRemoveAndShrink) {
+  table table{};
+  int values[1000];
+  for (int i = 0; i < 1000; i++) {
+    ASSERT_EQ(table_put(&table, key_u64(i * 7919), &values[i]), 0);
+  }
+  EXPECT_EQ(table.count, 1000u);
+  for (int i = 0; i < 1000; i++) {
+    EXPECT_EQ(table_get(&table, key_u64(i * 7919)), &values[i]);
+  }
+  EXPECT_EQ(table_get(&table, key_u64(1)), nullptr);
+  // Replace keeps the count.
+  ASSERT_EQ(table_put(&table, key_u64(0), &values[5]), 0);
+  EXPECT_EQ(table.count, 1000u);
+  EXPECT_EQ(table_get(&table, key_u64(0)), &values[5]);
+  // Remove everything; the table must give its memory back.
+  for (int i = 0; i < 1000; i++) {
+    EXPECT_EQ(table_remove(&table, key_u64(i * 7919)), i == 0 ? &values[5] : &values[i]);
+  }
+  EXPECT_EQ(table.count, 0u);
+  EXPECT_EQ(table.capacity, 0u);
+  EXPECT_EQ(table.slots, nullptr);
+  EXPECT_EQ(table_remove(&table, key_u64(3)), nullptr);
+}
+
+// Keys chosen to collide in a small table exercise probing, deletion from the
+// middle of a chain, and reuse of tombstones.
+TEST(Table, CollisionChainsAndTombstones) {
+  table table{};
+  int marker[64];
+  // Only the low bits index the table; these differ only in the high word.
+  for (uint64_t i = 0; i < 6; i++) {
+    key key{12345, i};
+    ASSERT_EQ(table_put(&table, key, &marker[i]), 0);
+  }
+  key middle{12345, 2};
+  EXPECT_EQ(table_remove(&table, middle), &marker[2]);
+  for (uint64_t i = 0; i < 6; i++) {
+    key key{12345, i};
+    EXPECT_EQ(table_get(&table, key), i == 2 ? nullptr : &marker[i]) << i;
+  }
+  // Insert after a tombstone, then grow past it repeatedly.
+  for (uint64_t i = 6; i < 60; i++) {
+    key key{12345, i};
+    ASSERT_EQ(table_put(&table, key, &marker[i]), 0);
+  }
+  for (uint64_t i = 0; i < 60; i++) {
+    key key{12345, i};
+    EXPECT_EQ(table_get(&table, key), i == 2 ? nullptr : &marker[i]) << i;
+  }
+  // Delete and re-add many times: the tombstone accounting must not fill the table.
+  for (int round = 0; round < 2000; round++) {
+    key key{12345, static_cast<uint64_t>(100 + (round % 3))};
+    ASSERT_EQ(table_put(&table, key, &marker[0]), 0);
+    EXPECT_EQ(table_remove(&table, key), &marker[0]);
+  }
+  EXPECT_EQ(table.count, 59u);
+  table_clear(&table);
+  EXPECT_EQ(table.capacity, 0u);
+}
+
+TEST(Table, ByteKeys) {
+  table table{};
+  uint8_t a[16], b[16];
+  std::memset(a, 0x11, sizeof(a));
+  std::memset(b, 0x11, sizeof(b));
+  b[15] = 0x12;
+  int va = 1, vb = 2;
+  ASSERT_EQ(table_put(&table, key_bytes(a), &va), 0);
+  ASSERT_EQ(table_put(&table, key_bytes(b), &vb), 0);
+  EXPECT_EQ(table_get(&table, key_bytes(a)), &va);
+  EXPECT_EQ(table_get(&table, key_bytes(b)), &vb);
+  int visited = 0;
+  table_each(&table, [](key, void*, void* arg) { (*static_cast<int*>(arg))++; return 0; }, &visited);
+  EXPECT_EQ(visited, 2);
+  table_clear(&table);
+}
+
+TEST(Ranges, InsertLookupCoverRemove) {
+  ranges ranges{};
+  int v[8];
+  ASSERT_EQ(ranges_insert(&ranges, 0x1000, 0x2000, &v[0]), 0);
+  ASSERT_EQ(ranges_insert(&ranges, 0x3000, 0x4000, &v[1]), 0);
+  ASSERT_EQ(ranges_insert(&ranges, 0x2000, 0x3000, &v[2]), 0) << "adjacent is fine";
+  EXPECT_EQ(ranges_insert(&ranges, 0x1800, 0x1900, &v[3]), 1) << "inside an existing range";
+  EXPECT_EQ(ranges_insert(&ranges, 0x0800, 0x1800, &v[3]), 1) << "straddling";
+  EXPECT_EQ(ranges_insert(&ranges, 0x5000, 0x5000, &v[3]), 1) << "empty";
+  EXPECT_EQ(ranges.count, 3u);
+  EXPECT_EQ(ranges.items[0].value, &v[0]);
+  EXPECT_EQ(ranges.items[1].value, &v[2]);
+  EXPECT_EQ(ranges.items[2].value, &v[1]);
+
+  EXPECT_EQ(ranges_at(&ranges, 0x1000)->value, &v[0]);
+  EXPECT_EQ(ranges_at(&ranges, 0x1fff)->value, &v[0]);
+  EXPECT_EQ(ranges_at(&ranges, 0x2000)->value, &v[2]);
+  EXPECT_EQ(ranges_at(&ranges, 0x0fff), nullptr);
+  EXPECT_EQ(ranges_at(&ranges, 0x4000), nullptr);
+
+  size_t first, last;
+  EXPECT_EQ(ranges_cover(&ranges, 0x1000, 0x3000, &first, &last), 0);
+  EXPECT_EQ(first, 0u);
+  EXPECT_EQ(last, 2u);
+  EXPECT_EQ(ranges_cover(&ranges, 0x1000, 0x2800, &first, &last), 1) << "cuts the second range";
+  EXPECT_EQ(ranges_cover(&ranges, 0x5000, 0x6000, &first, &last), 0);
+  EXPECT_EQ(first, last) << "nothing intersects";
+  EXPECT_EQ(ranges_cover(&ranges, 0x0000, 0x9000, &first, &last), 0);
+  EXPECT_EQ(last - first, 3u);
+
+  ranges_remove_at(&ranges, 1);
+  EXPECT_EQ(ranges.count, 2u);
+  EXPECT_EQ(ranges_at(&ranges, 0x2800), nullptr);
+  ranges_remove_at(&ranges, 0);
+  ranges_remove_at(&ranges, 0);
+  EXPECT_EQ(ranges.count, 0u);
+  EXPECT_EQ(ranges.items, nullptr);
+}
+
+class ExportCache : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::memset(id, 0x42, sizeof(id));
+    cuinterpose_export_cache_resume();
+  }
+  void TearDown() override {
+    cuinterpose_export_cache_quiesce();
+    cuinterpose_export_cache_resume();
+  }
+  int memfd(const char* text) {
+    int fd = memfd_create("t", MFD_CLOEXEC);
+    if (write(fd, text, std::strlen(text)) != static_cast<ssize_t>(std::strlen(text))) abort();
+    return fd;
+  }
+  uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+};
+
+TEST_F(ExportCache, ServesDuplicatesByAllocationID) {
+  ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("gpu")), 0);
+  EXPECT_TRUE(cuinterpose_export_cache_has(id));
+  EXPECT_EQ(cuinterpose_export_cache_count(), 1u);
+  int dup = -1;
+  const char* reason = nullptr;
+  ASSERT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), 0);
+  ASSERT_GE(dup, 0);
+  char buffer[4] = {};
+  EXPECT_EQ(pread(dup, buffer, 3, 0), 3);
+  EXPECT_STREQ(buffer, "gpu");
+  EXPECT_NE(fcntl(dup, F_GETFD) & FD_CLOEXEC, 0);
+  close(dup);
+  cuinterpose_export_cache_end(id);
+
+  uint8_t other[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  std::memset(other, 0x43, sizeof(other));
+  EXPECT_EQ(cuinterpose_export_cache_begin(other, &dup, &reason), -1);
+  EXPECT_EQ(dup, -1);
+  EXPECT_STREQ(reason, "creator resource is unavailable");
+}
+
+TEST_F(ExportCache, DropWaitsForInFlightRequests) {
+  ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("gpu")), 0);
+  int dup = -1;
+  const char* reason = nullptr;
+  ASSERT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), 0);
+  std::atomic<bool> dropped{false};
+  std::thread dropper([&] {
+    cuinterpose_export_cache_drop(id);
+    dropped = true;
+  });
+  usleep(20000);
+  EXPECT_FALSE(dropped) << "drop must wait while a request is being served";
+  // The descriptor we duplicated is still valid while the request is in flight.
+  char buffer[4] = {};
+  EXPECT_EQ(pread(dup, buffer, 3, 0), 3);
+  close(dup);
+  cuinterpose_export_cache_end(id);
+  dropper.join();
+  EXPECT_TRUE(dropped);
+  EXPECT_FALSE(cuinterpose_export_cache_has(id));
+  EXPECT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), -1);
+}
+
+TEST_F(ExportCache, QuiesceStopsServingAndResumeAllowsRefill) {
+  ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("gpu")), 0);
+  cuinterpose_export_cache_quiesce();
+  EXPECT_EQ(cuinterpose_export_cache_count(), 0u);
+  int dup = -1;
+  const char* reason = nullptr;
+  EXPECT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), -1);
+  // Refilling while quiesced stores the descriptor but does not serve it.
+  ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("again")), 0);
+  EXPECT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), -1) << "not accepting yet";
+  cuinterpose_export_cache_resume();
+  ASSERT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), 0);
+  close(dup);
+  cuinterpose_export_cache_end(id);
+}
+
+TEST_F(ExportCache, ReplacingAnEntryClosesTheOldDescriptorAfterDrain) {
+  int old = memfd("old");
+  ASSERT_EQ(cuinterpose_export_cache_put(id, old), 0);
+  ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("new")), 0);
+  EXPECT_EQ(cuinterpose_export_cache_count(), 1u);
+  EXPECT_EQ(fcntl(old, F_GETFD), -1) << "the replaced descriptor must have been closed";
+  int dup = -1;
+  const char* reason = nullptr;
+  ASSERT_EQ(cuinterpose_export_cache_begin(id, &dup, &reason), 0);
+  char buffer[4] = {};
+  EXPECT_EQ(pread(dup, buffer, 3, 0), 3);
+  EXPECT_STREQ(buffer, "new");
+  close(dup);
+  cuinterpose_export_cache_end(id);
+}
+
+// Many threads serving while another drops and re-adds the entry: the
+// sanitizers catch any use of a closed descriptor or freed entry.
+TEST_F(ExportCache, ConcurrentServeAndDropIsSafe) {
+  ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("gpu")), 0);
+  std::atomic<bool> stop{false};
+  std::atomic<int> served{0};
+  std::vector<std::thread> workers;
+  for (int i = 0; i < 4; i++) {
+    workers.emplace_back([&] {
+      while (!stop) {
+        int dup = -1;
+        const char* reason = nullptr;
+        if (cuinterpose_export_cache_begin(id, &dup, &reason) == 0) {
+          char buffer[4] = {};
+          EXPECT_EQ(pread(dup, buffer, 3, 0), 3);
+          EXPECT_STREQ(buffer, "gpu");
+          close(dup);
+          cuinterpose_export_cache_end(id);
+          served++;
+        }
+      }
+    });
+  }
+  for (int round = 0; round < 200; round++) {
+    cuinterpose_export_cache_drop(id);
+    ASSERT_EQ(cuinterpose_export_cache_put(id, memfd("gpu")), 0);
+  }
+  stop = true;
+  for (auto& worker : workers) worker.join();
+  EXPECT_GT(served.load(), 0);
+}
+
+}  // namespace

--- a/agent/cmd/cuinterpose/util/table.c
+++ b/agent/cmd/cuinterpose/util/table.c
@@ -1,0 +1,273 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "table.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* A slot that once held an entry; lookups skip it, inserts may reuse it. */
+static char tombstone_storage;
+#define TOMBSTONE ((void*)&tombstone_storage)
+
+struct key
+key_bytes(const uint8_t bytes[16])
+{
+  struct key key;
+
+  memcpy(&key.low, bytes, sizeof(key.low));
+  memcpy(&key.high, bytes + sizeof(key.low), sizeof(key.high));
+  return key;
+}
+
+static bool
+key_equal(struct key a, struct key b)
+{
+  return a.low == b.low && a.high == b.high;
+}
+
+static size_t
+key_hash(struct key key)
+{
+  /* splitmix64 over both words: cheap and well distributed for small counts. */
+  uint64_t x = key.low ^ (key.high * 0x9e3779b97f4a7c15ULL);
+  x ^= x >> 30;
+  x *= 0xbf58476d1ce4e5b9ULL;
+  x ^= x >> 27;
+  x *= 0x94d049bb133111ebULL;
+  x ^= x >> 31;
+  return (size_t)x;
+}
+
+static int
+rehash(struct table* table, size_t capacity)
+{
+  struct slot* slots = calloc(capacity, sizeof(*slots));
+  size_t index;
+
+  if (slots == NULL)
+    return -1;
+  for (index = 0; index < table->capacity; index++) {
+    struct slot* slot = &table->slots[index];
+    size_t position;
+
+    if (slot->value == NULL || slot->value == TOMBSTONE)
+      continue;
+    position = key_hash(slot->key) & (capacity - 1);
+    while (slots[position].value != NULL)
+      position = (position + 1) & (capacity - 1);
+    slots[position] = *slot;
+  }
+  free(table->slots);
+  table->slots = slots;
+  table->capacity = capacity;
+  table->used = table->count;
+  return 0;
+}
+
+static struct slot*
+find_slot(const struct table* table, struct key key)
+{
+  size_t position;
+  size_t probes;
+
+  if (table->capacity == 0)
+    return NULL;
+  position = key_hash(key) & (table->capacity - 1);
+  for (probes = 0; probes < table->capacity; probes++) {
+    struct slot* slot = &table->slots[position];
+    if (slot->value == NULL)
+      return NULL;
+    if (slot->value != TOMBSTONE && key_equal(slot->key, key))
+      return slot;
+    position = (position + 1) & (table->capacity - 1);
+  }
+  return NULL;
+}
+
+int
+table_put(struct table* table, struct key key, void* value)
+{
+  struct slot* existing = find_slot(table, key);
+  size_t position;
+
+  if (existing != NULL) {
+    existing->value = value;
+    return 0;
+  }
+  /* Keep the load, including tombstones, under 1/2 so probes stay short. */
+  if ((table->used + 1) * 2 > table->capacity) {
+    size_t capacity = table->capacity == 0 ? 16 : table->capacity;
+    while ((table->count + 1) * 2 > capacity)
+      capacity *= 2;
+    if (rehash(table, capacity) != 0)
+      return -1;
+  }
+  position = key_hash(key) & (table->capacity - 1);
+  while (table->slots[position].value != NULL && table->slots[position].value != TOMBSTONE)
+    position = (position + 1) & (table->capacity - 1);
+  if (table->slots[position].value == NULL)
+    table->used++;
+  table->slots[position].key = key;
+  table->slots[position].value = value;
+  table->count++;
+  return 0;
+}
+
+void*
+table_get(const struct table* table, struct key key)
+{
+  struct slot* slot = find_slot(table, key);
+
+  return slot == NULL ? NULL : slot->value;
+}
+
+void*
+table_remove(struct table* table, struct key key)
+{
+  struct slot* slot = find_slot(table, key);
+  void* value;
+
+  if (slot == NULL)
+    return NULL;
+  value = slot->value;
+  slot->value = TOMBSTONE;
+  table->count--;
+  /* Shrink when mostly empty; on failure the table simply stays large. */
+  if (table->count == 0) {
+    free(table->slots);
+    table->slots = NULL;
+    table->capacity = 0;
+    table->used = 0;
+  } else if (table->capacity > 16 && table->count * 8 < table->capacity) {
+    (void)rehash(table, table->capacity / 2);
+  }
+  return value;
+}
+
+int
+table_each(
+    const struct table* table, int (*fn)(struct key key, void* value, void* arg), void* arg)
+{
+  size_t index;
+
+  for (index = 0; index < table->capacity; index++) {
+    struct slot* slot = &table->slots[index];
+    int result;
+
+    if (slot->value == NULL || slot->value == TOMBSTONE)
+      continue;
+    result = fn(slot->key, slot->value, arg);
+    if (result != 0)
+      return result;
+  }
+  return 0;
+}
+
+void
+table_clear(struct table* table)
+{
+  free(table->slots);
+  memset(table, 0, sizeof(*table));
+}
+
+/* Index of the first range whose end is greater than address. */
+static size_t
+lower_bound(const struct ranges* ranges, uint64_t address)
+{
+  size_t low = 0;
+  size_t high = ranges->count;
+
+  while (low < high) {
+    size_t middle = low + (high - low) / 2;
+    if (ranges->items[middle].end <= address)
+      low = middle + 1;
+    else
+      high = middle;
+  }
+  return low;
+}
+
+int
+ranges_insert(struct ranges* ranges, uint64_t start, uint64_t end, void* value)
+{
+  size_t index;
+
+  if (end <= start)
+    return 1;
+  index = lower_bound(ranges, start);
+  if (index < ranges->count && ranges->items[index].start < end)
+    return 1;
+  if (ranges->count == ranges->capacity) {
+    size_t capacity = ranges->capacity == 0 ? 16 : ranges->capacity * 2;
+    struct range* items = reallocarray(ranges->items, capacity, sizeof(*items));
+    if (items == NULL)
+      return -1;
+    ranges->items = items;
+    ranges->capacity = capacity;
+  }
+  memmove(&ranges->items[index + 1], &ranges->items[index], (ranges->count - index) * sizeof(*ranges->items));
+  ranges->items[index].start = start;
+  ranges->items[index].end = end;
+  ranges->items[index].value = value;
+  ranges->count++;
+  return 0;
+}
+
+struct range*
+ranges_at(const struct ranges* ranges, uint64_t address)
+{
+  size_t index = lower_bound(ranges, address);
+
+  if (index < ranges->count && ranges->items[index].start <= address)
+    return &ranges->items[index];
+  return NULL;
+}
+
+int
+ranges_cover(
+    const struct ranges* ranges, uint64_t start, uint64_t end, size_t* first, size_t* last)
+{
+  size_t index = lower_bound(ranges, start);
+  size_t stop = index;
+  int partial = 0;
+
+  while (stop < ranges->count && ranges->items[stop].start < end) {
+    if (ranges->items[stop].start < start || ranges->items[stop].end > end)
+      partial = 1;
+    stop++;
+  }
+  *first = index;
+  *last = stop;
+  return partial;
+}
+
+void
+ranges_remove_at(struct ranges* ranges, size_t index)
+{
+  if (index >= ranges->count)
+    return;
+  memmove(&ranges->items[index], &ranges->items[index + 1], (ranges->count - index - 1) * sizeof(*ranges->items));
+  ranges->count--;
+  if (ranges->count == 0) {
+    free(ranges->items);
+    ranges->items = NULL;
+    ranges->capacity = 0;
+  } else if (ranges->capacity > 16 && ranges->count * 4 < ranges->capacity) {
+    struct range* items = reallocarray(ranges->items, ranges->capacity / 2, sizeof(*items));
+    if (items != NULL) {
+      ranges->items = items;
+      ranges->capacity /= 2;
+    }
+  }
+}
+
+void
+ranges_clear(struct ranges* ranges)
+{
+  free(ranges->items);
+  memset(ranges, 0, sizeof(*ranges));
+}

--- a/agent/cmd/cuinterpose/util/table.h
+++ b/agent/cmd/cuinterpose/util/table.h
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_TABLE_H
+#define CUINTERPOSE_TABLE_H
+
+/*
+ * Two small containers for the shim's bookkeeping. Both grow and shrink with
+ * use, so a long-running server that maps and unmaps constantly does not
+ * accumulate dead entries or slow down over time.
+ *
+ * table: open-addressing hash map from a 128-bit key to a pointer.
+ * Used for logical handles (key = handle, 0) and allocation ids (16 bytes).
+ *
+ * ranges: sorted array of non-overlapping address ranges, each
+ * carrying a pointer. Used for mappings, where the questions are "which
+ * mapping contains this address" and "which mappings does this range cover".
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct key {
+  uint64_t low;
+  uint64_t high;
+};
+
+struct slot {
+  struct key key;
+  void* value; /* NULL: empty; TOMBSTONE: deleted */
+};
+
+struct table {
+  struct slot* slots;
+  size_t capacity; /* power of two, or 0 */
+  size_t count; /* live entries */
+  size_t used; /* live entries + tombstones */
+};
+
+static inline struct key
+key_u64(uint64_t value)
+{
+  struct key key = {value, 0};
+  return key;
+}
+
+struct key key_bytes(const uint8_t bytes[16]);
+
+/* Insert or replace. Returns -1 only when memory allocation fails. */
+int table_put(struct table* table, struct key key, void* value);
+void* table_get(const struct table* table, struct key key);
+/* Returns the removed value, or NULL when absent. */
+void* table_remove(struct table* table, struct key key);
+/* Calls fn for every live entry; stops early when fn returns non-zero. */
+int table_each(
+    const struct table* table, int (*fn)(struct key key, void* value, void* arg), void* arg);
+void table_clear(struct table* table);
+
+struct range {
+  uint64_t start;
+  uint64_t end; /* exclusive */
+  void* value;
+};
+
+struct ranges {
+  struct range* items;
+  size_t count;
+  size_t capacity;
+};
+
+/* Inserts [start, end). Returns 1 if it overlaps an existing range (nothing
+ * inserted), -1 on allocation failure, 0 on success. */
+int ranges_insert(struct ranges* ranges, uint64_t start, uint64_t end, void* value);
+/* The range containing address, or NULL. */
+struct range* ranges_at(const struct ranges* ranges, uint64_t address);
+/*
+ * Classifies [start, end) against the stored ranges. *first and *last receive the
+ * index span of ranges that intersect it. Returns 0 when every intersecting
+ * range is fully inside [start, end), 1 when some range only partly overlaps
+ * it (the request cannot be expressed per range), and 0 with *first == *last
+ * when nothing intersects.
+ */
+int ranges_cover(
+    const struct ranges* ranges, uint64_t start, uint64_t end, size_t* first, size_t* last);
+void ranges_remove_at(struct ranges* ranges, size_t index);
+void ranges_clear(struct ranges* ranges);
+
+#endif


### PR DESCRIPTION
## Summary

Layer 7 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293). Closed PR #214 is intentionally not in the active stack.

This PR implements running-state POSIX CUDA VMM tracking without checkpoint/restore lifecycle mechanics.

`cuMemCreate` has an explicit three-way gate:

| Requested handle type | Runtime behavior | Checkpoint behavior |
| --- | --- | --- |
| `0` | Private allocation passes through natively | Allowed |
| Exactly `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` | Tracked and virtualized | Supported |
| Any other nonzero type, including FABRIC or combinations | Passes through to the driver | Refused by #216 preflight |

Only successful unsupported exportable creations increment the process-wide diagnostic. It is intentionally sticky for that process generation because cuinterpose did not track the resource and cannot prove that releasing one handle eliminated every derived sharing dependency. FABRIC logs once that checkpoint will be refused. A fork child discards inherited CUDA state and starts with a fresh count.

Tracked allocations receive stable random allocation IDs and tagged logical handles. Repeated imports and retained handles collapse onto one real driver handle per allocation per process. Mappings are indexed by address range; access grants merge by location; partial/ambiguous operations are refused; a possibly partial driver access failure marks state unknown so inspection fails closed.

On first POSIX export, the creator performs one real CUDA export, keeps that descriptor in the export cache under the allocation ID, and returns a sealed ticket FD to the application. An importing shim reads the ticket, connects to the original creator endpoint, requests the ticket's participant/resource/allocation identity, receives a fresh descriptor over `SCM_RIGHTS`, imports it, and returns another logical handle. The random allocation ID is the opaque resource identity and export-cache key. Re-export by an importer still names the original creator.

A non-ticket descriptor import passes through and is counted as live raw sharing until its driver handle is released. #216 refuses checkpoint while that count is nonzero. The export cache has independent locking, in-flight pinning, drain-on-drop, and lifecycle quiesce/resume so peer requests remain serviceable without the main state lock.

The library constructor establishes the participant ID and `/snapshot-control/cuinterpose-<namespace-pid>.sock`. `CUINTERPOSE_PARTICIPANT_ID` is the explicit identity override used by tests and controlled launchers. The socket is mode `0600`; the Pod-local control `emptyDir` is mounted through a container-name `subPath`, so ordinary other Pods have no filesystem path to it and Snapshot-managed target containers receive isolated views. The workload Pod remains one trust domain if its author deliberately gives a sidecar the reserved volume. This boundary does not claim protection from node root or an equivalently privileged workload. Fork children discard inherited CUDA bookkeeping and lazily create a new identity/socket on first CUDA activity. Control-endpoint ownership uses scoped cleanup and direct returns rather than `goto`.

## Stack boundary

Based on #216. #292 adds the isolated current allocation-content storage module; #218 invokes it from `SAVE_ALLOCATIONS`/`LOAD_ALLOCATIONS` and implements unicast teardown/rebuild.

## Validation

The pinned CUDA 13.1 builder passes 13 tracking tests, 9 table/cache tests, and 9 protocol tests with ASan/UBSan where configured. Coverage includes private/POSIX/FABRIC gate behavior, handle alias collapse, range mapping/access semantics, ticket exchange through a forked child, raw import accounting, listener concurrency, descriptor exhaustion, and table churn. `make test` passes in all Go modules. The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its physical-GPU suite passed all 3 tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.




