### PR TITLE
feat(agent): checkpoint and restore POSIX CUDA VMM state

### DIFF
--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -127,7 +127,12 @@ struct allocation_job {
   size_t allocation_count;
   uint16_t operation;
   int result;
+  uint32_t copy_us; /* the shim's own timing of its copies */
 };
+
+/* Longest copy time any participant reported in the last carrier phase; the
+ * participants copy concurrently, so this is the copy's share of the phase. */
+static uint32_t last_allocation_copy_us;
 
 static int
 connect_endpoint(const char* endpoint)
@@ -753,9 +758,7 @@ command_all_parallel(struct participant* participants, size_t count, uint16_t op
 }
 
 static int
-exchange_allocation(
-    struct participant* participant, uint16_t operation, const uint8_t allocation_id[CUINTERPOSE_ALLOCATION_ID_SIZE],
-    uint64_t size)
+exchange_allocations(struct participant* participant, uint16_t operation, uint64_t size, uint32_t* copy_us)
 {
   struct cuinterpose_header request;
   struct cuinterpose_header response;
@@ -768,37 +771,47 @@ exchange_allocation(
   request.operation = operation;
   request.payload_size = size;
   id_copy(request.participant_id, participant->id);
-  allocation_id_copy(request.allocation_id, allocation_id);
   fd = connect_endpoint(participant->endpoint);
   if (fd < 0 || set_socket_timeouts(fd, allocation_transfer_timeout_seconds()) != 0 ||
       cuinterpose_send_header(fd, &request, -1) != 0 || cuinterpose_receive_header(fd, &response, &response_fd) != 0)
     return -1;
   if (response_fd >= 0 || !cuinterpose_header_strings_terminated(&response) || response.magic != CUINTERPOSE_MAGIC ||
       response.version != CUINTERPOSE_VERSION || response.operation != operation || response.status != 0 ||
-      response.count != 0 || response.payload_size != 0 || !id_eq(response.participant_id, participant->id)) {
+      response.count != 0 || !id_eq(response.participant_id, participant->id)) {
     if (cuinterpose_header_strings_terminated(&response) && response.message[0] != '\0')
       fprintf(stderr, "%s: %s\n", participant->endpoint, response.message);
     return -1;
   }
+  if (response.payload_size != size) {
+    fprintf(
+        stderr, "%s: allocation transfer moved %llu bytes, expected %llu\n", participant->endpoint,
+        (unsigned long long)response.payload_size, (unsigned long long)size);
+    return -1;
+  }
+  *copy_us = response.copy_us;
   return 0;
 }
 
+/*
+ * One request per participant: the shim copies every allocation it owns in
+ * one batch (all copies issued on one stream, one wait), and reports
+ * the byte count in the reply's payload_size. The expected total is checked
+ * against the topology so a shim that silently skipped an allocation fails
+ * here rather than at restore.
+ */
 static void*
 run_allocation_job(void* argument)
 {
   struct allocation_job* job = argument;
   size_t index;
+  uint64_t expected = 0;
 
-  job->result = 0;
   for (index = 0; index < job->allocation_count; index++) {
     const struct allocation* allocation = &job->allocations[index];
-
-    if (!allocation->preserve_content || !id_eq(allocation->creator, job->participant->id))
-      continue;
-    job->result = exchange_allocation(job->participant, job->operation, allocation->id, allocation->size);
-    if (job->result != 0)
-      break;
+    if (allocation->preserve_content && id_eq(allocation->creator, job->participant->id))
+      expected += allocation->size;
   }
+  job->result = exchange_allocations(job->participant, job->operation, expected, &job->copy_us);
   return NULL;
 }
 
@@ -813,24 +826,13 @@ transfer_allocations(
   size_t index;
   int result = 0;
 
+  last_allocation_copy_us = 0;
   jobs = calloc(participant_count, sizeof(*jobs));
   threads = calloc(participant_count, sizeof(*threads));
   launched = calloc(participant_count, sizeof(*launched));
   if (jobs == NULL || threads == NULL || launched == NULL)
     return -1;
   for (index = 0; index < participant_count; index++) {
-    size_t allocation_index;
-    bool owns_content = false;
-
-    for (allocation_index = 0; allocation_index < allocation_count; allocation_index++) {
-      const struct allocation* allocation = &allocations[allocation_index];
-      if (allocation->preserve_content && id_eq(allocation->creator, participants[index].id)) {
-        owns_content = true;
-        break;
-      }
-    }
-    if (!owns_content)
-      continue;
     jobs[index].participant = &participants[index];
     jobs[index].allocations = allocations;
     jobs[index].allocation_count = allocation_count;
@@ -842,8 +844,12 @@ transfer_allocations(
     launched[index] = true;
   }
   for (index = 0; index < participant_count; index++) {
-    if (launched[index] && (pthread_join(threads[index], NULL) != 0 || jobs[index].result != 0))
+    if (!launched[index])
+      continue;
+    if (pthread_join(threads[index], NULL) != 0 || jobs[index].result != 0)
       result = -1;
+    else if (jobs[index].copy_us > last_allocation_copy_us)
+      last_allocation_copy_us = jobs[index].copy_us;
   }
   return result;
 }
@@ -912,9 +918,12 @@ allocation_extra(
   double ms = elapsed_since_milliseconds(start);
 
   allocation_totals(allocations, allocation_count, &count, &bytes);
+  /* gb_per_s covers setup, copies, teardown, and sockets; copy_gb_per_s uses
+   * the slowest participant's device-copy time. */
   snprintf(
-      buffer, size, "allocation_count=%zu allocation_bytes=%llu gb_per_s=%.2f", count, (unsigned long long)bytes,
-      ms > 0.0 ? ((double)bytes / 1e9) / (ms / 1000.0) : 0.0);
+      buffer, size, "allocation_count=%zu allocation_bytes=%llu gb_per_s=%.2f copy_gb_per_s=%.2f", count,
+      (unsigned long long)bytes, ms > 0.0 ? ((double)bytes / 1e9) / (ms / 1000.0) : 0.0,
+      last_allocation_copy_us > 0 ? ((double)bytes / 1e9) / ((double)last_allocation_copy_us / 1e6) : 0.0);
 }
 
 /* Prepare must not start with state cuinterpose cannot reconstruct. These

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -406,11 +406,12 @@ list_allocations(struct allocation_list* list)
   return 0;
 }
 
-/* Every supported exportable creator allocation needs content preservation. */
+/* Private VMM allocations and their handles remain owned by native CUDA. */
 static bool
 needs_allocation_content(const struct allocation* allocation)
 {
-  return allocation->creator && allocation->properties.requestedHandleTypes != 0 &&
+  return allocation->shared && allocation->creator &&
+         allocation->properties.requestedHandleTypes != 0 &&
          allocation->properties.type == CU_MEM_ALLOCATION_TYPE_PINNED &&
          allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE;
 }
@@ -451,8 +452,6 @@ inspect_records(uint32_t* count, const char** error)
       record->flags |= CUINTERPOSE_APPLICATION_HANDLE_LIVE;
     if (needs_allocation_content(allocation))
       record->flags |= CUINTERPOSE_ALLOCATION_CONTENT;
-    if (allocation->creator && !allocation->shared)
-      record->flags |= CUINTERPOSE_CONTENT_ONLY;
     memcpy(record->allocation_id, allocation->id, sizeof(record->allocation_id));
     record->allocation_size = allocation->size;
     record->allocation_type = allocation->properties.type;
@@ -491,7 +490,7 @@ inspect_records(uint32_t* count, const char** error)
 }
 
 /*
- * SAVE_ALLOCATIONS first makes sure every creator allocation has a driver
+ * SAVE_ALLOCATIONS first makes sure every shared creator allocation has a driver
  * handle to copy from. A creator that released its handles but still has a
  * mapping gets one back through cuMemRetainAllocationHandle.
  */
@@ -516,7 +515,7 @@ retain_creator_handles_for_save(const char** error)
     size_t range;
     CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-    if (!allocation->creator || allocation->driver != 0)
+    if (!allocation->shared || !allocation->creator || allocation->driver != 0)
       continue;
     if (enter_allocation_context(allocation, &scope) != 0) {
       free(list.items);
@@ -662,6 +661,8 @@ prepare(const char** error)
     struct cuinterpose_context_scope scope;
     size_t range;
 
+    if (!allocation->shared)
+      continue;
     if (needs_allocation_content(allocation) && !allocation->host_checkpointed) {
       free(list.items);
       *error = "a creator allocation was not saved to its host carrier";

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -31,7 +31,9 @@
 #include "interpose.h"
 
 #include <errno.h>
+#include <dirent.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -44,7 +46,9 @@
 #include <unistd.h>
 
 #include "export.h"
+#include "context.h"
 #include "export_cache.h"
+#include "host_carrier.h"
 #include "posix.h"
 #include "protocol.h"
 #include "symbols.h"
@@ -73,7 +77,6 @@ typedef CUresult(CUDAAPI* export_fn)(
     void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
 typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
 typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
-typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
 
 struct allocation {
   uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE];
@@ -87,6 +90,10 @@ struct allocation {
   bool shared; /* a ticket was issued (creator) or imported (importer) */
   unsigned live_handles;
   unsigned live_mappings;
+  /* Checkpoint state. */
+  bool checkpointed; /* PREPARE_UNICAST ran: mappings are unmapped and driver handles released */
+  void* host_carrier; /* creator: pinned host copy of the contents while checkpointed */
+  bool host_checkpointed; /* creator: the device backing was freed after copying to host */
 };
 
 struct handle {
@@ -102,10 +109,25 @@ struct mapping {
   CUmemAccessDesc access[CUINTERPOSE_MAX_ACCESS];
   size_t access_count;
   bool access_unknown; /* a driver access call failed part-way; replay cannot be trusted */
+  bool checkpointed; /* unmapped for the checkpoint; to be mapped again on restore */
 };
 
+/*
+ * Where this process is in the checkpoint/restore lifecycle. The coordinator
+ * drives the transitions; while not ACTIVE every tracked entry point answers
+ * CUDA_ERROR_NOT_READY, which is safe only because the workload is parked
+ * (see docs/reference/cuinterpose.md, "Quiescence").
+ */
 enum phase {
   PHASE_ACTIVE,
+  PHASE_MULTICAST_PREPARED,
+  PHASE_ALLOCATIONS_SAVED,
+  PHASE_PREPARED, /* PREPARE_UNICAST done: nothing shared is mapped or held */
+  PHASE_UNICAST_CREATORS_RESTORED,
+  PHASE_UNICAST_RESTORED,
+  PHASE_MULTICAST_CREATED,
+  PHASE_MULTICAST_IMPORTED,
+  PHASE_MULTICAST_JOINED,
   PHASE_FAILED,
 };
 
@@ -125,6 +147,9 @@ static uint64_t next_logical_handle = 1;
 static _Atomic uint32_t live_raw_imports;
 static _Atomic uint32_t unsupported_exportable_creations;
 static _Atomic bool fabric_passthrough_logged;
+
+static uint8_t phase_code(void);
+static int request_export(const struct cuinterpose_posix_ticket* ticket, int* output, char* error, size_t error_size);
 
 static void
 set_failure(const char* message)
@@ -210,7 +235,7 @@ settle_allocation(struct allocation* allocation)
     result = release != NULL ? release(allocation->driver) : cuinterpose_unavailable();
     allocation->driver = 0;
   }
-  if (allocation->live_handles == 0 && allocation->live_mappings == 0) {
+  if (allocation->live_handles == 0 && allocation->live_mappings == 0 && !allocation->checkpointed) {
     /* No local reference is left, so any ticket for this allocation is dead. */
     cuinterpose_export_cache_drop(allocation->id);
     table_remove(&allocations, key_bytes(allocation->id));
@@ -219,12 +244,18 @@ settle_allocation(struct allocation* allocation)
   return result;
 }
 
-static int
-current_context(CUcontext* context)
+/*
+ * The driver does not need a context for cuMemCreate or
+ * cuMemImportFromShareableHandle, so neither may the shim: an allocation
+ * without a context adopts the one current at its first map or export, and if
+ * it never gets one the lifecycle code falls back to the primary context of
+ * the allocation's device (context.c).
+ */
+static void
+adopt_context(struct allocation* allocation)
 {
-  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
-
-  return get_current != NULL && get_current(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
+  if (allocation->context == NULL)
+    cuinterpose_capture_context(&allocation->context);
 }
 
 /*
@@ -290,7 +321,7 @@ cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
   stats->mappings = mappings.count;
   stats->live_raw_imports = atomic_load(&live_raw_imports);
   stats->unsupported_exportable_creations = atomic_load(&unsupported_exportable_creations);
-  stats->phase = current_phase == PHASE_ACTIVE ? CUINTERPOSE_PHASE_ACTIVE : CUINTERPOSE_PHASE_FAILED;
+  stats->phase = phase_code();
   pthread_mutex_unlock(&state_lock);
   stats->cached_exports = cuinterpose_export_cache_count();
 }
@@ -302,7 +333,559 @@ cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
 static uint8_t
 phase_code(void)
 {
-  return current_phase == PHASE_ACTIVE ? CUINTERPOSE_PHASE_ACTIVE : CUINTERPOSE_PHASE_FAILED;
+  switch (current_phase) {
+    case PHASE_ACTIVE:
+      return CUINTERPOSE_PHASE_ACTIVE;
+    case PHASE_MULTICAST_PREPARED:
+    case PHASE_ALLOCATIONS_SAVED:
+      return CUINTERPOSE_PHASE_PREPARING;
+    case PHASE_PREPARED:
+      return CUINTERPOSE_PHASE_PREPARED;
+    case PHASE_FAILED:
+      return CUINTERPOSE_PHASE_FAILED;
+    default:
+      return CUINTERPOSE_PHASE_RESTORING;
+  }
+}
+
+
+/* ------------------------------------------------------------------------- */
+/* Checkpoint and restore of tracked allocations. Caller holds state_lock.    */
+/*                                                                            */
+/* The sequence, driven by the coordinator across every process at once:      */
+/*   PREPARE_MULTICAST  dismantle multicast state (implemented in multicast.c) */
+/*   SAVE_ALLOCATIONS   retain creator handles, copy contents to host memory   */
+/*   PREPARE_UNICAST    unmap shared memory, release every unicast handle       */
+/*   (native CUDA checkpoint, CRIU dump; later CRIU restore, native restore)  */
+/*   LOAD_ALLOCATIONS   new device memory, H2D, creator mappings and exports   */
+/*   RESTORE_UNICAST    fetch fresh descriptors from creators, import, remap   */
+/*   RESTORE_MULTICAST* (no multicast state in this layer)                    */
+/* ------------------------------------------------------------------------- */
+
+static int
+enter_allocation_context(const struct allocation* allocation, struct cuinterpose_context_scope* scope)
+{
+  CUdevice fallback = allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE
+                          ? (CUdevice)allocation->properties.location.id
+                          : CUINTERPOSE_NO_DEVICE;
+
+  return cuinterpose_enter_context(allocation->context, fallback, scope);
+}
+
+static int
+leave_context(struct cuinterpose_context_scope* scope)
+{
+  return cuinterpose_leave_context(scope);
+}
+
+struct allocation_list {
+  struct allocation** items;
+  size_t count;
+};
+
+static int
+collect_allocation(struct key key, void* value, void* arg)
+{
+  struct allocation_list* list = arg;
+
+  (void)key;
+  list->items[list->count++] = value;
+  return 0;
+}
+
+/* Snapshot of the allocation table as an array, so callers can mutate the
+ * table while walking. Returns -1 on allocation failure. */
+static int
+list_allocations(struct allocation_list* list)
+{
+  list->count = 0;
+  list->items = calloc(allocations.count == 0 ? 1 : allocations.count, sizeof(*list->items));
+  if (list->items == NULL)
+    return -1;
+  table_each(&allocations, collect_allocation, list);
+  return 0;
+}
+
+/* Every supported exportable creator allocation needs content preservation. */
+static bool
+needs_allocation_content(const struct allocation* allocation)
+{
+  return allocation->creator && allocation->properties.requestedHandleTypes != 0 &&
+         allocation->properties.type == CU_MEM_ALLOCATION_TYPE_PINNED &&
+         allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE;
+}
+
+static struct cuinterpose_record*
+inspect_records(uint32_t* count, const char** error)
+{
+  struct cuinterpose_record* records;
+  struct cuinterpose_record* record;
+  struct allocation_list list;
+  size_t total;
+  size_t index;
+
+  *error = NULL;
+  total = allocations.count + mappings.count;
+  if (total > CUINTERPOSE_MAX_RECORDS) {
+    *error = "too many tracked records for one participant";
+    return NULL;
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate inspect records";
+    return NULL;
+  }
+  records = calloc(total == 0 ? 1 : total, sizeof(*records));
+  if (records == NULL) {
+    free(list.items);
+    *error = "cannot allocate inspect records";
+    return NULL;
+  }
+  record = records;
+  for (index = 0; index < list.count; index++) {
+    const struct allocation* allocation = list.items[index];
+
+    record->kind = CUINTERPOSE_ALLOCATION;
+    if (allocation->creator)
+      record->flags |= CUINTERPOSE_CREATOR;
+    if (allocation->live_handles != 0)
+      record->flags |= CUINTERPOSE_APPLICATION_HANDLE_LIVE;
+    if (needs_allocation_content(allocation))
+      record->flags |= CUINTERPOSE_ALLOCATION_CONTENT;
+    if (allocation->creator && !allocation->shared)
+      record->flags |= CUINTERPOSE_CONTENT_ONLY;
+    memcpy(record->allocation_id, allocation->id, sizeof(record->allocation_id));
+    record->allocation_size = allocation->size;
+    record->allocation_type = allocation->properties.type;
+    record->requested_handle_types = allocation->properties.requestedHandleTypes;
+    record->allocation_location_type = allocation->properties.location.type;
+    record->allocation_location_id = allocation->properties.location.id;
+    record->application_handle_count = allocation->live_handles;
+    record++;
+  }
+  free(list.items);
+  for (index = 0; index < mappings.count; index++) {
+    const struct mapping* mapping = mappings.items[index].value;
+    size_t access;
+
+    if (mapping->access_unknown) {
+      free(records);
+      *error = "a mapping's access state is unknown after a failed cuMemSetAccess";
+      return NULL;
+    }
+    record->kind = CUINTERPOSE_MAPPING;
+    record->flags = mapping->allocation->creator ? CUINTERPOSE_CREATOR : 0;
+    memcpy(record->allocation_id, mapping->allocation->id, sizeof(record->allocation_id));
+    record->address = mapping->address;
+    record->size = mapping->size;
+    record->offset = mapping->offset;
+    record->access_count = (uint32_t)mapping->access_count;
+    for (access = 0; access < mapping->access_count; access++) {
+      record->access[access].location_type = mapping->access[access].location.type;
+      record->access[access].location_id = mapping->access[access].location.id;
+      record->access[access].flags = mapping->access[access].flags;
+    }
+    record++;
+  }
+  *count = (uint32_t)total;
+  return records;
+}
+
+/*
+ * SAVE_ALLOCATIONS first makes sure every creator allocation has a driver
+ * handle to copy from. A creator that released its handles but still has a
+ * mapping gets one back through cuMemRetainAllocationHandle.
+ */
+static int
+retain_creator_handles_for_save(const char** error)
+{
+  retain_fn retain = (retain_fn)cuinterpose_lookup_real_symbol("cuMemRetainAllocationHandle");
+  struct allocation_list list;
+  size_t index;
+
+  if (retain == NULL) {
+    *error = "cuMemRetainAllocationHandle is unavailable";
+    return -1;
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t range;
+    CUresult result = CUDA_ERROR_INVALID_VALUE;
+
+    if (!allocation->creator || allocation->driver != 0)
+      continue;
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    for (range = 0; range < mappings.count; range++) {
+      const struct mapping* mapping = mappings.items[range].value;
+      if (mapping->allocation == allocation) {
+        result = retain(&allocation->driver, (void*)(uintptr_t)mapping->address);
+        break;
+      }
+    }
+    if (leave_context(&scope) != 0 || result != CUDA_SUCCESS) {
+      free(list.items);
+      *error = "cannot retain a handle for a creator allocation";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Allocation content through host carriers                                  */
+/* ------------------------------------------------------------------------- */
+
+/* Build the concrete host-carrier module's batch from the tracked allocation
+ * table. Eligibility and checkpoint state remain lifecycle policy here. */
+static int
+collect_host_carrier_allocations(
+    bool restoring, struct allocation_list* selected,
+    struct cuinterpose_host_carrier_allocation** output, const char** error)
+{
+  struct cuinterpose_host_carrier_allocation* carriers;
+  size_t kept = 0;
+  size_t index;
+
+  *output = NULL;
+  if (list_allocations(selected) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < selected->count; index++) {
+    struct allocation* allocation = selected->items[index];
+    bool wanted = restoring ? allocation->host_checkpointed
+                            : needs_allocation_content(allocation) && allocation->host_carrier == NULL;
+
+    if (wanted)
+      selected->items[kept++] = allocation;
+  }
+  selected->count = kept;
+  carriers = calloc(kept == 0 ? 1 : kept, sizeof(*carriers));
+  if (carriers == NULL) {
+    free(selected->items);
+    selected->items = NULL;
+    selected->count = 0;
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < kept; index++) {
+    struct allocation* allocation = selected->items[index];
+
+    carriers[index].context = allocation->context;
+    carriers[index].properties = allocation->properties;
+    carriers[index].size = allocation->size;
+    carriers[index].device_handle = &allocation->driver;
+    carriers[index].host_address = &allocation->host_carrier;
+  }
+  *output = carriers;
+  return 0;
+}
+
+static int
+save_allocation_contents(uint64_t* bytes, uint32_t* copy_us, const char** error)
+{
+  struct allocation_list selected = {0};
+  struct cuinterpose_host_carrier_allocation* carriers = NULL;
+  size_t index;
+  int result;
+
+  if (collect_host_carrier_allocations(false, &selected, &carriers, error) != 0)
+    return -1;
+  result = cuinterpose_host_carrier_save(carriers, selected.count, bytes, copy_us, error);
+  if (result == 0) {
+    for (index = 0; index < selected.count; index++)
+      selected.items[index]->host_checkpointed = true;
+  }
+  free(carriers);
+  free(selected.items);
+  return result;
+}
+
+static int
+load_allocation_contents(uint64_t* bytes, uint32_t* copy_us, const char** error)
+{
+  struct allocation_list selected = {0};
+  struct cuinterpose_host_carrier_allocation* carriers = NULL;
+  size_t index;
+  int result;
+
+  if (collect_host_carrier_allocations(true, &selected, &carriers, error) != 0)
+    return -1;
+  result = cuinterpose_host_carrier_load(carriers, selected.count, bytes, copy_us, error);
+  if (result == 0) {
+    for (index = 0; index < selected.count; index++)
+      selected.items[index]->host_checkpointed = false;
+  }
+  free(carriers);
+  free(selected.items);
+  return result;
+}
+
+/* PREPARE_UNICAST: leave nothing shared mapped or held, so the native
+ * checkpoint sees only private memory. The records stay for restore. */
+static int
+prepare(const char** error)
+{
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  struct allocation_list list;
+  size_t index;
+
+  if (release == NULL || unmap == NULL) {
+    *error = "driver symbols are unavailable";
+    return -1;
+  }
+  for (index = 0; index < mappings.count; index++) {
+    const struct mapping* mapping = mappings.items[index].value;
+    if (mapping->access_unknown) {
+      *error = "a mapping's access state is unknown after a failed cuMemSetAccess";
+      return -1;
+    }
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  /* Peers must not fetch descriptors that are about to be invalidated. */
+  cuinterpose_export_cache_quiesce();
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t range;
+
+    if (needs_allocation_content(allocation) && !allocation->host_checkpointed) {
+      free(list.items);
+      *error = "a creator allocation was not saved to its host carrier";
+      return -1;
+    }
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    for (range = 0; range < mappings.count; range++) {
+      struct mapping* mapping = mappings.items[range].value;
+      if (mapping->allocation != allocation || mapping->checkpointed)
+        continue;
+      if (unmap(mapping->address, mapping->size) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        free(list.items);
+        *error = "cuMemUnmap failed during prepare";
+        return -1;
+      }
+      mapping->checkpointed = true;
+    }
+    if (allocation->driver != 0) {
+      if (release(allocation->driver) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        free(list.items);
+        *error = "cuMemRelease failed during prepare";
+        return -1;
+      }
+      allocation->driver = 0;
+    }
+    allocation->checkpointed = true;
+    if (leave_context(&scope) != 0) {
+      free(list.items);
+      *error = "cannot leave the allocation's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* Map every checkpointed mapping of allocation back where it was. */
+static CUresult
+remap_allocation(struct allocation* allocation, const char** error)
+{
+  map_fn map = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  access_fn set_access = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  size_t index;
+
+  if (map == NULL || set_access == NULL) {
+    *error = "mapping symbols are unavailable";
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  for (index = 0; index < mappings.count; index++) {
+    struct mapping* mapping = mappings.items[index].value;
+    CUresult result;
+
+    if (mapping->allocation != allocation || !mapping->checkpointed)
+      continue;
+    result = map(mapping->address, mapping->size, mapping->offset, allocation->driver, 0);
+    if (result != CUDA_SUCCESS) {
+      *error = "cuMemMap failed during restore";
+      return result;
+    }
+    mapping->checkpointed = false;
+    if (mapping->access_count != 0) {
+      result = set_access(mapping->address, mapping->size, mapping->access, mapping->access_count);
+      if (result != CUDA_SUCCESS) {
+        *error = "cuMemSetAccess failed during restore";
+        return result;
+      }
+    }
+  }
+  return CUDA_SUCCESS;
+}
+
+/* Once an allocation is back, keep the driver handle only if the application
+ * still holds a logical handle; mappings keep the memory alive otherwise. */
+static int
+finish_restore(struct allocation* allocation, const char** error)
+{
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+
+  allocation->checkpointed = false;
+  if (allocation->live_handles == 0 && allocation->driver != 0) {
+    if (release == NULL || release(allocation->driver) != CUDA_SUCCESS) {
+      *error = "cuMemRelease failed during restore";
+      return -1;
+    }
+    allocation->driver = 0;
+  }
+  return 0;
+}
+
+/* LOAD_ALLOCATIONS, creator topology: remap and re-export after the module has
+ * loaded every creator's bytes. The command's reply is the importer barrier. */
+static int
+restore_creators(const char** error)
+{
+  export_fn export_handle = (export_fn)cuinterpose_lookup_real_symbol("cuMemExportToShareableHandle");
+  struct allocation_list list;
+  size_t index;
+
+  if (export_handle == NULL) {
+    *error = "cuMemExportToShareableHandle is unavailable";
+    return -1;
+  }
+  if (list_allocations(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_context_scope scope;
+
+    if (!allocation->creator || !allocation->checkpointed)
+      continue;
+    if (allocation->driver == 0) {
+      free(list.items);
+      *error = "creator allocation has no device memory after restore";
+      return -1;
+    }
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    if (remap_allocation(allocation, error) != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      free(list.items);
+      return -1;
+    }
+    if (allocation->shared) {
+      int real_fd = -1;
+      if (export_handle(&real_fd, allocation->driver, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) != CUDA_SUCCESS ||
+          cuinterpose_export_cache_put(allocation->id, real_fd) != 0) {
+        if (real_fd >= 0)
+          close(real_fd);
+        (void)leave_context(&scope);
+        free(list.items);
+        *error = "cannot re-export a restored creator allocation";
+        return -1;
+      }
+    }
+    if (finish_restore(allocation, error) != 0 || leave_context(&scope) != 0) {
+      free(list.items);
+      if (*error == NULL)
+        *error = "cannot leave the allocation's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  /* Peers may fetch descriptors again. */
+  cuinterpose_export_cache_resume();
+  return 0;
+}
+
+/* RESTORE_UNICAST: importers fetch fresh descriptors and remap. */
+static int
+restore_importers(char* message, size_t message_size)
+{
+  import_fn import_handle = (import_fn)cuinterpose_lookup_real_symbol("cuMemImportFromShareableHandle");
+  struct allocation_list list;
+  size_t index;
+
+  if (import_handle == NULL) {
+    snprintf(message, message_size, "%s", "cuMemImportFromShareableHandle is unavailable");
+    return -1;
+  }
+  if (list_allocations(&list) != 0) {
+    snprintf(message, message_size, "%s", "cannot allocate");
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct allocation* allocation = list.items[index];
+    struct cuinterpose_posix_ticket ticket;
+    struct cuinterpose_context_scope scope;
+    const char* error = NULL;
+    char export_error[96];
+    int raw_fd = -1;
+    CUmemGenericAllocationHandle imported = 0;
+    CUresult result;
+
+    if (allocation->creator || !allocation->checkpointed)
+      continue;
+    memset(&ticket, 0, sizeof(ticket));
+    ticket.magic = CUINTERPOSE_POSIX_TICKET_MAGIC;
+    ticket.version = CUINTERPOSE_POSIX_TICKET_VERSION;
+    ticket.resource_kind = CUINTERPOSE_RESOURCE_UNICAST;
+    snprintf(ticket.creator_participant, sizeof(ticket.creator_participant), "%s", allocation->creator_participant);
+    memcpy(ticket.allocation_id, allocation->id, sizeof(ticket.allocation_id));
+    snprintf(ticket.creator_endpoint, sizeof(ticket.creator_endpoint), "%s", allocation->creator_endpoint);
+    /* The creator's listener answers without any lock of its own that we hold,
+     * so the request can be made while holding state_lock. */
+    if (request_export(&ticket, &raw_fd, export_error, sizeof(export_error)) != 0) {
+      free(list.items);
+      snprintf(message, message_size, "creator export: %.70s", export_error);
+      return -1;
+    }
+    if (enter_allocation_context(allocation, &scope) != 0) {
+      close(raw_fd);
+      free(list.items);
+      snprintf(message, message_size, "%s", "cannot enter the allocation's CUDA context");
+      return -1;
+    }
+    result = import_handle(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    close(raw_fd);
+    if (result != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      free(list.items);
+      snprintf(message, message_size, "cuMemImportFromShareableHandle failed: CUresult=%d", (int)result);
+      return -1;
+    }
+    allocation->driver = imported;
+    if (remap_allocation(allocation, &error) != CUDA_SUCCESS || finish_restore(allocation, &error) != 0 ||
+        leave_context(&scope) != 0) {
+      free(list.items);
+      snprintf(message, message_size, "%s", error != NULL ? error : "cannot leave the allocation's CUDA context");
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
 }
 
 static void
@@ -324,7 +907,7 @@ serve(int client)
   response.live_raw_imports = atomic_load(&live_raw_imports);
   response.unsupported_exportable_creations = atomic_load(&unsupported_exportable_creations);
   response.phase = phase_code();
-  if (passed_fd >= 0 || request.payload_size != 0 || !cuinterpose_header_strings_terminated(&request) ||
+  if (passed_fd >= 0 || !cuinterpose_header_strings_terminated(&request) ||
       request.magic != CUINTERPOSE_MAGIC || request.version != CUINTERPOSE_VERSION || request.status != 0 ||
       request.count != 0 ||
       !((request.operation == CUINTERPOSE_HANDSHAKE && request.participant_id[0] == '\0') ||
@@ -339,6 +922,157 @@ serve(int client)
         cuinterpose_header_error(&response, failure);
       (void)cuinterpose_send_header(client, &response, -1);
       break;
+    case CUINTERPOSE_INSPECT: {
+      struct cuinterpose_record* records;
+      const char* error;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_ACTIVE) {
+        pthread_mutex_unlock(&state_lock);
+        cuinterpose_header_error(&response, "cuinterpose is not in the active phase");
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      records = inspect_records(&response.count, &error);
+      pthread_mutex_unlock(&state_lock);
+      if (records == NULL) {
+        cuinterpose_header_error(&response, error);
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      response.payload_size = (uint64_t)response.count * sizeof(struct cuinterpose_record);
+      if (cuinterpose_send_header(client, &response, -1) == 0 && response.payload_size != 0)
+        (void)send_all(client, records, (size_t)response.payload_size);
+      free(records);
+      break;
+    }
+    case CUINTERPOSE_PREPARE_MULTICAST: {
+      const char* error = NULL;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_ACTIVE) {
+        error = "cuinterpose is not in the active phase";
+      } else {
+        current_phase = PHASE_MULTICAST_PREPARED;
+      }
+      if (error != NULL) {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_SAVE_ALLOCATIONS: {
+      const char* error = NULL;
+      uint64_t bytes = 0;
+      uint32_t copy_us = 0;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_MULTICAST_PREPARED) {
+        error = "multicast was not prepared before allocation save";
+      } else if (retain_creator_handles_for_save(&error) != 0 ||
+                 save_allocation_contents(&bytes, &copy_us, &error) != 0) {
+        set_failure(error);
+      } else {
+        current_phase = PHASE_ALLOCATIONS_SAVED;
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      response.payload_size = bytes;
+      response.copy_us = copy_us;
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_PREPARE_UNICAST: {
+      const char* error = NULL;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_ALLOCATIONS_SAVED) {
+        error = "allocations were not saved before unicast prepare";
+      } else if (prepare(&error) == 0) {
+        current_phase = PHASE_PREPARED;
+      } else {
+        set_failure(error);
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_LOAD_ALLOCATIONS: {
+      const char* error = NULL;
+      uint64_t bytes = 0;
+      uint32_t copy_us = 0;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_PREPARED) {
+        error = "cuinterpose is not in the prepared phase";
+      } else if (load_allocation_contents(&bytes, &copy_us, &error) != 0 ||
+                 restore_creators(&error) != 0) {
+        set_failure(error);
+      } else {
+        current_phase = PHASE_UNICAST_CREATORS_RESTORED;
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
+      response.payload_size = bytes;
+      response.copy_us = copy_us;
+      (void)cuinterpose_send_header(client, &response, -1);
+      /* Off the hot path: the coordinator has its answer and moves on. */
+      if (error == NULL)
+        cuinterpose_host_carrier_release();
+      break;
+    }
+    case CUINTERPOSE_RESTORE_UNICAST: {
+      char message[96] = {0};
+      bool failed = false;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != PHASE_UNICAST_CREATORS_RESTORED) {
+        snprintf(message, sizeof(message), "%s", "creator allocations were not loaded before unicast restore");
+        failed = true;
+      } else if (restore_importers(message, sizeof(message)) == 0) {
+        current_phase = PHASE_UNICAST_RESTORED;
+      } else {
+        set_failure(message);
+        failed = true;
+      }
+      pthread_mutex_unlock(&state_lock);
+      if (failed)
+        cuinterpose_header_error(&response, message);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
+    case CUINTERPOSE_RESTORE_MULTICAST_CREATORS:
+    case CUINTERPOSE_RESTORE_MULTICAST_IMPORTERS:
+    case CUINTERPOSE_RESTORE_MULTICAST_DEVICES:
+    case CUINTERPOSE_RESTORE_MULTICAST_BINDINGS: {
+      /* No multicast state in this layer: each phase only advances. */
+      static const enum phase expected[] = {
+          PHASE_UNICAST_RESTORED, PHASE_MULTICAST_CREATED, PHASE_MULTICAST_IMPORTED, PHASE_MULTICAST_JOINED};
+      static const enum phase next[] = {
+          PHASE_MULTICAST_CREATED, PHASE_MULTICAST_IMPORTED, PHASE_MULTICAST_JOINED, PHASE_ACTIVE};
+      size_t step = request.operation - CUINTERPOSE_RESTORE_MULTICAST_CREATORS;
+
+      pthread_mutex_lock(&state_lock);
+      if (current_phase != expected[step]) {
+        pthread_mutex_unlock(&state_lock);
+        cuinterpose_header_error(&response, "multicast restore phase out of order");
+        (void)cuinterpose_send_header(client, &response, -1);
+        break;
+      }
+      current_phase = next[step];
+      if (current_phase == PHASE_ACTIVE)
+        failure[0] = '\0';
+      pthread_mutex_unlock(&state_lock);
+      (void)cuinterpose_send_header(client, &response, -1);
+      break;
+    }
     case CUINTERPOSE_EXPORT: {
       /* A peer holding a ticket wants the real descriptor. Served from the
        * export cache only: no driver call, no state_lock. */
@@ -420,6 +1154,44 @@ control_agent(void* unused)
   }
 }
 
+/*
+ * A process that exits without running destructors (os._exit, a signal) leaves
+ * its socket behind, and CUDA workloads spawn many such helpers. Remove the
+ * sockets whose process no longer exists, so the control directory describes
+ * the processes that are actually there.
+ */
+static void
+remove_dead_sockets(void)
+{
+  DIR* directory = opendir(control_directory);
+  struct dirent* entry;
+
+  if (directory == NULL)
+    return;
+  while ((entry = readdir(directory)) != NULL) {
+    const char* name = entry->d_name;
+    const char* digits;
+    long pid = 0;
+
+    if (strncmp(name, CUINTERPOSE_SOCKET_PREFIX, strlen(CUINTERPOSE_SOCKET_PREFIX)) != 0)
+      continue;
+    /* Hand-rolled: strtol resolves to a glibc 2.38 symbol under C2x headers,
+     * and the shim must load on glibc 2.34. */
+    for (digits = name + strlen(CUINTERPOSE_SOCKET_PREFIX); *digits >= '0' && *digits <= '9' && pid < 100000000L;
+         digits++)
+      pid = pid * 10 + (*digits - '0');
+    if (pid <= 0 || strcmp(digits, ".sock") != 0 || pid == (long)getpid())
+      continue;
+    if (kill((pid_t)pid, 0) == -1 && errno == ESRCH) {
+      char path[sizeof(socket_path)];
+
+      if (snprintf(path, sizeof(path), "%s/%s", control_directory, name) < (int)sizeof(path))
+        unlink(path);
+    }
+  }
+  closedir(directory);
+}
+
 static int
 discard_control_endpoint(void)
 {
@@ -439,6 +1211,7 @@ start_control_endpoint(void)
   pthread_t thread;
   int count;
 
+  remove_dead_sockets();
   count = snprintf(
       socket_path, sizeof(socket_path), "%s/%s%ld.sock", control_directory, CUINTERPOSE_SOCKET_PREFIX,
       (long)getpid());
@@ -523,6 +1296,7 @@ fork_child(void)
   next_logical_handle = 1;
   current_phase = PHASE_ACTIVE;
   failure[0] = '\0';
+  cuinterpose_host_carrier_fork_child();
   cuinterpose_export_cache_fork_child();
   pthread_mutex_init(&state_lock, NULL);
 }
@@ -656,9 +1430,15 @@ cuMemCreate(
     return result;
   allocation = calloc(1, sizeof(*allocation));
   pthread_mutex_lock(&state_lock);
-  if (allocation == NULL || current_phase != PHASE_ACTIVE ||
-      random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
-      current_context(&allocation->context) != 0 ||
+  if (current_phase != PHASE_ACTIVE) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+    pthread_mutex_unlock(&state_lock);
+    if (release != NULL)
+      (void)release(driver);
+    free(allocation);
+    return CUDA_ERROR_NOT_READY;
+  }
+  if (allocation == NULL || random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
       table_put(&allocations, key_bytes(allocation->id), allocation) != 0) {
     release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
     pthread_mutex_unlock(&state_lock);
@@ -671,6 +1451,7 @@ cuMemCreate(
   allocation->properties = *properties;
   allocation->driver = driver;
   allocation->creator = true;
+  cuinterpose_capture_context(&allocation->context);
   snprintf(allocation->creator_participant, sizeof(allocation->creator_participant), "%s", participant_id);
   snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", socket_path);
   if (add_handle(allocation, &logical) != 0) {
@@ -841,6 +1622,7 @@ cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocation
   mapping->offset = offset;
   mapping->allocation = handle->allocation;
   handle->allocation->live_mappings++;
+  adopt_context(handle->allocation);
   pthread_mutex_unlock(&state_lock);
   return CUDA_SUCCESS;
 }
@@ -1039,6 +1821,7 @@ cuMemExportToShareableHandle(
     return CUDA_ERROR_NOT_READY;
   }
   allocation = handle->allocation;
+  adopt_context(allocation);
   if (allocation->creator && !cuinterpose_export_cache_has(allocation->id)) {
     /*
      * The one real export for this allocation in this process. The descriptor
@@ -1145,7 +1928,6 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
   if (allocation == NULL) {
     allocation = calloc(1, sizeof(*allocation));
     if (allocation == NULL || get_properties(&allocation->properties, imported) != CUDA_SUCCESS ||
-        current_context(&allocation->context) != 0 ||
         table_put(&allocations, key_bytes(ticket.allocation_id), allocation) != 0) {
       pthread_mutex_unlock(&state_lock);
       (void)release(imported);
@@ -1158,6 +1940,7 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
     snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", ticket.creator_endpoint);
     allocation->creator = false;
     allocation->driver = imported;
+    cuinterpose_capture_context(&allocation->context);
   } else if (allocation->driver != 0) {
     /* Already imported here: alias the existing driver handle. */
     if (release(imported) != CUDA_SUCCESS) {

--- a/agent/cmd/cuinterpose/protocol.h
+++ b/agent/cmd/cuinterpose/protocol.h
@@ -83,9 +83,7 @@ enum cuinterpose_record_flags {
   CUINTERPOSE_CREATOR = 1U << 0,
   CUINTERPOSE_APPLICATION_HANDLE_LIVE = 1U << 1,
   CUINTERPOSE_ALLOCATION_CONTENT = 1U << 2,
-  /* A creator allocation that was never exported. It is reported only so its
-   * contents can be preserved; no importer refers to it. */
-  CUINTERPOSE_CONTENT_ONLY = 1U << 3,
+  /* Bit 3 is reserved; private allocations stay with native CUDA. */
 };
 
 /* Where a participant is in the checkpoint/restore lifecycle; reported in

--- a/agent/cmd/cuinterpose/tests/coordinator_driver.h
+++ b/agent/cmd/cuinterpose/tests/coordinator_driver.h
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Runs the real coordinator binary against this test process (and any forked
+// children) the way the snapshot agent would, for the lifecycle tests.
+
+#ifndef CUINTERPOSE_TESTS_COORDINATOR_DRIVER_H
+#define CUINTERPOSE_TESTS_COORDINATOR_DRIVER_H
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+struct Outcome {
+  int status;
+  std::string out;
+  std::string err;
+};
+
+// Runs `cuinterpose-coordinator MODE` (CUINTERPOSE_COORDINATOR in the
+// environment) against the given PIDs, which double as namespace PIDs because
+// the tests run without a PID namespace. Returns its exit status and output.
+inline Outcome coordinate(const char* mode, const std::string& checkpoint, const std::vector<pid_t>& pids) {
+  const char* binary = getenv("CUINTERPOSE_COORDINATOR");
+  const char* control = getenv("SNAPSHOT_CONTROL_DIR");
+  int out_pipe[2], err_pipe[2];
+  if (pipe(out_pipe) != 0 || pipe(err_pipe) != 0) abort();
+  pid_t child = fork();
+  if (child == 0) {
+    dup2(out_pipe[1], STDOUT_FILENO);
+    dup2(err_pipe[1], STDERR_FILENO);
+    std::vector<std::string> args = {binary, mode, "--proc-root", "", "--checkpoint-dir", checkpoint,
+                                     "--control-dir", control};
+    for (pid_t pid : pids) {
+      args.push_back("--process");
+      args.push_back(std::to_string(pid));
+      args.push_back(std::to_string(pid));
+    }
+    std::vector<char*> argv;
+    for (auto& a : args) argv.push_back(const_cast<char*>(a.c_str()));
+    argv.push_back(nullptr);
+    // The coordinator must not itself be interposed.
+    unsetenv("LD_PRELOAD");
+    execv(binary, argv.data());
+    perror("execv cuinterpose-coordinator");
+    _exit(127);
+  }
+  close(out_pipe[1]);
+  close(err_pipe[1]);
+  auto drain = [](int fd) {
+    std::string s;
+    char buffer[4096];
+    ssize_t n;
+    while ((n = read(fd, buffer, sizeof(buffer))) > 0) s.append(buffer, n);
+    close(fd);
+    return s;
+  };
+  Outcome outcome;
+  outcome.out = drain(out_pipe[0]);
+  outcome.err = drain(err_pipe[0]);
+  int status = 0;
+  waitpid(child, &status, 0);
+  outcome.status = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+  return outcome;
+}
+
+#endif

--- a/agent/cmd/cuinterpose/tests/coordinator_test.cc
+++ b/agent/cmd/cuinterpose/tests/coordinator_test.cc
@@ -23,6 +23,7 @@
 #include <functional>
 #include <mutex>
 #include <sstream>
+#include <filesystem>
 #include <string>
 #include <thread>
 #include <vector>
@@ -187,7 +188,8 @@ class Coordinator : public ::testing::Test {
     ASSERT_EQ(mkdir(checkpoint.c_str(), 0700), 0);
   }
   void TearDown() override {
-    if (std::system(("rm -rf " + dir).c_str()) != 0) ADD_FAILURE() << "cleanup failed";
+    std::error_code ignored;
+    std::filesystem::remove_all(dir, ignored);
   }
 
   std::vector<std::string> args(const char* mode, std::initializer_list<int> pids) {
@@ -264,7 +266,7 @@ TEST_F(Coordinator, PrepareDrivesEveryPhaseInOrderAndWritesState) {
   for (auto* p : {&a, &b}) {
     std::vector<uint16_t> want = {
         CUINTERPOSE_HANDSHAKE, CUINTERPOSE_INSPECT, CUINTERPOSE_PREPARE_MULTICAST,
-        CUINTERPOSE_PREPARE_UNICAST};
+        CUINTERPOSE_SAVE_ALLOCATIONS, CUINTERPOSE_PREPARE_UNICAST};
     EXPECT_EQ(p->operations(), want);
   }
   // Progress lines, one per phase, in order.
@@ -471,6 +473,7 @@ TEST_F(Coordinator, RestoreRunsPhasesWithBarriers) {
   EXPECT_EQ(run.status, 0) << run.err;
   EXPECT_FALSE(a_got_final_while_b_held) << "RESTORE_MULTICAST_BINDINGS was dispatched before every DEVICES reply";
   std::vector<uint16_t> want = {CUINTERPOSE_HANDSHAKE,
+                                CUINTERPOSE_LOAD_ALLOCATIONS,
                                 CUINTERPOSE_RESTORE_UNICAST,
                                 CUINTERPOSE_RESTORE_MULTICAST_CREATORS,
                                 CUINTERPOSE_RESTORE_MULTICAST_IMPORTERS,

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -25,6 +25,26 @@ CUresult CUDAAPI fakeCuGetProcAddress(const char*, void**, int, cuuint64_t);
 
 static struct fake_last_call last;
 
+#define FAKE_MAX_HOST 256
+
+struct fake_host_range {
+  int used;
+  void* address;
+  size_t size;
+};
+
+static struct fake_host_range host_ranges[FAKE_MAX_HOST];
+static uint64_t copied_to_host;
+static uint64_t copied_to_device;
+static CUcontext current_context = (CUcontext)(uintptr_t)1;
+/* Primary contexts: one per device, handed out by cuDevicePrimaryCtxRetain. */
+static int primary_retain_calls;
+static int primary_contexts_held;
+static char fail_next[64];
+static CUdeviceptr next_reservation = 0x7f0000000000ULL;
+
+static int should_fail(const char* function);
+
 void
 fakeReset(void)
 {
@@ -96,12 +116,19 @@ fakeEnableTrackedBehavior(void)
 void
 fakeResetModel(void)
 {
+  current_context = (CUcontext)(uintptr_t)1;
+  primary_retain_calls = 0;
+  primary_contexts_held = 0;
   pthread_mutex_lock(&model_lock);
   memset(allocations, 0, sizeof(allocations));
   memset(handles, 0, sizeof(handles));
   memset(mappings, 0, sizeof(mappings));
+  memset(host_ranges, 0, sizeof(host_ranges));
   export_calls = 0;
   access_calls = 0;
+  copied_to_host = 0;
+  copied_to_device = 0;
+  fail_next[0] = '\0';
   pthread_mutex_unlock(&model_lock);
 }
 
@@ -234,6 +261,8 @@ fakeCuMemCreate(
     last.handle_type = properties != NULL ? (int)properties->requestedHandleTypes : -1;
     if (output == NULL)
       return CUDA_ERROR_INVALID_VALUE;
+    if (should_fail("cuMemCreate"))
+      return CUDA_ERROR_UNKNOWN;
     pthread_mutex_lock(&model_lock);
     allocation = new_allocation(size, properties);
     if (allocation >= 0)
@@ -702,11 +731,260 @@ cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_
   return fakeCuMulticastUnbind(multicast, device, offset, size);
 }
 
+
+/* ---------------------------------------------------------------------- */
+/* Tracked mode: staging, host carriers, streams, contexts.                 */
+/* ---------------------------------------------------------------------- */
+
+
+void
+fakeFailNext(const char* function)
+{
+  snprintf(fail_next, sizeof(fail_next), "%s", function);
+}
+
+/* True (and consumed) when this call was armed to fail. */
+static int
+should_fail(const char* function)
+{
+  if (fail_next[0] != '\0' && strcmp(fail_next, function) == 0) {
+    fail_next[0] = '\0';
+    return 1;
+  }
+  return 0;
+}
+
+uint64_t
+fakeCopiedToHost(void)
+{
+  return copied_to_host;
+}
+
+uint64_t
+fakeCopiedToDevice(void)
+{
+  return copied_to_device;
+}
+
+int
+fakeRegisteredHostRanges(void)
+{
+  int index;
+  int count = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++)
+    count += host_ranges[index].used;
+  pthread_mutex_unlock(&model_lock);
+  return count;
+}
+
+void
+fakeForgetHostRegistrations(void)
+{
+  pthread_mutex_lock(&model_lock);
+  memset(host_ranges, 0, sizeof(host_ranges));
+  pthread_mutex_unlock(&model_lock);
+}
+
+CUcontext
+fakeCurrentContext(void)
+{
+  return current_context;
+}
+
+CUresult CUDAAPI
+cuCtxSetCurrent(CUcontext context)
+{
+  current_context = context;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemAddressReserve(CUdeviceptr* address, size_t size, size_t alignment, CUdeviceptr fixed, unsigned long long flags)
+{
+  (void)alignment;
+  (void)fixed;
+  (void)flags;
+  if (should_fail("cuMemAddressReserve"))
+    return CUDA_ERROR_UNKNOWN;
+  pthread_mutex_lock(&model_lock);
+  *address = next_reservation;
+  next_reservation += (size + 0xfffff) & ~(CUdeviceptr)0xfffff;
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemAddressFree(CUdeviceptr address, size_t size)
+{
+  (void)address;
+  (void)size;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemHostRegister_v2(void* address, size_t size, unsigned int flags)
+{
+  int index;
+
+  (void)flags;
+  if (should_fail("cuMemHostRegister_v2"))
+    return CUDA_ERROR_UNKNOWN;
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++) {
+    if (!host_ranges[index].used) {
+      host_ranges[index].used = 1;
+      host_ranges[index].address = address;
+      host_ranges[index].size = size;
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_SUCCESS;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_ERROR_OUT_OF_MEMORY;
+}
+
+CUresult CUDAAPI
+cuMemHostUnregister(void* address)
+{
+  int index;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++) {
+    if (host_ranges[index].used && host_ranges[index].address == address) {
+      host_ranges[index].used = 0;
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_SUCCESS;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED;
+}
+
+CUresult CUDAAPI
+cuMemHostGetFlags(unsigned int* flags, void* address)
+{
+  int index;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_HOST; index++) {
+    if (host_ranges[index].used && host_ranges[index].address == address) {
+      pthread_mutex_unlock(&model_lock);
+      *flags = 0;
+      return CUDA_SUCCESS;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_ERROR_INVALID_VALUE;
+}
+
+/* The fake has no device memory: copies only count bytes. A staging mapping
+ * must exist for the device address, as the driver would require. */
+static int
+staged(CUdeviceptr address, size_t size)
+{
+  int index;
+  int ok = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_MAPPINGS; index++) {
+    if (mappings[index].used && address >= mappings[index].address &&
+        address + size <= mappings[index].address + mappings[index].size)
+      ok = 1;
+  }
+  pthread_mutex_unlock(&model_lock);
+  return ok;
+}
+
+CUresult CUDAAPI
+cuMemcpyDtoHAsync_v2(void* host, CUdeviceptr device, size_t size, CUstream stream)
+{
+  (void)host;
+  (void)stream;
+  if (should_fail("cuMemcpyDtoHAsync_v2"))
+    return CUDA_ERROR_UNKNOWN;
+  if (!staged(device, size))
+    return CUDA_ERROR_INVALID_VALUE;
+  copied_to_host += size;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemcpyHtoDAsync_v2(CUdeviceptr device, const void* host, size_t size, CUstream stream)
+{
+  (void)host;
+  (void)stream;
+  if (should_fail("cuMemcpyHtoDAsync_v2"))
+    return CUDA_ERROR_UNKNOWN;
+  if (!staged(device, size))
+    return CUDA_ERROR_INVALID_VALUE;
+  copied_to_device += size;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuStreamCreate(CUstream* stream, unsigned int flags)
+{
+  (void)flags;
+  *stream = (CUstream)(uintptr_t)0x5eed;
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuStreamSynchronize(CUstream stream)
+{
+  (void)stream;
+  return should_fail("cuStreamSynchronize") ? CUDA_ERROR_UNKNOWN : CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuStreamDestroy_v2(CUstream stream)
+{
+  (void)stream;
+  return CUDA_SUCCESS;
+}
+
 CUresult CUDAAPI
 cuCtxGetCurrent(CUcontext* context)
 {
-  *context = (CUcontext)(uintptr_t)1;
+  *context = current_context;
   return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuDevicePrimaryCtxRetain(CUcontext* context, CUdevice device)
+{
+  if (should_fail("cuDevicePrimaryCtxRetain"))
+    return CUDA_ERROR_UNKNOWN;
+  *context = (CUcontext)(uintptr_t)(0x100 + device);
+  pthread_mutex_lock(&model_lock);
+  primary_retain_calls++;
+  primary_contexts_held++;
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuDevicePrimaryCtxRelease_v2(CUdevice device)
+{
+  (void)device;
+  pthread_mutex_lock(&model_lock);
+  primary_contexts_held--;
+  pthread_mutex_unlock(&model_lock);
+  return CUDA_SUCCESS;
+}
+
+int
+fakePrimaryContextRetainCalls(void)
+{
+  return primary_retain_calls;
+}
+
+int
+fakePrimaryContextsHeld(void)
+{
+  return primary_contexts_held;
 }
 
 /*

--- a/agent/cmd/cuinterpose/tests/fake_cuda.h
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.h
@@ -82,6 +82,21 @@ int fakeAllocationRefs(CUmemGenericAllocationHandle handle);
 int fakeSameAllocation(CUmemGenericAllocationHandle a, CUmemGenericAllocationHandle b);
 int fakeExportCalls(void);
 int fakeMappedCount(void);
+/* Bytes moved by cuMemcpyDtoHAsync / cuMemcpyHtoDAsync since the last model reset. */
+uint64_t fakeCopiedToHost(void);
+uint64_t fakeCopiedToDevice(void);
+/* Host ranges currently registered with cuMemHostRegister. */
+int fakeRegisteredHostRanges(void);
+/* Make cuMemHostGetFlags report every range as unregistered (simulates a
+ * registration that did not survive restore). */
+void fakeForgetHostRegistrations(void);
+/* Fail the next call to the named entry point once, with CUDA_ERROR_UNKNOWN. */
+void fakeFailNext(const char* function);
+/* The fake's notion of the current context, changed by cuCtxSetCurrent. */
+CUcontext fakeCurrentContext(void);
+/* cuDevicePrimaryCtxRetain calls since the last model reset, and retains not yet released. */
+int fakePrimaryContextRetainCalls(void);
+int fakePrimaryContextsHeld(void);
 /* Number of cuMemSetAccess calls since the last reset. */
 int fakeAccessCalls(void);
 /* The fake's own implementation of `symbol`, bypassing any interposer. */

--- a/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
@@ -72,8 +72,8 @@ class Lifecycle : public ::testing::Test {
 };
 
 // Creator (this process) and importer (child) share one 1 MiB allocation and
-// a second, never-exported allocation that must still travel through the host
-// carrier. The coordinator prepares both, then restores both; the fake driver
+// a second, never-exported allocation that must remain with native CUDA.
+// The coordinator prepares both, then restores both; the fake driver
 // counts bytes copied out and back in, and the child confirms its imported
 // mapping came back.
 TEST_F(Lifecycle, PrepareAndRestoreAcrossTwoProcesses) {
@@ -152,11 +152,11 @@ TEST_F(Lifecycle, PrepareAndRestoreAcrossTwoProcesses) {
   EXPECT_EQ(fakeRegisteredHostRanges(), 1) << "one pinned arena holds every host carrier while checkpointed";
   struct stat st{};
   EXPECT_EQ(stat((checkpoint + "/" + CUINTERPOSE_STATE_FILENAME).c_str(), &st), 0);
-  EXPECT_EQ(fakeCopiedToHost(), static_cast<uint64_t>((1 << 20) + (1 << 19)))
-      << "both creator allocations, the never-exported one included, were copied to the host";
-  EXPECT_NE(prepare.out.find("allocation_count=2 allocation_bytes=1572864"), std::string::npos)
+  EXPECT_EQ(fakeCopiedToHost(), static_cast<uint64_t>(1 << 20))
+      << "only the shared creator is copied to the host";
+  EXPECT_NE(prepare.out.find("allocation_count=1 allocation_bytes=1048576"), std::string::npos)
       << prepare.out;
-  EXPECT_EQ(fakeMappedCount(), 0) << "nothing shared stays mapped in the parent for the native checkpoint";
+  EXPECT_EQ(fakeMappedCount(), 1) << "private mapping stays intact for native checkpoint";
   EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_PREPARED));
   EXPECT_EQ(stats().cached_exports, 0u) << "the export cache is closed while checkpointed";
   // While prepared, the application's handles answer "not ready".
@@ -171,7 +171,7 @@ TEST_F(Lifecycle, PrepareAndRestoreAcrossTwoProcesses) {
   // Restore.
   Outcome restore = coordinate("--restore", checkpoint, {getpid(), child});
   EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
-  EXPECT_EQ(fakeCopiedToDevice(), static_cast<uint64_t>((1 << 20) + (1 << 19)));
+  EXPECT_EQ(fakeCopiedToDevice(), static_cast<uint64_t>(1 << 20));
   EXPECT_NE(restore.out.find("phase=load_allocations status=ok"), std::string::npos) << restore.out;
   EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
   EXPECT_EQ(stats().mappings, 2u);
@@ -207,6 +207,35 @@ TEST_F(Lifecycle, PrepareAndRestoreAcrossTwoProcesses) {
   EXPECT_EQ(fakeLiveAllocations(), 0);
 }
 
+TEST_F(Lifecycle, ReleasedPrivateHandleIsNotRetainedOrCarried) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle allocation = 0;
+  ASSERT_EQ(cuMemCreate(&allocation, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x10000000, 1 << 20, 0, allocation, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemRelease(allocation), CUDA_SUCCESS);
+  EXPECT_EQ(stats().handles, 0u);
+
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  ASSERT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_EQ(fakeCopiedToHost(), 0u);
+  EXPECT_EQ(fakeMappedCount(), 1);
+  EXPECT_EQ(fakePrimaryContextRetainCalls(), 0);
+  EXPECT_NE(prepare.out.find("allocation_count=0 allocation_bytes=0"),
+            std::string::npos) << prepare.out;
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  ASSERT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeCopiedToDevice(), 0u);
+  EXPECT_EQ(fakeMappedCount(), 1);
+  CUmemGenericAllocationHandle retained = 0;
+  ASSERT_EQ(cuMemRetainAllocationHandle(&retained, reinterpret_cast<void*>(0x10000000)), CUDA_SUCCESS);
+  CUmemAllocationProp restored{};
+  EXPECT_EQ(cuMemGetAllocationPropertiesFromHandle(&restored, retained), CUDA_SUCCESS);
+  EXPECT_EQ(restored.requestedHandleTypes, prop.requestedHandleTypes);
+  EXPECT_EQ(cuMemUnmap(0x10000000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(retained), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+}
+
 TEST_F(Lifecycle, PrepareIsRefusedWhileARawImportIsAlive) {
   int foreign = memfd_create("foreign", MFD_CLOEXEC);
   ASSERT_EQ(write(foreign, "x", 1), 1);
@@ -232,13 +261,18 @@ TEST_F(Lifecycle, PrepareIsRefusedWhileARawImportIsAlive) {
 // The driver needs no current context for cuMemCreate, and some workloads
 // allocate before they initialize one. Such an allocation adopts the context
 // current at its first map or export; one that never gets a context is still
-// carried through checkpoint and restore in its device's primary context.
+// carried through checkpoint and restore if it has actually been exported.
 TEST_F(Lifecycle, AllocationsCreatedWithoutAContextAreCarried) {
   CUmemAllocationProp prop = posix_props();
   CUmemGenericAllocationHandle mapped_later = 0, never_mapped = 0;
   ASSERT_EQ(cuCtxSetCurrent(nullptr), CUDA_SUCCESS);  // not interposed: goes to the fake
   ASSERT_EQ(cuMemCreate(&mapped_later, 1 << 20, &prop, 0), CUDA_SUCCESS);
   ASSERT_EQ(cuMemCreate(&never_mapped, 1 << 19, &prop, 0), CUDA_SUCCESS);
+  int tickets[2] = {-1, -1};
+  ASSERT_EQ(cuMemExportToShareableHandle(&tickets[0], mapped_later, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemExportToShareableHandle(&tickets[1], never_mapped, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  close(tickets[0]);
+  close(tickets[1]);
   EXPECT_EQ(stats().allocations, 2u) << "allocations made without a context are tracked";
 
   CUcontext application = reinterpret_cast<CUcontext>(static_cast<uintptr_t>(7));
@@ -277,6 +311,9 @@ TEST_F(Lifecycle, FailedHostCopyLeavesTheWorkloadIntactAndFailsClosed) {
   CUmemGenericAllocationHandle handle = 0;
   ASSERT_EQ(cuMemCreate(&handle, 1 << 20, &prop, 0), CUDA_SUCCESS);
   ASSERT_EQ(cuMemMap(0x10000000, 1 << 20, 0, handle, 0), CUDA_SUCCESS);
+  int ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  close(ticket);
   fakeFailNext("cuMemcpyDtoHAsync_v2");
   Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
   EXPECT_NE(prepare.status, 0);

--- a/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
@@ -1,0 +1,296 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// End-to-end checkpoint and restore of shared allocations with the shim
+// LD_PRELOADed over the fake driver: this process creates and shares memory, a
+// forked child imports it, and the real cuinterpose-coordinator binary drives
+// both through prepare and restore exactly as the agent would. Requires
+// SNAPSHOT_CONTROL_DIR (writable) and CUINTERPOSE_COORDINATOR (binary path).
+
+#include <cuda.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "../export.h"
+#include "../protocol.h"
+#include "fake_cuda.h"
+#include "coordinator_driver.h"
+
+namespace {
+
+struct cuinterpose_debug_stats stats() {
+  using fn = void (*)(struct cuinterpose_debug_stats*);
+  static fn get = reinterpret_cast<fn>(dlsym(RTLD_DEFAULT, "cuinterpose_debug_stats"));
+  struct cuinterpose_debug_stats s{};
+  get(&s);
+  return s;
+}
+
+CUmemAllocationProp posix_props() {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+
+// Commands the parent sends the importer child over a pipe.
+enum Command : int { kImport = 1, kCheckRestored = 2, kRelease = 3, kQuit = 4 };
+
+class Lifecycle : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { fakeEnableTrackedBehavior(); }
+  void SetUp() override {
+    ASSERT_NE(getenv("CUINTERPOSE_COORDINATOR"), nullptr) << "set CUINTERPOSE_COORDINATOR";
+    fakeResetModel();
+    char tmpl[] = "/tmp/cuinterpose-lifecycle-XXXXXX";
+    ASSERT_NE(mkdtemp(tmpl), nullptr);
+    checkpoint = tmpl;
+  }
+  void TearDown() override {
+    // Not std::system(): a shell child would inherit the sanitized LD_PRELOAD,
+    // and the base image's /bin/sh runs a profile script whose helpers then
+    // report their own tiny leaks.
+    std::error_code ignored;
+    std::filesystem::remove_all(checkpoint, ignored);
+  }
+  std::string checkpoint;
+};
+
+// Creator (this process) and importer (child) share one 1 MiB allocation and
+// a second, never-exported allocation that must still travel through the host
+// carrier. The coordinator prepares both, then restores both; the fake driver
+// counts bytes copied out and back in, and the child confirms its imported
+// mapping came back.
+TEST_F(Lifecycle, PrepareAndRestoreAcrossTwoProcesses) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle shared = 0, private_alloc = 0;
+  ASSERT_EQ(cuMemCreate(&shared, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemCreate(&private_alloc, 1 << 19, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x10000000, 1 << 20, 0, shared, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x20000000, 1 << 19, 0, private_alloc, 0), CUDA_SUCCESS);
+  CUmemAccessDesc access{};
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  ASSERT_EQ(cuMemSetAccess(0x10000000, 1 << 20, &access, 1), CUDA_SUCCESS);
+  int ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&ticket, shared, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+
+  int to_child[2], from_child[2];
+  ASSERT_EQ(pipe(to_child), 0);
+  ASSERT_EQ(pipe(from_child), 0);
+  pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(to_child[1]);
+    close(from_child[0]);
+    // A real fork child has no usable CUDA state; the fake model starts empty too.
+    fakeResetModel();
+    CUmemGenericAllocationHandle imported = 0;
+    for (;;) {
+      int command = 0;
+      if (read(to_child[0], &command, sizeof(command)) != static_cast<ssize_t>(sizeof(command))) _exit(2);
+      int result = 0;
+      switch (command) {
+        case kImport:
+          if (cuMemImportFromShareableHandle(&imported, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                             CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS)
+            result |= 1;
+          if (cuMemMap(0x30000000, 1 << 20, 0, imported, 0) != CUDA_SUCCESS) result |= 2;
+          if (cuMemSetAccess(0x30000000, 1 << 20, &access, 1) != CUDA_SUCCESS) result |= 4;
+          break;
+        case kCheckRestored: {
+          struct cuinterpose_debug_stats s = stats();
+          if (s.phase != CUINTERPOSE_PHASE_ACTIVE) result |= 1;
+          if (s.allocations != 1 || s.handles != 1 || s.mappings != 1) result |= 2;
+          if (fakeMappedCount() != 1) result |= 4;  // the importer's mapping is back in the driver
+          // The logical handle still works after restore.
+          CUmemAllocationProp got{};
+          if (cuMemGetAllocationPropertiesFromHandle(&got, imported) != CUDA_SUCCESS) result |= 8;
+          break;
+        }
+        case kRelease:
+          if (cuMemUnmap(0x30000000, 1 << 20) != CUDA_SUCCESS) result |= 1;
+          if (cuMemRelease(imported) != CUDA_SUCCESS) result |= 2;
+          if (stats().allocations != 0) result |= 4;
+          break;
+        case kQuit:
+          _exit(0);
+      }
+      if (write(from_child[1], &result, sizeof(result)) != static_cast<ssize_t>(sizeof(result))) _exit(3);
+    }
+  }
+  close(to_child[0]);
+  close(from_child[1]);
+  auto tell = [&](int command) {
+    int result = -1;
+    EXPECT_EQ(write(to_child[1], &command, sizeof(command)), static_cast<ssize_t>(sizeof(command)));
+    EXPECT_EQ(read(from_child[0], &result, sizeof(result)), static_cast<ssize_t>(sizeof(result)));
+    return result;
+  };
+
+  EXPECT_EQ(tell(kImport), 0) << "child import failed";
+  EXPECT_EQ(fakeExportCalls(), 1);
+
+  // Checkpoint.
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid(), child});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_EQ(fakeRegisteredHostRanges(), 1) << "one pinned arena holds every host carrier while checkpointed";
+  struct stat st{};
+  EXPECT_EQ(stat((checkpoint + "/" + CUINTERPOSE_STATE_FILENAME).c_str(), &st), 0);
+  EXPECT_EQ(fakeCopiedToHost(), static_cast<uint64_t>((1 << 20) + (1 << 19)))
+      << "both creator allocations, the never-exported one included, were copied to the host";
+  EXPECT_NE(prepare.out.find("allocation_count=2 allocation_bytes=1572864"), std::string::npos)
+      << prepare.out;
+  EXPECT_EQ(fakeMappedCount(), 0) << "nothing shared stays mapped in the parent for the native checkpoint";
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_PREPARED));
+  EXPECT_EQ(stats().cached_exports, 0u) << "the export cache is closed while checkpointed";
+  // While prepared, the application's handles answer "not ready".
+  EXPECT_EQ(cuMemRelease(shared), CUDA_ERROR_NOT_READY);
+  EXPECT_EQ(cuMemMap(0x40000000, 4096, 0, shared, 0), CUDA_ERROR_NOT_READY);
+
+  // Simulate what a native restore leaves behind: the host pages lost their
+  // registration in one process, so the shim must pin them again.
+  fakeForgetHostRegistrations();
+  EXPECT_EQ(fakeRegisteredHostRanges(), 0);
+
+  // Restore.
+  Outcome restore = coordinate("--restore", checkpoint, {getpid(), child});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeCopiedToDevice(), static_cast<uint64_t>((1 << 20) + (1 << 19)));
+  EXPECT_NE(restore.out.find("phase=load_allocations status=ok"), std::string::npos) << restore.out;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+  EXPECT_EQ(stats().mappings, 2u);
+  EXPECT_EQ(fakeMappedCount(), 2) << "both creator mappings are back";
+  EXPECT_EQ(fakeExportCalls(), 2) << "the shared allocation was exported again for the export cache";
+  EXPECT_EQ(stats().cached_exports, 1u);
+  // The arena is unpinned after the reply, off the coordinator's critical path.
+  for (int attempt = 0; attempt < 200 && fakeRegisteredHostRanges() != 0; attempt++) usleep(10000);
+  EXPECT_EQ(fakeRegisteredHostRanges(), 0) << "the host carrier arena is released after the copy back";
+  EXPECT_EQ(tell(kCheckRestored), 0) << "child did not see its mapping restored";
+
+  // Normal operation resumes: a fresh import of the old ticket still works.
+  CUmemGenericAllocationHandle again = 0;
+  EXPECT_EQ(cuMemImportFromShareableHandle(&again, reinterpret_cast<void*>(static_cast<intptr_t>(ticket)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(again), CUDA_SUCCESS);
+
+  EXPECT_EQ(tell(kRelease), 0);
+  int quit = kQuit;  // no reply: the child exits
+  EXPECT_EQ(write(to_child[1], &quit, sizeof(quit)), static_cast<ssize_t>(sizeof(quit)));
+  int status = 0;
+  waitpid(child, &status, 0);
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "child status " << status << (WIFSIGNALED(status) ? " signal " + std::to_string(WTERMSIG(status)) : "");
+
+  close(ticket);
+  EXPECT_EQ(cuMemUnmap(0x10000000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemUnmap(0x20000000, 1 << 19), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(shared), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(private_alloc), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+TEST_F(Lifecycle, PrepareIsRefusedWhileARawImportIsAlive) {
+  int foreign = memfd_create("foreign", MFD_CLOEXEC);
+  ASSERT_EQ(write(foreign, "x", 1), 1);
+  CUmemGenericAllocationHandle raw = 0;
+  ASSERT_EQ(cuMemImportFromShareableHandle(&raw, reinterpret_cast<void*>(static_cast<intptr_t>(foreign)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  close(foreign);
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_NE(prepare.status, 0);
+  EXPECT_NE(prepare.err.find("live raw imports"), std::string::npos) << prepare.err;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE)) << "nothing was torn down";
+  EXPECT_EQ(cuMemRelease(raw), CUDA_SUCCESS);
+  // With the raw import gone, prepare succeeds (on an empty topology).
+  Outcome again = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_EQ(again.status, 0) << again.err;
+  // Bring the shim back to ACTIVE for the next test.
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  EXPECT_EQ(restore.status, 0) << restore.err;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+}
+
+// The driver needs no current context for cuMemCreate, and some workloads
+// allocate before they initialize one. Such an allocation adopts the context
+// current at its first map or export; one that never gets a context is still
+// carried through checkpoint and restore in its device's primary context.
+TEST_F(Lifecycle, AllocationsCreatedWithoutAContextAreCarried) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle mapped_later = 0, never_mapped = 0;
+  ASSERT_EQ(cuCtxSetCurrent(nullptr), CUDA_SUCCESS);  // not interposed: goes to the fake
+  ASSERT_EQ(cuMemCreate(&mapped_later, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemCreate(&never_mapped, 1 << 19, &prop, 0), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 2u) << "allocations made without a context are tracked";
+
+  CUcontext application = reinterpret_cast<CUcontext>(static_cast<uintptr_t>(7));
+  ASSERT_EQ(cuCtxSetCurrent(application), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x50000000, 1 << 20, 0, mapped_later, 0), CUDA_SUCCESS);
+
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_EQ(fakeCopiedToHost(), static_cast<uint64_t>((1 << 20) + (1 << 19)))
+      << "both allocations were copied out, the never-mapped one in its primary context";
+  EXPECT_GT(fakePrimaryContextRetainCalls(), 0) << "the primary context was used for the context-less allocation";
+  EXPECT_EQ(fakePrimaryContextsHeld(), 0) << "every retained primary context was released";
+  EXPECT_EQ(fakeCurrentContext(), application) << "the application's context is current again";
+
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeCopiedToDevice(), static_cast<uint64_t>((1 << 20) + (1 << 19)));
+  EXPECT_EQ(fakePrimaryContextsHeld(), 0);
+  EXPECT_EQ(fakeCurrentContext(), application);
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+
+  // The allocation that never had a context is still usable afterwards.
+  EXPECT_EQ(cuMemMap(0x60000000, 1 << 19, 0, never_mapped, 0), CUDA_SUCCESS);
+  EXPECT_EQ(fakeMappedCount(), 2);
+
+  EXPECT_EQ(cuMemUnmap(0x50000000, 1 << 20), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemUnmap(0x60000000, 1 << 19), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(mapped_later), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(never_mapped), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+TEST_F(Lifecycle, FailedHostCopyLeavesTheWorkloadIntactAndFailsClosed) {
+  CUmemAllocationProp prop = posix_props();
+  CUmemGenericAllocationHandle handle = 0;
+  ASSERT_EQ(cuMemCreate(&handle, 1 << 20, &prop, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x10000000, 1 << 20, 0, handle, 0), CUDA_SUCCESS);
+  fakeFailNext("cuMemcpyDtoHAsync_v2");
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_NE(prepare.status, 0);
+  EXPECT_NE(prepare.err.find("allocation save"), std::string::npos) << prepare.err;
+  struct stat st{};
+  EXPECT_NE(stat((checkpoint + "/" + CUINTERPOSE_STATE_FILENAME).c_str(), &st), 0) << "no state file on failure";
+  EXPECT_EQ(fakeRegisteredHostRanges(), 0) << "partial host carriers were released";
+  EXPECT_EQ(fakeMappedCount(), 1) << "the mapping was never touched";
+  // The shim is in the failed phase: IDENTIFY reports it, and the application
+  // cannot continue with VMM calls. This is the documented fail-stop behavior.
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_FAILED));
+  EXPECT_EQ(cuMemUnmap(0x10000000, 1 << 20), CUDA_ERROR_NOT_READY);
+  // The process is unusable for the rest of this test binary, so run this
+  // test last (gtest runs tests in definition order within a binary).
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Layer 9 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293), based on the host-carrier module in #292. Closed PR #214 is not in the active stack.

This PR checkpoints and restores actually shared POSIX-FD CUDA VMM allocations. It owns allocation eligibility and unicast topology; #292 owns the D2H/H2D host-carrier mechanics.

### Ownership boundary

| Allocation | Checkpoint owner |
| --- | --- |
| Private VMM allocation, including POSIX-capable memory never exported or bound into tracked multicast | Native CUDA checkpoint |
| Allocation actually exported/imported through the tracked POSIX sharing path | Interposer |
| Allocation bound into tracked multicast | Interposer; #219 marks the member shared |
| Legacy `cuIpc*` memory | Native CUDA checkpoint |

Export capability alone does not make an allocation shared. Private allocations remain mapped with their native handles intact when the interposer finishes preparation. The native driver remains responsible for saving and rebuilding their physical backing; this does not imply that GPU contents survive checkpoint automatically.

Only shared eligible creators advertise `ALLOCATION_CONTENT` and use host carriers. Imported allocations reference their canonical creator without duplicating content. Private records remain available for topology inspection, but no longer advertise `CONTENT_ONLY`; its protocol bit is reserved. Existing device-location, pinned-allocation, and exportability checks are retained. Unsupported exportable resources and live raw imports still fail preflight before destructive teardown.

### Lifecycle

```text
PREPARE_MULTICAST → SAVE_ALLOCATIONS → PREPARE_UNICAST
```

At this layer multicast preparation is a phase boundary; #219 supplies teardown. `SAVE_ALLOCATIONS` recovers handles only for shared creators with surviving mappings, copies their contents through #292, and advances all participants. `PREPARE_UNICAST` quiesces descriptor export, drains in-flight requests, and unmaps/releases only shared allocations. Private allocations are not temporarily retained, copied, unmapped, or released.

```text
LOAD_ALLOCATIONS → RESTORE_UNICAST
```

Creators reconstruct shared backing, copy saved contents, restore mappings/access, and publish fresh descriptors under the original allocation IDs. The all-participant load barrier precedes importer reconstruction. #219 subsequently reconstructs multicast. Lifecycle failures remain fail-stop, and application-facing tracked VMM operations remain gated while preparation/restoration is in progress.

## Validation

The ownership update extends the existing fake-driver lifecycle tests:

- Mixed shared/private allocations: only shared bytes enter the carrier; private mappings remain present.
- Private mapping whose application handle was released: preparation does not recover a temporary handle or copy content; retain-by-address works afterward.
- Context-less creation and failed-copy cases explicitly export the allocations intended to exercise the interposer path.

Candidate `4100a48c72a3541ce547f4f4994d12682d475ab1` passes all **68 native fake-driver tests**, including five lifecycle tests, with the configured ASan/UBSan instrumentation. The build used CUDA 13.1 headers, `/usr/bin/gcc` and `/usr/bin/g++`, cached GoogleTest, and a short `SNAPSHOT_CONTROL_DIR`. `git diff --check` and strict C syntax checks also pass. Logs: `stack-private-vmm/pr218-final-tests.log`.

The initial default-toolchain attempt could not link static libc/pthread; a subsequent long-path attempt exceeded the Unix-socket path limit. Both were corrected in the test environment without source changes. Real GPU validation of this exact candidate has not yet been run.

The existing 73-test sanitizer and three-test B200 results described in earlier revisions belong to historical stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a`; they are not validation of this ownership update.

## Contribution notes

This updates the existing stack rather than creating a duplicate PR. AI assistance was used to prepare the implementation, tests, and description; the submitting human must review the changes and validation.

The full stack at exact #220 head `21008b50b93a9879a805665e331e777bb93abf49`, including this fix, passed all **3 physical-GPU tests with 0 skips and 0 failures in 19.896 s** on two B200 GPUs on nscale-dev, 2026-09-12 UTC. Compilation used the documented `ALLOW_OLD_CUDA_HEADERS=1` override with CUDA 13.0 headers. This is full-stack GPU validation, not a standalone GPU run of #218. The restore-performance experiment's NIXL and driver changes are not part of this PR.
