### PR TITLE
feat(agent): checkpoint CUDA multicast state

### DIFF
--- a/agent/cmd/cuinterpose/coordinator.c
+++ b/agent/cmd/cuinterpose/coordinator.c
@@ -374,10 +374,16 @@ validate_topology(
           multicast->num_devices = record->num_devices;
           id_copy(multicast->creator, record->creator_participant);
         } else if (
-            multicast->size != record->allocation_size || multicast->handle_types != record->handle_types ||
-            multicast->flags != record->object_flags || multicast->num_devices != record->num_devices ||
+            multicast->handle_types != record->handle_types || multicast->flags != record->object_flags ||
+            multicast->num_devices != record->num_devices ||
             !id_eq(multicast->creator, record->creator_participant)) {
           return topology_rejected("inconsistent multicast properties", participant_index, participant_count, record_index);
+        } else if (record->allocation_size > multicast->size) {
+          /* Each participant reports the extent it used; the driver may have
+           * given the object more capacity than was asked for, and ranks
+           * need not use the same amount of it. Bounds are checked against
+           * the largest. */
+          multicast->size = record->allocation_size;
         }
         if ((record->flags & CUINTERPOSE_CREATOR) != 0) {
           if (!id_eq(participant->id, multicast->creator)) {

--- a/agent/cmd/cuinterpose/interpose.c
+++ b/agent/cmd/cuinterpose/interpose.c
@@ -29,9 +29,10 @@
 #define _GNU_SOURCE
 
 #include "interpose.h"
+#include "multicast.h"
 
-#include <errno.h>
 #include <dirent.h>
+#include <errno.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdatomic.h>
@@ -196,24 +197,39 @@ mapping_at(CUdeviceptr address)
   return range == NULL ? NULL : range->value;
 }
 
+/* Logical handle numbers are shared with the multicast module. */
+static int
+mint_logical_handle(CUmemGenericAllocationHandle* logical)
+{
+  if (next_logical_handle > LOGICAL_HANDLE_VALUE_MASK)
+    return -1;
+  *logical = (CUmemGenericAllocationHandle)(LOGICAL_HANDLE_TAG | next_logical_handle);
+  next_logical_handle++;
+  return 0;
+}
+
+bool
+cuinterpose_is_logical_handle(CUmemGenericAllocationHandle handle)
+{
+  return is_logical_handle(handle);
+}
+
 /* Mint a logical handle for allocation. Returns 0 and sets *logical. */
 static int
 add_handle(struct allocation* allocation, CUmemGenericAllocationHandle* logical)
 {
   struct handle* handle;
 
-  if (next_logical_handle > LOGICAL_HANDLE_VALUE_MASK)
-    return -1;
   handle = calloc(1, sizeof(*handle));
-  if (handle == NULL)
+  if (handle == NULL || mint_logical_handle(&handle->logical) != 0) {
+    free(handle);
     return -1;
-  handle->logical = (CUmemGenericAllocationHandle)(LOGICAL_HANDLE_TAG | next_logical_handle);
+  }
   handle->allocation = allocation;
   if (table_put(&handles, key_u64((uint64_t)handle->logical), handle) != 0) {
     free(handle);
     return -1;
   }
-  next_logical_handle++;
   allocation->live_handles++;
   *logical = handle->logical;
   return 0;
@@ -319,6 +335,7 @@ cuinterpose_debug_stats(struct cuinterpose_debug_stats* stats)
   stats->allocations = allocations.count;
   stats->handles = handles.count;
   stats->mappings = mappings.count;
+  stats->multicasts = cuinterpose_multicast_count();
   stats->live_raw_imports = atomic_load(&live_raw_imports);
   stats->unsupported_exportable_creations = atomic_load(&unsupported_exportable_creations);
   stats->phase = phase_code();
@@ -425,7 +442,7 @@ inspect_records(uint32_t* count, const char** error)
   size_t index;
 
   *error = NULL;
-  total = allocations.count + mappings.count;
+  total = allocations.count + mappings.count + cuinterpose_multicast_record_count();
   if (total > CUINTERPOSE_MAX_RECORDS) {
     *error = "too many tracked records for one participant";
     return NULL;
@@ -485,6 +502,10 @@ inspect_records(uint32_t* count, const char** error)
       record->access[access].flags = mapping->access[access].flags;
     }
     record++;
+  }
+  if (cuinterpose_multicast_write_records(record, total - (size_t)(record - records), error) != 0) {
+    free(records);
+    return NULL;
   }
   *count = (uint32_t)total;
   return records;
@@ -952,11 +973,10 @@ serve(int client)
       pthread_mutex_lock(&state_lock);
       if (current_phase != PHASE_ACTIVE) {
         error = "cuinterpose is not in the active phase";
+      } else if (cuinterpose_multicast_prepare(&error) != 0) {
+        set_failure(error);
       } else {
         current_phase = PHASE_MULTICAST_PREPARED;
-      }
-      if (error != NULL) {
-        set_failure(error);
       }
       pthread_mutex_unlock(&state_lock);
       if (error != NULL)
@@ -1052,24 +1072,41 @@ serve(int client)
     case CUINTERPOSE_RESTORE_MULTICAST_IMPORTERS:
     case CUINTERPOSE_RESTORE_MULTICAST_DEVICES:
     case CUINTERPOSE_RESTORE_MULTICAST_BINDINGS: {
-      /* No multicast state in this layer: each phase only advances. */
+      /* Four phases with a coordinator barrier after each: binding waits for
+       * every device of the team, so all AddDevice calls must be done first. */
       static const enum phase expected[] = {
           PHASE_UNICAST_RESTORED, PHASE_MULTICAST_CREATED, PHASE_MULTICAST_IMPORTED, PHASE_MULTICAST_JOINED};
       static const enum phase next[] = {
           PHASE_MULTICAST_CREATED, PHASE_MULTICAST_IMPORTED, PHASE_MULTICAST_JOINED, PHASE_ACTIVE};
       size_t step = request.operation - CUINTERPOSE_RESTORE_MULTICAST_CREATORS;
+      char message[96] = {0};
+      const char* error = NULL;
 
       pthread_mutex_lock(&state_lock);
       if (current_phase != expected[step]) {
-        pthread_mutex_unlock(&state_lock);
-        cuinterpose_header_error(&response, "multicast restore phase out of order");
-        (void)cuinterpose_send_header(client, &response, -1);
-        break;
+        error = "multicast restore phase out of order";
+      } else if (step == 0) {
+        if (cuinterpose_multicast_restore_creators(&error) != 0)
+          set_failure(error);
+      } else if (step == 1) {
+        if (cuinterpose_multicast_restore_importers(message, sizeof(message)) != 0) {
+          error = message;
+          set_failure(error);
+        }
+      } else if (step == 2) {
+        if (cuinterpose_multicast_restore_devices(&error) != 0)
+          set_failure(error);
+      } else if (cuinterpose_multicast_restore_bindings(&error) != 0) {
+        set_failure(error);
       }
-      current_phase = next[step];
-      if (current_phase == PHASE_ACTIVE)
-        failure[0] = '\0';
+      if (error == NULL) {
+        current_phase = next[step];
+        if (current_phase == PHASE_ACTIVE)
+          failure[0] = '\0';
+      }
       pthread_mutex_unlock(&state_lock);
+      if (error != NULL)
+        cuinterpose_header_error(&response, error);
       (void)cuinterpose_send_header(client, &response, -1);
       break;
     }
@@ -1079,7 +1116,8 @@ serve(int client)
       const char* reason = NULL;
       int dup = -1;
 
-      if (request.resource_kind != CUINTERPOSE_RESOURCE_UNICAST) {
+      if (request.resource_kind != CUINTERPOSE_RESOURCE_UNICAST &&
+          request.resource_kind != CUINTERPOSE_RESOURCE_MULTICAST) {
         cuinterpose_header_error(&response, "creator resource is unavailable");
         (void)cuinterpose_send_header(client, &response, -1);
         break;
@@ -1298,6 +1336,7 @@ fork_child(void)
   failure[0] = '\0';
   cuinterpose_host_carrier_fork_child();
   cuinterpose_export_cache_fork_child();
+  cuinterpose_multicast_fork_child();
   pthread_mutex_init(&state_lock, NULL);
 }
 
@@ -1321,11 +1360,117 @@ cuinterpose_ensure_process_endpoint(void)
   return result;
 }
 
+/* ------------------------------------------------------------------------- */
+/* What the multicast module needs from the unicast side.                     */
+/* ------------------------------------------------------------------------- */
+
+static int
+multicast_allocate_logical_handle(CUmemGenericAllocationHandle* output)
+{
+  return mint_logical_handle(output);
+}
+
+static int
+multicast_member_from_handle(CUmemGenericAllocationHandle logical, struct cuinterpose_multicast_member* member)
+{
+  struct handle* handle = find_handle(logical);
+
+  if (handle == NULL || handle->allocation->driver == 0)
+    return -1;
+  memcpy(member->id, handle->allocation->id, sizeof(member->id));
+  member->handle = handle->allocation->driver;
+  member->device = handle->allocation->properties.location.id;
+  return 0;
+}
+
+static int
+multicast_member_from_address(CUdeviceptr address, size_t size, struct cuinterpose_multicast_member* member)
+{
+  struct mapping* mapping = mapping_at(address);
+
+  if (mapping == NULL || size > mapping->size || address - mapping->address > mapping->size - size)
+    return -1;
+  memcpy(member->id, mapping->allocation->id, sizeof(member->id));
+  member->address = address;
+  member->allocation_offset = mapping->offset + (size_t)(address - mapping->address);
+  member->device = mapping->allocation->properties.location.id;
+  return 0;
+}
+
+/* A driver handle for the member: the one we hold, or one retained through a
+ * mapping when the application released all of its handles. */
+static int
+multicast_member_from_id(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE], struct cuinterpose_multicast_member* member)
+{
+  retain_fn retain = (retain_fn)cuinterpose_lookup_real_symbol("cuMemRetainAllocationHandle");
+  struct allocation* allocation = find_allocation(id);
+  size_t index;
+
+  if (allocation == NULL)
+    return -1;
+  memcpy(member->id, allocation->id, sizeof(member->id));
+  member->device = allocation->properties.location.id;
+  if (allocation->driver != 0) {
+    member->handle = allocation->driver;
+    return 0;
+  }
+  for (index = 0; index < mappings.count; index++) {
+    const struct mapping* mapping = mappings.items[index].value;
+
+    if (mapping->allocation == allocation) {
+      if (retain == NULL || retain(&member->handle, (void*)(uintptr_t)mapping->address) != CUDA_SUCCESS)
+        return -1;
+      member->temporary_handle = true;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+static void
+multicast_mark_member_shared(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  struct allocation* allocation = find_allocation(id);
+
+  if (allocation != NULL)
+    allocation->shared = true;
+}
+
+static void
+multicast_release_state_lock(void)
+{
+  pthread_mutex_unlock(&state_lock);
+}
+
+static void
+multicast_acquire_state_lock(void)
+{
+  pthread_mutex_lock(&state_lock);
+}
+
+static bool
+multicast_state_is_active(void)
+{
+  return current_phase == PHASE_ACTIVE;
+}
+
 __attribute__((constructor)) static void
 initialize(void)
 {
+  static const struct cuinterpose_multicast_callbacks multicast_callbacks = {
+      .allocate_logical_handle = multicast_allocate_logical_handle,
+      .member_from_handle = multicast_member_from_handle,
+      .member_from_address = multicast_member_from_address,
+      .member_from_id = multicast_member_from_id,
+      .mark_member_shared = multicast_mark_member_shared,
+      .release_state_lock = multicast_release_state_lock,
+      .acquire_state_lock = multicast_acquire_state_lock,
+      .state_is_active = multicast_state_is_active,
+  };
   const char* control;
   const char* configured_participant;
+
+  cuinterpose_multicast_initialize(&multicast_callbacks, participant_id, socket_path);
 
   configured_participant = getenv(CUINTERPOSE_PARTICIPANT_ID_ENV);
   if (configured_participant != NULL && !is_lower_hex_id(configured_participant)) {
@@ -1481,6 +1626,11 @@ cuMemRelease(CUmemGenericAllocationHandle application)
   pthread_mutex_lock(&state_lock);
   handle = find_handle(application);
   if (handle == NULL) {
+    if (cuinterpose_multicast_is_handle(application)) {
+      result = cuinterpose_multicast_release(application);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     if (is_logical_handle(application)) {
       pthread_mutex_unlock(&state_lock);
       return CUDA_ERROR_INVALID_HANDLE;
@@ -1523,6 +1673,11 @@ cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
   pthread_mutex_lock(&state_lock);
   mapping = mapping_at((CUdeviceptr)(uintptr_t)address);
   if (mapping == NULL) {
+    if (cuinterpose_multicast_owns_range((CUdeviceptr)(uintptr_t)address, 1)) {
+      result = cuinterpose_multicast_retain(output, address);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     result = function(&driver, address);
     return passthrough_handle(result, driver, output);
@@ -1571,6 +1726,11 @@ cuMemMap(CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocation
   pthread_mutex_lock(&state_lock);
   handle = find_handle(application);
   if (handle == NULL) {
+    if (cuinterpose_multicast_is_handle(application)) {
+      result = cuinterpose_multicast_map(address, size, offset, application, flags);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     if (is_logical_handle(application))
       return CUDA_ERROR_INVALID_HANDLE;
@@ -1652,6 +1812,11 @@ cuMemUnmap(CUdeviceptr address, size_t size)
     return CUDA_ERROR_INVALID_VALUE;
   }
   if (first == last) {
+    if (cuinterpose_multicast_owns_range(address, size)) {
+      result = cuinterpose_multicast_unmap(address, size);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     return function != NULL ? function(address, size) : cuinterpose_unavailable();
   }
@@ -1742,6 +1907,11 @@ cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descript
     return CUDA_ERROR_INVALID_VALUE;
   }
   if (first == last) {
+    if (cuinterpose_multicast_owns_range(address, size)) {
+      result = cuinterpose_multicast_set_access(address, size, descriptors, count);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     return function != NULL ? function(address, size, descriptors, count) : cuinterpose_unavailable();
   }
@@ -1806,6 +1976,11 @@ cuMemExportToShareableHandle(
   pthread_mutex_lock(&state_lock);
   handle = find_handle(application);
   if (handle == NULL) {
+    if (cuinterpose_multicast_is_handle(application)) {
+      result = cuinterpose_multicast_export(shareable, application, type, flags);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     if (is_logical_handle(application))
       return CUDA_ERROR_INVALID_HANDLE;
@@ -1902,6 +2077,8 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
     }
     return result;
   }
+  if (ticket.resource_kind == CUINTERPOSE_RESOURCE_MULTICAST)
+    return cuinterpose_multicast_import(output, &ticket);
   if (ticket.resource_kind != CUINTERPOSE_RESOURCE_UNICAST)
     return CUDA_ERROR_INVALID_HANDLE;
   if (get_properties == NULL || release == NULL)
@@ -1978,6 +2155,11 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGen
   pthread_mutex_lock(&state_lock);
   handle = find_handle(application);
   if (handle == NULL) {
+    if (cuinterpose_multicast_is_handle(application)) {
+      result = cuinterpose_multicast_get_properties(properties, application);
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     if (is_logical_handle(application))
       return CUDA_ERROR_INVALID_HANDLE;

--- a/agent/cmd/cuinterpose/interpose.h
+++ b/agent/cmd/cuinterpose/interpose.h
@@ -32,4 +32,7 @@ bool cuinterpose_translate_handle(CUmemGenericAllocationHandle handle, CUmemGene
  * counter is non-zero. Multicast uses the same process-wide diagnostic. */
 void cuinterpose_note_unsupported_exportable_creation(uint64_t handle_types);
 
+/* True for handles minted by the shim (unicast or multicast), by their tag. */
+bool cuinterpose_is_logical_handle(CUmemGenericAllocationHandle handle);
+
 #endif

--- a/agent/cmd/cuinterpose/multicast.c
+++ b/agent/cmd/cuinterpose/multicast.c
@@ -9,15 +9,36 @@
 #include "multicast.h"
 
 #include <cuda.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/un.h>
+#include <unistd.h>
 
+#include "context.h"
 #include "export.h"
+#include "export_cache.h"
 #include "interpose.h"
 #include "symbols.h"
+#include "util/array.h"
+#include "util/cleanup.h"
+#include "util/misc.h"
+#include "util/table.h"
 
 /* cuda.h maps these names to versioned entry points; the shim wraps the names. */
 #undef cuMulticastBindAddr
 #undef cuMulticastBindMem
 
+typedef CUresult(CUDAAPI* release_fn)(CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* retain_fn)(CUmemGenericAllocationHandle*, void*);
+typedef CUresult(CUDAAPI* map_fn)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+typedef CUresult(CUDAAPI* unmap_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* access_fn)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+typedef CUresult(CUDAAPI* export_fn)(void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* context_device_fn)(CUdevice*);
 typedef CUresult(CUDAAPI* create_fn)(CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
 typedef CUresult(CUDAAPI* add_device_fn)(CUmemGenericAllocationHandle, CUdevice);
 typedef CUresult(CUDAAPI* bind_mem_fn)(
@@ -32,20 +53,1604 @@ typedef CUresult(CUDAAPI* bind_address_v2_fn)(
 typedef CUresult(CUDAAPI* granularity_fn)(size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
 typedef CUresult(CUDAAPI* unbind_fn)(CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
 
+struct multicast;
+
+struct multicast_handle {
+  CUmemGenericAllocationHandle logical;
+  struct multicast* multicast;
+};
+
+struct multicast_binding {
+  uint8_t member_id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  CUdeviceptr member_address; /* BIND_ADDR only */
+  size_t multicast_offset;
+  size_t member_offset;
+  size_t size;
+  unsigned long long flags;
+  CUdevice device;
+  uint8_t kind; /* enum cuinterpose_multicast_binding_kind */
+  uint8_t api_version; /* 1: device taken from the member; 2: device-explicit (_v2) */
+  bool checkpointed; /* unbound by PREPARE_MULTICAST, to be bound again on restore */
+};
+
+struct multicast_mapping {
+  CUdeviceptr address;
+  size_t size;
+  size_t offset;
+  unsigned long long flags;
+  CUmemAccessDesc access[CUINTERPOSE_MAX_ACCESS];
+  size_t access_count;
+  bool access_unknown; /* a cuMemSetAccess failed part-way; the record cannot be trusted */
+  bool mapped;
+  bool checkpointed;
+  struct multicast* multicast;
+};
+
+struct multicast {
+  uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  char creator_participant[CUINTERPOSE_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  CUmulticastObjectProp properties; /* as passed to cuMulticastCreate; replayed on restore */
+  size_t effective_size; /* the largest extent the driver accepted; see observe_extent */
+  CUcontext context;
+  CUmemGenericAllocationHandle driver; /* the one driver handle, 0 while checkpointed */
+  bool creator;
+  bool shared; /* a ticket was issued (creator) or imported (importer) */
+  bool checkpointed;
+  unsigned live_handles;
+  CUdevice* devices; /* devices this process attached */
+  size_t device_count;
+  struct multicast_binding* bindings;
+  size_t binding_count;
+  struct multicast_mapping** mappings;
+  size_t mapping_count;
+};
+
+static struct cuinterpose_multicast_callbacks ops;
+static const char* participant_id;
+static const char* endpoint_path;
+static struct table handles; /* logical handle -> struct multicast_handle */
+static struct table objects; /* id -> struct multicast */
+static struct ranges mapped; /* live mappings by address -> struct multicast_mapping */
+static atomic_bool untracked_member_logged;
+
+/* ------------------------------------------------------------------------- */
+/* Bookkeeping                                                               */
+/* ------------------------------------------------------------------------- */
+
+static struct multicast*
+find_object(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE])
+{
+  return table_get(&objects, key_bytes(id));
+}
+
+static struct multicast_handle*
+find_handle(CUmemGenericAllocationHandle logical)
+{
+  return table_get(&handles, key_u64((uint64_t)logical));
+}
+
+static struct multicast_mapping*
+mapping_at(CUdeviceptr address)
+{
+  struct range* range = ranges_at(&mapped, (uint64_t)address);
+
+  return range != NULL ? range->value : NULL;
+}
+
+/* An object is alive while the application holds a handle or a mapping of it;
+ * bindings alone do not keep it, exactly as in the driver. */
+static bool
+active(const struct multicast* multicast)
+{
+  size_t index;
+
+  if (multicast->live_handles != 0)
+    return true;
+  for (index = 0; index < multicast->mapping_count; index++) {
+    if (multicast->mappings[index]->mapped)
+      return true;
+  }
+  return false;
+}
+
+/*
+ * The driver may give a multicast object more capacity than cuMulticastCreate
+ * asked for (r615 rounds up to 512 MiB), and the application may then bind and
+ * map beyond the requested size. INSPECT reports the largest extent actually
+ * used so the coordinator's bounds checks accept it; `properties` keeps the
+ * requested size for replay and for ticket identity.
+ */
+static void
+observe_extent(struct multicast* multicast, size_t offset, size_t size)
+{
+  if (size <= SIZE_MAX - offset && multicast->effective_size < offset + size)
+    multicast->effective_size = offset + size;
+}
+
+static void
+adopt_context(struct multicast* multicast)
+{
+  if (multicast->context == NULL)
+    cuinterpose_capture_context(&multicast->context);
+}
+
+/* An object that never had a context is handled in the primary context of the
+ * first device it was attached to. */
+static int
+enter(const struct multicast* multicast, struct cuinterpose_context_scope* scope)
+{
+  CUdevice fallback = CUINTERPOSE_NO_DEVICE;
+
+  if (multicast->device_count != 0)
+    fallback = multicast->devices[0];
+  else if (multicast->binding_count != 0)
+    fallback = multicast->bindings[0].device;
+  return cuinterpose_enter_context(multicast->context, fallback, scope);
+}
+
+static int
+add_handle(struct multicast* multicast, CUmemGenericAllocationHandle* logical)
+{
+  struct multicast_handle* handle = calloc(1, sizeof(*handle));
+
+  if (handle == NULL || ops.allocate_logical_handle(&handle->logical) != 0) {
+    free(handle);
+    return -1;
+  }
+  handle->multicast = multicast;
+  if (table_put(&handles, key_u64((uint64_t)handle->logical), handle) != 0) {
+    free(handle);
+    return -1;
+  }
+  multicast->live_handles++;
+  *logical = handle->logical;
+  return 0;
+}
+
+static void
+remove_mapping(struct multicast* multicast, struct multicast_mapping* mapping)
+{
+  size_t index;
+
+  for (index = 0; index < multicast->mapping_count; index++) {
+    if (multicast->mappings[index] == mapping) {
+      multicast->mappings[index] = multicast->mappings[multicast->mapping_count - 1];
+      multicast->mapping_count--;
+      break;
+    }
+  }
+  free(mapping);
+}
+
+static void
+free_object(struct multicast* multicast)
+{
+  size_t index;
+
+  table_remove(&objects, key_bytes(multicast->id));
+  for (index = 0; index < multicast->mapping_count; index++) {
+    struct multicast_mapping* mapping = multicast->mappings[index];
+    struct range* range = ranges_at(&mapped, (uint64_t)mapping->address);
+
+    if (range != NULL && range->value == mapping)
+      ranges_remove_at(&mapped, (size_t)(range - mapped.items));
+    free(mapping);
+  }
+  free(multicast->mappings);
+  free(multicast->bindings);
+  free(multicast->devices);
+  free(multicast);
+}
+
+/* Frees an object nobody holds any more: the cached descriptor goes first,
+ * then the driver handle, then the records. */
+static void
+settle(struct multicast* multicast)
+{
+  if (active(multicast) || multicast->checkpointed)
+    return;
+  cuinterpose_export_cache_drop(multicast->id);
+  if (multicast->driver != 0) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+
+    if (release != NULL)
+      (void)release(multicast->driver);
+    multicast->driver = 0;
+  }
+  free_object(multicast);
+}
+
+struct object_list {
+  struct multicast** items;
+  size_t count;
+};
+
+static int
+collect_object(struct key key, void* value, void* arg)
+{
+  struct object_list* list = arg;
+
+  (void)key;
+  list->items[list->count++] = value;
+  return 0;
+}
+
+static int
+list_objects(struct object_list* list)
+{
+  list->count = 0;
+  list->items = calloc(objects.count == 0 ? 1 : objects.count, sizeof(*list->items));
+  if (list->items == NULL)
+    return -1;
+  table_each(&objects, collect_object, list);
+  return 0;
+}
+
+static void
+fill_ticket(const struct multicast* multicast, struct cuinterpose_posix_ticket* ticket)
+{
+  memset(ticket, 0, sizeof(*ticket));
+  ticket->magic = CUINTERPOSE_POSIX_TICKET_MAGIC;
+  ticket->version = CUINTERPOSE_POSIX_TICKET_VERSION;
+  ticket->resource_kind = CUINTERPOSE_RESOURCE_MULTICAST;
+  snprintf(ticket->creator_participant, sizeof(ticket->creator_participant), "%s", multicast->creator_participant);
+  memcpy(ticket->allocation_id, multicast->id, sizeof(ticket->allocation_id));
+  snprintf(ticket->creator_endpoint, sizeof(ticket->creator_endpoint), "%s", multicast->creator_endpoint);
+  ticket->allocation_size = multicast->properties.size;
+  ticket->handle_types = multicast->properties.handleTypes;
+  ticket->object_flags = multicast->properties.flags;
+  ticket->num_devices = multicast->properties.numDevices;
+}
+
+static bool
+matches_ticket(const struct multicast* multicast, const struct cuinterpose_posix_ticket* ticket)
+{
+  return strcmp(multicast->creator_participant, ticket->creator_participant) == 0 &&
+         strcmp(multicast->creator_endpoint, ticket->creator_endpoint) == 0 &&
+         multicast->properties.numDevices == ticket->num_devices &&
+         multicast->properties.size == ticket->allocation_size &&
+         multicast->properties.handleTypes == ticket->handle_types &&
+         multicast->properties.flags == ticket->object_flags;
+}
+
+/* Merge descriptors into a mapping's per-location access set (same rules as
+ * interpose.c: one entry per location, PROT_NONE removes it). */
+static int
+merge_access(
+    const struct multicast_mapping* mapping, const CUmemAccessDesc* descriptors, size_t count, CUmemAccessDesc* merged,
+    size_t* merged_count)
+{
+  size_t index;
+
+  memcpy(merged, mapping->access, mapping->access_count * sizeof(*merged));
+  *merged_count = mapping->access_count;
+  for (index = 0; index < count; index++) {
+    const CUmemAccessDesc* descriptor = &descriptors[index];
+    size_t slot;
+
+    for (slot = 0; slot < *merged_count; slot++) {
+      if (merged[slot].location.type == descriptor->location.type &&
+          merged[slot].location.id == descriptor->location.id)
+        break;
+    }
+    if (descriptor->flags == CU_MEM_ACCESS_FLAGS_PROT_NONE) {
+      if (slot < *merged_count) {
+        merged[slot] = merged[*merged_count - 1];
+        (*merged_count)--;
+      }
+      continue;
+    }
+    if (slot == *merged_count) {
+      if (*merged_count == CUINTERPOSE_MAX_ACCESS)
+        return -1;
+      (*merged_count)++;
+    }
+    merged[slot] = *descriptor;
+  }
+  return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Driver calls shared by the wrappers and restore                           */
+/* ------------------------------------------------------------------------- */
+
+static CUresult
+forward_bind_mem(
+    CUmemGenericAllocationHandle driver, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUmemGenericAllocationHandle member, size_t member_offset, size_t size, unsigned long long flags)
+{
+  if (device_explicit) {
+#if CUDA_VERSION >= 13010
+    bind_mem_v2_fn function = (bind_mem_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem_v2");
+
+    if (function == NULL)
+      return cuinterpose_unavailable();
+    return function(driver, device, multicast_offset, member, member_offset, size, flags);
+#else
+    (void)device;
+    return CUDA_ERROR_NOT_SUPPORTED;
+#endif
+  }
+  {
+    bind_mem_fn function = (bind_mem_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem");
+
+    if (function == NULL)
+      return cuinterpose_unavailable();
+    return function(driver, multicast_offset, member, member_offset, size, flags);
+  }
+}
+
+static CUresult
+forward_bind_address(
+    CUmemGenericAllocationHandle driver, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUdeviceptr member, size_t size, unsigned long long flags)
+{
+  if (device_explicit) {
+#if CUDA_VERSION >= 13010
+    bind_address_v2_fn function = (bind_address_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindAddr_v2");
+
+    if (function == NULL)
+      return cuinterpose_unavailable();
+    return function(driver, device, multicast_offset, member, size, flags);
+#else
+    (void)device;
+    return CUDA_ERROR_NOT_SUPPORTED;
+#endif
+  }
+  {
+    bind_address_fn function = (bind_address_fn)cuinterpose_lookup_real_symbol("cuMulticastBindAddr");
+
+    if (function == NULL)
+      return cuinterpose_unavailable();
+    return function(driver, multicast_offset, member, size, flags);
+  }
+}
+
+static CUresult
+replay_binding(CUmemGenericAllocationHandle driver, const struct multicast_binding* binding, const char** error)
+{
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  CUresult result;
+
+  if (binding->kind == CUINTERPOSE_MULTICAST_BIND_MEM) {
+    struct cuinterpose_multicast_member member;
+
+    memset(&member, 0, sizeof(member));
+    if (ops.member_from_id(binding->member_id, &member) != 0) {
+      *error = "a multicast member allocation is missing after restore";
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    result = forward_bind_mem(
+        driver, binding->device, binding->api_version == 2, binding->multicast_offset, member.handle,
+        binding->member_offset, binding->size, binding->flags);
+    if (member.temporary_handle && release != NULL) {
+      CUresult released = release(member.handle);
+      if (result == CUDA_SUCCESS)
+        result = released;
+    }
+  } else {
+    result = forward_bind_address(
+        driver, binding->device, binding->api_version == 2, binding->multicast_offset, binding->member_address,
+        binding->size, binding->flags);
+  }
+  if (result != CUDA_SUCCESS)
+    *error = "cuMulticastBind failed during restore";
+  return result;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Module interface                                                          */
+/* ------------------------------------------------------------------------- */
+
+void
+cuinterpose_multicast_initialize(
+    const struct cuinterpose_multicast_callbacks* callbacks, const char* participant, const char* endpoint)
+{
+  ops = *callbacks;
+  participant_id = participant;
+  endpoint_path = endpoint;
+}
+
+static int
+free_handle_value(struct key key, void* value, void* arg)
+{
+  (void)key;
+  (void)arg;
+  free(value);
+  return 0;
+}
+
+static int
+free_object_value(struct key key, void* value, void* arg)
+{
+  struct multicast* multicast = value;
+  size_t index;
+
+  (void)key;
+  (void)arg;
+  for (index = 0; index < multicast->mapping_count; index++)
+    free(multicast->mappings[index]);
+  free(multicast->mappings);
+  free(multicast->bindings);
+  free(multicast->devices);
+  free(multicast);
+  return 0;
+}
+
+void
+cuinterpose_multicast_fork_child(void)
+{
+  table_each(&handles, free_handle_value, NULL);
+  table_clear(&handles);
+  table_each(&objects, free_object_value, NULL);
+  table_clear(&objects);
+  ranges_clear(&mapped);
+}
+
+size_t
+cuinterpose_multicast_count(void)
+{
+  return objects.count;
+}
+
+bool
+cuinterpose_multicast_is_handle(CUmemGenericAllocationHandle logical)
+{
+  return find_handle(logical) != NULL;
+}
+
+bool
+cuinterpose_multicast_owns_range(CUdeviceptr address, size_t size)
+{
+  size_t first;
+  size_t last;
+
+  if (size == 0 || (uint64_t)address > UINT64_MAX - size)
+    return false;
+  (void)ranges_cover(&mapped, (uint64_t)address, (uint64_t)address + size, &first, &last);
+  return first != last;
+}
+
+CUresult
+cuinterpose_multicast_release(CUmemGenericAllocationHandle logical)
+{
+  struct multicast_handle* handle = find_handle(logical);
+  struct multicast* multicast;
+
+  if (handle == NULL)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (!ops.state_is_active())
+    return CUDA_ERROR_NOT_READY;
+  multicast = handle->multicast;
+  table_remove(&handles, key_u64((uint64_t)logical));
+  free(handle);
+  multicast->live_handles--;
+  settle(multicast);
+  return CUDA_SUCCESS;
+}
+
+CUresult
+cuinterpose_multicast_retain(CUmemGenericAllocationHandle* output, void* address)
+{
+  struct multicast_mapping* mapping = mapping_at((CUdeviceptr)(uintptr_t)address);
+  struct multicast* multicast;
+  CUmemGenericAllocationHandle logical;
+
+  if (mapping == NULL || !mapping->mapped)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (!ops.state_is_active())
+    return CUDA_ERROR_NOT_READY;
+  multicast = mapping->multicast;
+  if (multicast->driver == 0) {
+    retain_fn retain = (retain_fn)cuinterpose_lookup_real_symbol("cuMemRetainAllocationHandle");
+    CUresult result;
+
+    if (retain == NULL)
+      return cuinterpose_unavailable();
+    result = retain(&multicast->driver, address);
+    if (result != CUDA_SUCCESS) {
+      multicast->driver = 0;
+      return result;
+    }
+  }
+  /* The one driver handle is already held; the new logical handle aliases it. */
+  if (add_handle(multicast, &logical) != 0)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  *output = logical;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+cuinterpose_multicast_map(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle logical, unsigned long long flags)
+{
+  map_fn map = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  struct multicast_handle* handle = find_handle(logical);
+  struct multicast* multicast;
+  struct multicast_mapping* mapping;
+  struct multicast_mapping** slot;
+  CUmemGenericAllocationHandle driver;
+  CUresult result;
+
+  if (handle == NULL)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (!ops.state_is_active() || handle->multicast->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  if (map == NULL || unmap == NULL)
+    return cuinterpose_unavailable();
+  if (size == 0 || (uint64_t)address > UINT64_MAX - size)
+    return CUDA_ERROR_INVALID_VALUE;
+  mapping = calloc(1, sizeof(*mapping));
+  if (mapping == NULL)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  /* Reserve the range before the driver sees it: two records for one address
+   * would make restore ambiguous. */
+  switch (ranges_insert(&mapped, (uint64_t)address, (uint64_t)address + size, mapping)) {
+    case 1:
+      free(mapping);
+      return CUDA_ERROR_INVALID_VALUE;
+    case -1:
+      free(mapping);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    default:
+      break;
+  }
+  /*
+   * Mapping a multicast object waits for the whole team, so the lock is not
+   * held across it: other threads of this process must be able to go on
+   * allocating, and a checkpoint that starts meanwhile must be able to see
+   * the state. Everything is looked up again afterwards.
+   */
+  driver = handle->multicast->driver;
+  ops.release_state_lock();
+  result = map(address, size, offset, driver, flags);
+  ops.acquire_state_lock();
+  handle = find_handle(logical);
+  if (result != CUDA_SUCCESS || handle == NULL || handle->multicast->driver != driver || !ops.state_is_active()) {
+    struct range* range = ranges_at(&mapped, (uint64_t)address);
+
+    if (range != NULL && range->value == mapping)
+      ranges_remove_at(&mapped, (size_t)(range - mapped.items));
+    free(mapping);
+    if (result != CUDA_SUCCESS)
+      return result;
+    (void)unmap(address, size);
+    return handle == NULL ? CUDA_ERROR_INVALID_HANDLE : CUDA_ERROR_NOT_READY;
+  }
+  multicast = handle->multicast;
+  slot = array_push((void**)&multicast->mappings, &multicast->mapping_count, sizeof(*multicast->mappings));
+  if (slot == NULL) {
+    struct range* range = ranges_at(&mapped, (uint64_t)address);
+
+    if (range != NULL && range->value == mapping)
+      ranges_remove_at(&mapped, (size_t)(range - mapped.items));
+    free(mapping);
+    (void)unmap(address, size);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *slot = mapping;
+  mapping->address = address;
+  mapping->size = size;
+  mapping->offset = offset;
+  mapping->flags = flags;
+  mapping->mapped = true;
+  mapping->multicast = multicast;
+  observe_extent(multicast, offset, size);
+  adopt_context(multicast);
+  return CUDA_SUCCESS;
+}
+
+CUresult
+cuinterpose_multicast_unmap(CUdeviceptr address, size_t size)
+{
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  struct multicast** affected;
+  size_t affected_count = 0;
+  size_t first;
+  size_t last;
+  size_t index;
+  CUresult result;
+
+  if (unmap == NULL)
+    return cuinterpose_unavailable();
+  if (ranges_cover(&mapped, (uint64_t)address, (uint64_t)address + size, &first, &last) != 0 ||
+      first == last)
+    return CUDA_ERROR_INVALID_VALUE;
+  for (index = first; index < last; index++) {
+    const struct multicast_mapping* mapping = mapped.items[index].value;
+    if (!mapping->mapped)
+      return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (!ops.state_is_active())
+    return CUDA_ERROR_NOT_READY;
+  affected = calloc(last - first, sizeof(*affected));
+  if (affected == NULL)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  result = unmap(address, size);
+  if (result != CUDA_SUCCESS) {
+    free(affected);
+    return result;
+  }
+  for (index = last; index > first; index--) {
+    struct multicast_mapping* mapping = mapped.items[index - 1].value;
+    struct multicast* multicast = mapping->multicast;
+    size_t seen;
+
+    ranges_remove_at(&mapped, index - 1);
+    remove_mapping(multicast, mapping);
+    for (seen = 0; seen < affected_count; seen++) {
+      if (affected[seen] == multicast)
+        break;
+    }
+    if (seen == affected_count)
+      affected[affected_count++] = multicast;
+  }
+  for (index = 0; index < affected_count; index++)
+    settle(affected[index]);
+  free(affected);
+  return CUDA_SUCCESS;
+}
+
+CUresult
+cuinterpose_multicast_set_access(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  access_fn set_access = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  CUmemAccessDesc (*merged)[CUINTERPOSE_MAX_ACCESS] = NULL;
+  size_t* merged_counts = NULL;
+  size_t first;
+  size_t last;
+  size_t index;
+  CUresult result;
+
+  if (set_access == NULL)
+    return cuinterpose_unavailable();
+  if (ranges_cover(&mapped, (uint64_t)address, (uint64_t)address + size, &first, &last) != 0 ||
+      first == last)
+    return CUDA_ERROR_INVALID_VALUE;
+  for (index = first; index < last; index++) {
+    const struct multicast_mapping* mapping = mapped.items[index].value;
+    if (!mapping->mapped)
+      return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (!ops.state_is_active())
+    return CUDA_ERROR_NOT_READY;
+  merged = calloc(last - first, sizeof(*merged));
+  merged_counts = calloc(last - first, sizeof(*merged_counts));
+  if (merged == NULL || merged_counts == NULL) {
+    free(merged);
+    free(merged_counts);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  for (index = first; index < last; index++) {
+    if (merge_access(mapped.items[index].value, descriptors, count, merged[index - first], &merged_counts[index - first]) !=
+        0) {
+      free(merged);
+      free(merged_counts);
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+  }
+  result = set_access(address, size, descriptors, count);
+  for (index = first; index < last; index++) {
+    struct multicast_mapping* mapping = mapped.items[index].value;
+    if (result == CUDA_SUCCESS) {
+      memcpy(mapping->access, merged[index - first], merged_counts[index - first] * sizeof(*mapping->access));
+      mapping->access_count = merged_counts[index - first];
+    } else {
+      mapping->access_unknown = true;
+    }
+  }
+  free(merged);
+  free(merged_counts);
+  return result;
+}
+
+CUresult
+cuinterpose_multicast_export(
+    void* shareable, CUmemGenericAllocationHandle logical, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  struct multicast_handle* handle = find_handle(logical);
+  struct multicast* multicast;
+  struct cuinterpose_posix_ticket ticket;
+  int ticket_fd = -1;
+
+  if (handle == NULL)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (shareable == NULL || flags != 0 || type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (!ops.state_is_active())
+    return CUDA_ERROR_NOT_READY;
+  multicast = handle->multicast;
+  adopt_context(multicast);
+  if (multicast->creator && !cuinterpose_export_cache_has(multicast->id)) {
+    /* The one real export of this object in this process; peers are served
+     * duplicates of the descriptor from the export cache. */
+    export_fn export_handle = (export_fn)cuinterpose_lookup_real_symbol("cuMemExportToShareableHandle");
+    int real_fd = -1;
+    CUresult result;
+
+    if (export_handle == NULL)
+      return cuinterpose_unavailable();
+    if (multicast->driver == 0)
+      return CUDA_ERROR_INVALID_HANDLE;
+    result = export_handle(&real_fd, multicast->driver, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+    if (result != CUDA_SUCCESS)
+      return result;
+    if (cuinterpose_export_cache_put(multicast->id, real_fd) != 0) {
+      close(real_fd);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+  fill_ticket(multicast, &ticket);
+  if (cuinterpose_posix_create_ticket(&ticket, &ticket_fd) != 0)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  multicast->shared = true;
+  *(int*)shareable = ticket_fd;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+cuinterpose_multicast_get_properties(CUmemAllocationProp* properties, CUmemGenericAllocationHandle logical)
+{
+  properties_fn function = (properties_fn)cuinterpose_lookup_real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  struct multicast_handle* handle = find_handle(logical);
+
+  if (handle == NULL)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (!ops.state_is_active() || handle->multicast->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  return function != NULL ? function(properties, handle->multicast->driver) : cuinterpose_unavailable();
+}
+
+CUresult
+cuinterpose_multicast_import(CUmemGenericAllocationHandle* output, const struct cuinterpose_posix_ticket* ticket)
+{
+  import_fn import_handle = (import_fn)cuinterpose_lookup_real_symbol("cuMemImportFromShareableHandle");
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  struct multicast* multicast;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  bool created = false;
+  int raw_fd = -1;
+  CUresult result;
+
+  if (import_handle == NULL || release == NULL)
+    return cuinterpose_unavailable();
+  if (ticket->handle_types != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_INVALID_HANDLE;
+  ops.acquire_state_lock();
+  if (!ops.state_is_active()) {
+    ops.release_state_lock();
+    return CUDA_ERROR_NOT_READY;
+  }
+  ops.release_state_lock();
+  if (cuinterpose_posix_request_export(ticket, &raw_fd, NULL, 0) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  result = import_handle(&driver, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  close(raw_fd);
+  if (result != CUDA_SUCCESS)
+    return result;
+  ops.acquire_state_lock();
+  if (!ops.state_is_active()) {
+    ops.release_state_lock();
+    (void)release(driver);
+    return CUDA_ERROR_NOT_READY;
+  }
+  multicast = find_object(ticket->allocation_id);
+  if (multicast != NULL && !matches_ticket(multicast, ticket)) {
+    ops.release_state_lock();
+    (void)release(driver);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  if (multicast == NULL) {
+    multicast = calloc(1, sizeof(*multicast));
+    if (multicast == NULL ||
+        table_put(&objects, key_bytes(ticket->allocation_id), multicast) != 0) {
+      ops.release_state_lock();
+      (void)release(driver);
+      free(multicast);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    created = true;
+    memcpy(multicast->id, ticket->allocation_id, sizeof(multicast->id));
+    snprintf(
+        multicast->creator_participant, sizeof(multicast->creator_participant), "%s", ticket->creator_participant);
+    snprintf(multicast->creator_endpoint, sizeof(multicast->creator_endpoint), "%s", ticket->creator_endpoint);
+    multicast->properties.numDevices = ticket->num_devices;
+    multicast->properties.size = ticket->allocation_size;
+    multicast->properties.handleTypes = ticket->handle_types;
+    multicast->properties.flags = ticket->object_flags;
+    multicast->effective_size = ticket->allocation_size;
+    multicast->creator = false;
+    multicast->driver = driver;
+    cuinterpose_capture_context(&multicast->context);
+  } else if (multicast->driver != 0) {
+    /* Already imported here: the new logical handle aliases the driver handle. */
+    if (release(driver) != CUDA_SUCCESS) {
+      ops.release_state_lock();
+      return CUDA_ERROR_UNKNOWN;
+    }
+  } else {
+    multicast->driver = driver;
+  }
+  multicast->shared = true;
+  if (add_handle(multicast, &logical) != 0) {
+    if (created) {
+      (void)release(multicast->driver);
+      multicast->driver = 0;
+      free_object(multicast);
+    }
+    ops.release_state_lock();
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  ops.release_state_lock();
+  return CUDA_SUCCESS;
+}
+
+/* ------------------------------------------------------------------------- */
+/* INSPECT records                                                           */
+/* ------------------------------------------------------------------------- */
+
+static int
+count_records(struct key key, void* value, void* arg)
+{
+  const struct multicast* multicast = value;
+  size_t* total = arg;
+  size_t index;
+
+  (void)key;
+  if (!active(multicast))
+    return 0;
+  *total += 1 + multicast->device_count + multicast->binding_count;
+  for (index = 0; index < multicast->mapping_count; index++)
+    *total += multicast->mappings[index]->mapped ? 1 : 0;
+  return 0;
+}
+
+size_t
+cuinterpose_multicast_record_count(void)
+{
+  size_t total = 0;
+
+  table_each(&objects, count_records, &total);
+  return total;
+}
+
+int
+cuinterpose_multicast_write_records(struct cuinterpose_record* records, size_t count, const char** error)
+{
+  struct object_list list = {0};
+  CUINTERPOSE_CLEANUP(free_ptr) struct multicast** listed_objects = NULL;
+  size_t written = 0;
+  size_t index;
+
+  if (list_objects(&list) != 0) {
+    *error = "cannot allocate inspect records";
+    return -1;
+  }
+  listed_objects = list.items;
+  for (index = 0; index < list.count; index++) {
+    const struct multicast* multicast = list.items[index];
+    struct cuinterpose_record* record;
+    size_t item;
+
+    if (!active(multicast))
+      continue;
+    if (written == count) {
+      *error = "multicast records changed while being described";
+      return -1;
+    }
+    record = &records[written++];
+    record->kind = CUINTERPOSE_MULTICAST;
+    record->flags = multicast->creator ? CUINTERPOSE_CREATOR : 0;
+    if (multicast->live_handles != 0)
+      record->flags |= CUINTERPOSE_APPLICATION_HANDLE_LIVE;
+    memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+    record->allocation_size = multicast->effective_size;
+    record->application_handle_count = multicast->live_handles;
+    record->handle_types = multicast->properties.handleTypes;
+    record->object_flags = multicast->properties.flags;
+    record->num_devices = multicast->properties.numDevices;
+    snprintf(record->creator_participant, sizeof(record->creator_participant), "%s", multicast->creator_participant);
+    for (item = 0; item < multicast->device_count; item++) {
+      if (written == count) {
+        *error = "multicast records changed while being described";
+        return -1;
+      }
+      record = &records[written++];
+      record->kind = CUINTERPOSE_MULTICAST_DEVICE;
+      memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+      record->device = multicast->devices[item];
+    }
+    for (item = 0; item < multicast->binding_count; item++) {
+      const struct multicast_binding* binding = &multicast->bindings[item];
+
+      if (written == count) {
+        *error = "multicast records changed while being described";
+        return -1;
+      }
+      record = &records[written++];
+      record->kind = CUINTERPOSE_MULTICAST_BINDING;
+      memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+      memcpy(record->member_id, binding->member_id, sizeof(record->member_id));
+      record->address = binding->member_address;
+      record->size = binding->size;
+      record->offset = binding->multicast_offset;
+      record->member_offset = binding->member_offset;
+      record->operation_flags = binding->flags;
+      record->binding_kind = binding->kind;
+      record->api_version = binding->api_version;
+      record->device = binding->device;
+    }
+    for (item = 0; item < multicast->mapping_count; item++) {
+      const struct multicast_mapping* mapping = multicast->mappings[item];
+      size_t access;
+
+      if (!mapping->mapped)
+        continue;
+      if (mapping->access_unknown) {
+        *error = "a multicast mapping's access state is unknown after a failed cuMemSetAccess";
+        return -1;
+      }
+      if (written == count) {
+        *error = "multicast records changed while being described";
+        return -1;
+      }
+      record = &records[written++];
+      record->kind = CUINTERPOSE_MULTICAST_MAPPING;
+      memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+      record->address = mapping->address;
+      record->size = mapping->size;
+      record->offset = mapping->offset;
+      record->operation_flags = mapping->flags;
+      record->access_count = (uint32_t)mapping->access_count;
+      for (access = 0; access < mapping->access_count; access++) {
+        record->access[access].location_type = mapping->access[access].location.type;
+        record->access[access].location_id = mapping->access[access].location.id;
+        record->access[access].flags = mapping->access[access].flags;
+      }
+    }
+  }
+  if (written != count) {
+    *error = "multicast records changed while being described";
+    return -1;
+  }
+  return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Lifecycle                                                                 */
+/* ------------------------------------------------------------------------- */
+
+/*
+ * PREPARE_MULTICAST: take every live object apart so the native checkpoint
+ * sees none of it. The cached export descriptor is closed first: it is an
+ * independent reference to the object in the driver, and the object must be
+ * gone before the checkpoint. Then mappings are unmapped, bindings unbound,
+ * and the driver handle released. The records stay for restore.
+ */
+int
+cuinterpose_multicast_prepare(const char** error)
+{
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  unbind_fn unbind = (unbind_fn)cuinterpose_lookup_real_symbol("cuMulticastUnbind");
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  struct object_list list;
+  size_t index;
+
+  if (unmap == NULL || unbind == NULL || release == NULL) {
+    *error = "multicast teardown symbols are unavailable";
+    return -1;
+  }
+  if (list_objects(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct multicast* multicast = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t item;
+
+    if (!active(multicast))
+      continue;
+    for (item = 0; item < multicast->mapping_count; item++) {
+      if (multicast->mappings[item]->mapped && multicast->mappings[item]->access_unknown) {
+        free(list.items);
+        *error = "a multicast mapping's access state is unknown after a failed cuMemSetAccess";
+        return -1;
+      }
+    }
+    if (multicast->driver == 0) {
+      free(list.items);
+      *error = "a live multicast object has no driver handle";
+      return -1;
+    }
+    cuinterpose_export_cache_drop(multicast->id);
+    if (enter(multicast, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the multicast object's CUDA context";
+      return -1;
+    }
+    for (item = 0; item < multicast->mapping_count; item++) {
+      struct multicast_mapping* mapping = multicast->mappings[item];
+      struct range* range;
+
+      if (!mapping->mapped)
+        continue;
+      if (unmap(mapping->address, mapping->size) != CUDA_SUCCESS) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        *error = "cuMemUnmap of a multicast mapping failed during prepare";
+        return -1;
+      }
+      range = ranges_at(&mapped, (uint64_t)mapping->address);
+      if (range != NULL && range->value == mapping)
+        ranges_remove_at(&mapped, (size_t)(range - mapped.items));
+      mapping->mapped = false;
+      mapping->checkpointed = true;
+    }
+    for (item = 0; item < multicast->binding_count; item++) {
+      struct multicast_binding* binding = &multicast->bindings[item];
+
+      if (unbind(multicast->driver, binding->device, binding->multicast_offset, binding->size) != CUDA_SUCCESS) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        *error = "cuMulticastUnbind failed during prepare";
+        return -1;
+      }
+      binding->checkpointed = true;
+    }
+    if (release(multicast->driver) != CUDA_SUCCESS) {
+      (void)cuinterpose_leave_context(&scope);
+      free(list.items);
+      *error = "cuMemRelease of a multicast object failed during prepare";
+      return -1;
+    }
+    multicast->driver = 0;
+    multicast->checkpointed = true;
+    if (cuinterpose_leave_context(&scope) != 0) {
+      free(list.items);
+      *error = "cannot leave the multicast object's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* RESTORE_MULTICAST_CREATORS: creators make the object again and re-export it
+ * into the cache; importers ask for it in the next phase. */
+int
+cuinterpose_multicast_restore_creators(const char** error)
+{
+  create_fn create = (create_fn)cuinterpose_lookup_real_symbol("cuMulticastCreate");
+  export_fn export_handle = (export_fn)cuinterpose_lookup_real_symbol("cuMemExportToShareableHandle");
+  struct object_list list;
+  size_t index;
+
+  if (create == NULL || export_handle == NULL) {
+    *error = "multicast restore symbols are unavailable";
+    return -1;
+  }
+  if (list_objects(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct multicast* multicast = list.items[index];
+    struct cuinterpose_context_scope scope;
+    CUmemGenericAllocationHandle driver = 0;
+    int real_fd = -1;
+
+    if (!multicast->checkpointed || !multicast->creator)
+      continue;
+    if (enter(multicast, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the multicast object's CUDA context";
+      return -1;
+    }
+    if (create(&driver, &multicast->properties) != CUDA_SUCCESS) {
+      (void)cuinterpose_leave_context(&scope);
+      free(list.items);
+      *error = "cuMulticastCreate failed during restore";
+      return -1;
+    }
+    multicast->driver = driver;
+    if (multicast->shared &&
+        (export_handle(&real_fd, driver, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) != CUDA_SUCCESS ||
+         cuinterpose_export_cache_put(multicast->id, real_fd) != 0)) {
+      if (real_fd >= 0)
+        close(real_fd);
+      (void)cuinterpose_leave_context(&scope);
+      free(list.items);
+      *error = "cannot export a multicast object again after restore";
+      return -1;
+    }
+    if (cuinterpose_leave_context(&scope) != 0) {
+      free(list.items);
+      *error = "cannot leave the multicast object's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* RESTORE_MULTICAST_IMPORTERS: importers fetch the object from its creator. */
+int
+cuinterpose_multicast_restore_importers(char* message, size_t message_size)
+{
+  import_fn import_handle = (import_fn)cuinterpose_lookup_real_symbol("cuMemImportFromShareableHandle");
+  struct object_list list;
+  size_t index;
+
+  if (import_handle == NULL) {
+    snprintf(message, message_size, "%s", "cuMemImportFromShareableHandle is unavailable");
+    return -1;
+  }
+  if (list_objects(&list) != 0) {
+    snprintf(message, message_size, "%s", "cannot allocate");
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct multicast* multicast = list.items[index];
+    struct cuinterpose_posix_ticket ticket;
+    struct cuinterpose_context_scope scope;
+    char export_error[96] = {0};
+    CUmemGenericAllocationHandle driver = 0;
+    int raw_fd = -1;
+    CUresult result;
+
+    if (!multicast->checkpointed || multicast->creator)
+      continue;
+    fill_ticket(multicast, &ticket);
+    /* The creator's listener serves this from its export cache without any
+     * lock we hold, so the request can be made under state_lock. */
+    if (cuinterpose_posix_request_export(&ticket, &raw_fd, export_error, sizeof(export_error)) != 0) {
+      free(list.items);
+      snprintf(message, message_size, "multicast creator export: %.70s", export_error);
+      return -1;
+    }
+    if (enter(multicast, &scope) != 0) {
+      close(raw_fd);
+      free(list.items);
+      snprintf(message, message_size, "%s", "cannot enter the multicast object's CUDA context");
+      return -1;
+    }
+    result = import_handle(&driver, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    close(raw_fd);
+    if (result != CUDA_SUCCESS) {
+      (void)cuinterpose_leave_context(&scope);
+      free(list.items);
+      snprintf(message, message_size, "multicast import failed during restore: CUresult=%d", (int)result);
+      return -1;
+    }
+    multicast->driver = driver;
+    if (cuinterpose_leave_context(&scope) != 0) {
+      free(list.items);
+      snprintf(message, message_size, "%s", "cannot leave the multicast object's CUDA context");
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* RESTORE_MULTICAST_DEVICES: every participant attaches the devices it had
+ * attached before. Binding in the next phase waits for all of them, which is
+ * why the coordinator puts a barrier between the two. */
+int
+cuinterpose_multicast_restore_devices(const char** error)
+{
+  add_device_fn add_device = (add_device_fn)cuinterpose_lookup_real_symbol("cuMulticastAddDevice");
+  struct object_list list;
+  size_t index;
+
+  if (add_device == NULL) {
+    *error = "cuMulticastAddDevice is unavailable";
+    return -1;
+  }
+  if (list_objects(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct multicast* multicast = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t item;
+
+    if (!multicast->checkpointed)
+      continue;
+    if (multicast->driver == 0) {
+      free(list.items);
+      *error = "a multicast object was not recreated before its devices";
+      return -1;
+    }
+    if (enter(multicast, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the multicast object's CUDA context";
+      return -1;
+    }
+    for (item = 0; item < multicast->device_count; item++) {
+      if (add_device(multicast->driver, multicast->devices[item]) != CUDA_SUCCESS) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        *error = "cuMulticastAddDevice failed during restore";
+        return -1;
+      }
+    }
+    if (cuinterpose_leave_context(&scope) != 0) {
+      free(list.items);
+      *error = "cannot leave the multicast object's CUDA context";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* RESTORE_MULTICAST_BINDINGS: bind the members again, map the object at the
+ * old addresses with the old access, and check nothing is left checkpointed. */
+int
+cuinterpose_multicast_restore_bindings(const char** error)
+{
+  map_fn map = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  access_fn set_access = (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  struct object_list list;
+  size_t index;
+
+  if (map == NULL || set_access == NULL) {
+    *error = "multicast mapping symbols are unavailable";
+    return -1;
+  }
+  if (list_objects(&list) != 0) {
+    *error = "cannot allocate";
+    return -1;
+  }
+  for (index = 0; index < list.count; index++) {
+    struct multicast* multicast = list.items[index];
+    struct cuinterpose_context_scope scope;
+    size_t item;
+
+    if (!multicast->checkpointed)
+      continue;
+    if (multicast->driver == 0) {
+      free(list.items);
+      *error = "a multicast object was not recreated before its bindings";
+      return -1;
+    }
+    if (enter(multicast, &scope) != 0) {
+      free(list.items);
+      *error = "cannot enter the multicast object's CUDA context";
+      return -1;
+    }
+    for (item = 0; item < multicast->binding_count; item++) {
+      struct multicast_binding* binding = &multicast->bindings[item];
+
+      if (!binding->checkpointed)
+        continue;
+      if (replay_binding(multicast->driver, binding, error) != CUDA_SUCCESS) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        return -1;
+      }
+      binding->checkpointed = false;
+    }
+    for (item = 0; item < multicast->mapping_count; item++) {
+      struct multicast_mapping* mapping = multicast->mappings[item];
+
+      if (!mapping->checkpointed)
+        continue;
+      if (map(mapping->address, mapping->size, mapping->offset, multicast->driver, mapping->flags) != CUDA_SUCCESS) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        *error = "cuMemMap of a multicast mapping failed during restore";
+        return -1;
+      }
+      if (mapping->access_count != 0 &&
+          set_access(mapping->address, mapping->size, mapping->access, mapping->access_count) != CUDA_SUCCESS) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        *error = "cuMemSetAccess of a multicast mapping failed during restore";
+        return -1;
+      }
+      if (ranges_insert(&mapped, (uint64_t)mapping->address, (uint64_t)mapping->address + mapping->size,
+                                    mapping) != 0) {
+        (void)cuinterpose_leave_context(&scope);
+        free(list.items);
+        *error = "a restored multicast mapping overlaps another mapping";
+        return -1;
+      }
+      mapping->mapped = true;
+      mapping->checkpointed = false;
+    }
+    multicast->checkpointed = false;
+    if (cuinterpose_leave_context(&scope) != 0) {
+      free(list.items);
+      *error = "cannot leave the multicast object's CUDA context";
+      return -1;
+    }
+  }
+  for (index = 0; index < list.count; index++) {
+    if (list.items[index]->checkpointed || (active(list.items[index]) && list.items[index]->driver == 0)) {
+      free(list.items);
+      *error = "a multicast object remains checkpointed after restore";
+      return -1;
+    }
+  }
+  free(list.items);
+  return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* The cuMulticast* entry points                                             */
+/* ------------------------------------------------------------------------- */
+
+/* Refuses a raw driver handle that happens to fall in the shim's logical range. */
+static CUresult
+passthrough_handle(CUresult result, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* output)
+{
+  if (result != CUDA_SUCCESS) {
+    *output = driver;
+    return result;
+  }
+  if (cuinterpose_is_logical_handle(driver)) {
+    release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+
+    if (release != NULL)
+      (void)release(driver);
+    fprintf(stderr, "cuinterpose: driver returned a multicast handle in the reserved logical range; refusing it\n");
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  *output = driver;
+  return CUDA_SUCCESS;
+}
+
 CUINTERPOSE_API CUresult CUDAAPI
 cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
 {
   create_fn function = (create_fn)cuinterpose_lookup_real_symbol("cuMulticastCreate");
+  release_fn release = (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  struct multicast* multicast;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
 
-  return function != NULL ? function(output, properties) : cuinterpose_unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterpose_unavailable();
+  if (properties == NULL || properties->handleTypes != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    /* Same rule as cuMemCreate: private resources stay native; unsupported
+     * exportable resources run normally but make checkpoint preflight fail. */
+    result = function(&driver, properties);
+    result = passthrough_handle(result, driver, output);
+    if (result == CUDA_SUCCESS && properties != NULL && properties->handleTypes != 0)
+      cuinterpose_note_unsupported_exportable_creation(properties->handleTypes);
+    return result;
+  }
+  /*
+   * cuMulticastCreate is a team collective that can wait for the other ranks
+   * (and contends the driver's global lock); nothing of ours needs protecting
+   * until it returns, so the lock is taken only afterwards.
+   */
+  result = function(&driver, properties);
+  if (result != CUDA_SUCCESS) {
+    *output = driver; /* whatever the driver wrote, as if it had been called directly */
+    return result;
+  }
+  multicast = calloc(1, sizeof(*multicast));
+  ops.acquire_state_lock();
+  if (!ops.state_is_active()) {
+    ops.release_state_lock();
+    if (release != NULL)
+      (void)release(driver);
+    free(multicast);
+    return CUDA_ERROR_NOT_READY;
+  }
+  if (multicast == NULL || random_bytes(multicast->id, sizeof(multicast->id)) != 0 ||
+      table_put(&objects, key_bytes(multicast->id), multicast) != 0) {
+    ops.release_state_lock();
+    if (release != NULL)
+      (void)release(driver);
+    free(multicast);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  multicast->properties = *properties;
+  multicast->effective_size = properties->size;
+  multicast->driver = driver;
+  multicast->creator = true;
+  cuinterpose_capture_context(&multicast->context);
+  snprintf(multicast->creator_participant, sizeof(multicast->creator_participant), "%s", participant_id);
+  snprintf(multicast->creator_endpoint, sizeof(multicast->creator_endpoint), "%s", endpoint_path);
+  if (add_handle(multicast, &logical) != 0) {
+    table_remove(&objects, key_bytes(multicast->id));
+    ops.release_state_lock();
+    if (release != NULL)
+      (void)release(driver);
+    free(multicast);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  ops.release_state_lock();
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
-cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+cuMulticastAddDevice(CUmemGenericAllocationHandle application, CUdevice device)
 {
   add_device_fn function = (add_device_fn)cuinterpose_lookup_real_symbol("cuMulticastAddDevice");
+  struct multicast_handle* handle;
+  struct multicast* multicast;
+  CUmemGenericAllocationHandle driver;
+  CUdevice* slot;
+  CUresult result;
 
-  return function != NULL ? function(multicast, device) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterpose_unavailable();
+  ops.acquire_state_lock();
+  handle = find_handle(application);
+  if (handle == NULL) {
+    ops.release_state_lock();
+    if (cuinterpose_is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function(application, device);
+  }
+  if (!ops.state_is_active() || handle->multicast->driver == 0) {
+    ops.release_state_lock();
+    return CUDA_ERROR_NOT_READY;
+  }
+  /* Another team collective: not under the lock. */
+  driver = handle->multicast->driver;
+  ops.release_state_lock();
+  result = function(driver, device);
+  ops.acquire_state_lock();
+  if (result != CUDA_SUCCESS) {
+    ops.release_state_lock();
+    return result;
+  }
+  handle = find_handle(application);
+  if (handle == NULL || handle->multicast->driver != driver || !ops.state_is_active()) {
+    /* The object went away or a checkpoint began meanwhile; the driver keeps
+     * the device attached, the record cannot. */
+    ops.release_state_lock();
+    return handle == NULL ? CUDA_ERROR_INVALID_HANDLE : CUDA_ERROR_NOT_READY;
+  }
+  multicast = handle->multicast;
+  slot = array_push((void**)&multicast->devices, &multicast->device_count, sizeof(*multicast->devices));
+  if (slot == NULL) {
+    ops.release_state_lock();
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *slot = device;
+  adopt_context(multicast);
+  ops.release_state_lock();
+  return CUDA_SUCCESS;
+}
+
+/* The two bind entry points share everything but how the member is named. */
+static CUresult
+bind(
+    CUmemGenericAllocationHandle application, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUmemGenericAllocationHandle member_handle, CUdeviceptr member_address, size_t member_offset, size_t size,
+    unsigned long long flags, uint8_t kind)
+{
+  struct multicast_handle* handle;
+  struct multicast* multicast;
+  struct multicast_binding binding;
+  struct multicast_binding* slot;
+  struct cuinterpose_multicast_member member;
+  CUmemGenericAllocationHandle driver;
+  bool tracked_member;
+  CUresult result;
+
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  ops.acquire_state_lock();
+  handle = find_handle(application);
+  if (handle == NULL) {
+    ops.release_state_lock();
+    if (cuinterpose_is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    /* An untracked object; a tracked member still needs its driver handle. */
+    if (kind == CUINTERPOSE_MULTICAST_BIND_MEM) {
+      CUmemGenericAllocationHandle member_driver = member_handle;
+
+      (void)cuinterpose_translate_handle(member_handle, &member_driver);
+      return forward_bind_mem(application, device, device_explicit, multicast_offset, member_driver, member_offset, size, flags);
+    }
+    return forward_bind_address(application, device, device_explicit, multicast_offset, member_address, size, flags);
+  }
+  multicast = handle->multicast;
+  if (!ops.state_is_active() || multicast->driver == 0) {
+    ops.release_state_lock();
+    return CUDA_ERROR_NOT_READY;
+  }
+  memset(&member, 0, sizeof(member));
+  memset(&binding, 0, sizeof(binding));
+  if (kind == CUINTERPOSE_MULTICAST_BIND_MEM) {
+    if (ops.member_from_handle(member_handle, &member) != 0) {
+      /* Memory the shim does not track cannot be bound again on restore. */
+      ops.release_state_lock();
+      if (!atomic_exchange(&untracked_member_logged, true))
+        fprintf(stderr, "cuinterpose: refusing to bind memory the shim does not track to a tracked multicast object\n");
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+    tracked_member = true;
+  } else {
+    tracked_member = ops.member_from_address(member_address, size, &member) == 0;
+    if (!tracked_member) {
+      /* Memory outside the shim's records is rebound by address on restore;
+       * its address is preserved by the native restore. */
+      context_device_fn current_device = (context_device_fn)cuinterpose_lookup_real_symbol("cuCtxGetDevice");
+
+      if (random_bytes(member.id, sizeof(member.id)) != 0 ||
+          (!device_explicit && (current_device == NULL || current_device(&device) != CUDA_SUCCESS))) {
+        ops.release_state_lock();
+        return CUDA_ERROR_NOT_SUPPORTED;
+      }
+      member.device = device;
+    }
+    member.address = member_address;
+  }
+  memcpy(binding.member_id, member.id, sizeof(binding.member_id));
+  binding.member_address = kind == CUINTERPOSE_MULTICAST_BIND_ADDR ? member_address : 0;
+  binding.multicast_offset = multicast_offset;
+  binding.member_offset = kind == CUINTERPOSE_MULTICAST_BIND_MEM ? member_offset : member.allocation_offset;
+  binding.size = size;
+  binding.flags = flags;
+  binding.device = device_explicit ? device : member.device;
+  binding.kind = kind;
+  binding.api_version = device_explicit ? 2 : 1;
+  /*
+   * Binding waits until every device of the team has been attached, so it
+   * runs without the lock; see cuinterpose_multicast_map.
+   */
+  driver = multicast->driver;
+  ops.release_state_lock();
+  if (kind == CUINTERPOSE_MULTICAST_BIND_MEM)
+    result = forward_bind_mem(driver, binding.device, device_explicit, multicast_offset, member.handle, member_offset, size, flags);
+  else
+    result = forward_bind_address(driver, binding.device, device_explicit, multicast_offset, member_address, size, flags);
+  ops.acquire_state_lock();
+  if (result != CUDA_SUCCESS) {
+    ops.release_state_lock();
+    return result;
+  }
+  handle = find_handle(application);
+  if (handle == NULL || handle->multicast->driver != driver || !ops.state_is_active()) {
+    if (handle != NULL) {
+      unbind_fn unbind = (unbind_fn)cuinterpose_lookup_real_symbol("cuMulticastUnbind");
+
+      if (unbind != NULL)
+        (void)unbind(driver, binding.device, multicast_offset, size);
+    }
+    ops.release_state_lock();
+    return handle == NULL ? CUDA_ERROR_INVALID_HANDLE : CUDA_ERROR_NOT_READY;
+  }
+  multicast = handle->multicast;
+  slot = array_push((void**)&multicast->bindings, &multicast->binding_count, sizeof(*multicast->bindings));
+  if (slot == NULL) {
+    unbind_fn unbind = (unbind_fn)cuinterpose_lookup_real_symbol("cuMulticastUnbind");
+
+    if (unbind != NULL)
+      (void)unbind(driver, binding.device, multicast_offset, size);
+    ops.release_state_lock();
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *slot = binding;
+  if (tracked_member)
+    ops.mark_member_shared(member.id);
+  observe_extent(multicast, multicast_offset, size);
+  adopt_context(multicast);
+  ops.release_state_lock();
+  return CUDA_SUCCESS;
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
@@ -53,14 +1658,7 @@ cuMulticastBindMem(
     CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUmemGenericAllocationHandle memory,
     size_t memory_offset, size_t size, unsigned long long flags)
 {
-  bind_mem_fn function = (bind_mem_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem");
-  CUmemGenericAllocationHandle driver = memory;
-
-  (void)cuinterpose_ensure_process_endpoint();
-  /* The application binds by its logical handle; the driver needs its own. */
-  (void)cuinterpose_translate_handle(memory, &driver);
-  return function != NULL ? function(multicast, multicast_offset, driver, memory_offset, size, flags)
-                          : cuinterpose_unavailable();
+  return bind(multicast, 0, false, multicast_offset, memory, 0, memory_offset, size, flags, CUINTERPOSE_MULTICAST_BIND_MEM);
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
@@ -68,9 +1666,7 @@ cuMulticastBindAddr(
     CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory, size_t size,
     unsigned long long flags)
 {
-  bind_address_fn function = (bind_address_fn)cuinterpose_lookup_real_symbol("cuMulticastBindAddr");
-
-  return function != NULL ? function(multicast, multicast_offset, memory, size, flags) : cuinterpose_unavailable();
+  return bind(multicast, 0, false, multicast_offset, 0, memory, 0, size, flags, CUINTERPOSE_MULTICAST_BIND_ADDR);
 }
 
 #if CUDA_VERSION >= 13010
@@ -79,13 +1675,7 @@ cuMulticastBindMem_v2(
     CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
     CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
 {
-  bind_mem_v2_fn function = (bind_mem_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindMem_v2");
-  CUmemGenericAllocationHandle driver = memory;
-
-  (void)cuinterpose_ensure_process_endpoint();
-  (void)cuinterpose_translate_handle(memory, &driver);
-  return function != NULL ? function(multicast, device, multicast_offset, driver, memory_offset, size, flags)
-                          : cuinterpose_unavailable();
+  return bind(multicast, device, true, multicast_offset, memory, 0, memory_offset, size, flags, CUINTERPOSE_MULTICAST_BIND_MEM);
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
@@ -93,10 +1683,7 @@ cuMulticastBindAddr_v2(
     CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
     unsigned long long flags)
 {
-  bind_address_v2_fn function = (bind_address_v2_fn)cuinterpose_lookup_real_symbol("cuMulticastBindAddr_v2");
-
-  return function != NULL ? function(multicast, device, multicast_offset, memory, size, flags)
-                          : cuinterpose_unavailable();
+  return bind(multicast, device, true, multicast_offset, 0, memory, 0, size, flags, CUINTERPOSE_MULTICAST_BIND_ADDR);
 }
 #endif
 
@@ -110,9 +1697,44 @@ cuMulticastGetGranularity(
 }
 
 CUINTERPOSE_API CUresult CUDAAPI
-cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+cuMulticastUnbind(CUmemGenericAllocationHandle application, CUdevice device, size_t offset, size_t size)
 {
   unbind_fn function = (unbind_fn)cuinterpose_lookup_real_symbol("cuMulticastUnbind");
+  struct multicast_handle* handle;
+  struct multicast* multicast;
+  size_t index;
+  CUresult result;
 
-  return function != NULL ? function(multicast, device, offset, size) : cuinterpose_unavailable();
+  if ((result = cuinterpose_ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return cuinterpose_unavailable();
+  ops.acquire_state_lock();
+  handle = find_handle(application);
+  if (handle == NULL) {
+    ops.release_state_lock();
+    if (cuinterpose_is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function(application, device, offset, size);
+  }
+  multicast = handle->multicast;
+  if (!ops.state_is_active() || multicast->driver == 0) {
+    ops.release_state_lock();
+    return CUDA_ERROR_NOT_READY;
+  }
+  /* Unbind is not a collective: it runs under the lock. */
+  result = function(multicast->driver, device, offset, size);
+  if (result == CUDA_SUCCESS) {
+    for (index = 0; index < multicast->binding_count; index++) {
+      struct multicast_binding* binding = &multicast->bindings[index];
+
+      if (binding->device == device && binding->multicast_offset == offset && binding->size == size) {
+        multicast->bindings[index] = multicast->bindings[multicast->binding_count - 1];
+        multicast->binding_count--;
+        break;
+      }
+    }
+  }
+  ops.release_state_lock();
+  return result;
 }

--- a/agent/cmd/cuinterpose/multicast.h
+++ b/agent/cmd/cuinterpose/multicast.h
@@ -9,9 +9,90 @@
 
 /*
  * CUDA multicast objects (cuMulticast*) let several GPUs write one buffer
- * through NVLink. This layer forwards the entry points, translating tracked
- * unicast handles for the bind calls; tracking and checkpoint of multicast
- * groups is added in a later change.
+ * through NVLink: a team of devices is attached to an object, each rank binds
+ * a slice of its own memory to it, and everyone maps the object into their
+ * address space. NCCL's NVLS and PyTorch's symmetric memory build on this.
+ *
+ * This module tracks the objects created with the POSIX file-descriptor handle
+ * type exactly as interpose.c tracks unicast allocations: the application
+ * holds logical handles, one driver handle per object per process sits behind
+ * them, sharing goes through tickets served from the export cache, and the
+ * coordinator tears the objects down before the native checkpoint and rebuilds
+ * them afterwards in four phases (create, import, add devices, bind and map)
+ * with a barrier after each, because binding waits for the whole team to be
+ * attached.
+ *
+ * Everything here runs under interpose.c's state_lock unless noted. The bind,
+ * map, and add-device calls are team collectives that can block until the
+ * other ranks arrive, so the lock is dropped around them and the object is
+ * looked up again afterwards.
  */
+
+#include <cuda.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "posix.h"
+#include "protocol.h"
+
+/* A tracked unicast allocation as seen from a multicast binding. */
+struct cuinterpose_multicast_member {
+  uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE];
+  CUmemGenericAllocationHandle handle; /* driver handle, for cuMulticastBindMem */
+  CUdeviceptr address; /* for cuMulticastBindAddr */
+  size_t allocation_offset;
+  CUdevice device;
+  bool temporary_handle; /* the caller must cuMemRelease `handle` when done */
+};
+
+/* What interpose.c provides: logical handle numbers, member lookups, the lock. */
+struct cuinterpose_multicast_callbacks {
+  int (*allocate_logical_handle)(CUmemGenericAllocationHandle* output);
+  int (*member_from_handle)(CUmemGenericAllocationHandle logical, struct cuinterpose_multicast_member* member);
+  int (*member_from_address)(CUdeviceptr address, size_t size, struct cuinterpose_multicast_member* member);
+  int (*member_from_id)(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE], struct cuinterpose_multicast_member* member);
+  void (*mark_member_shared)(const uint8_t id[CUINTERPOSE_ALLOCATION_ID_SIZE]);
+  void (*release_state_lock)(void);
+  void (*acquire_state_lock)(void);
+  bool (*state_is_active)(void); /* PHASE_ACTIVE; re-checked after every lock drop */
+};
+
+/* participant_id and endpoint point at interpose.c's buffers, filled in later. */
+void cuinterpose_multicast_initialize(
+    const struct cuinterpose_multicast_callbacks* callbacks, const char* participant_id, const char* endpoint);
+/* The child of fork() owns none of the parent's objects. */
+void cuinterpose_multicast_fork_child(void);
+size_t cuinterpose_multicast_count(void);
+
+/* Entry points interpose.c dispatches to when a handle or range is a multicast one. Lock held. */
+bool cuinterpose_multicast_is_handle(CUmemGenericAllocationHandle logical);
+bool cuinterpose_multicast_owns_range(CUdeviceptr address, size_t size);
+CUresult cuinterpose_multicast_release(CUmemGenericAllocationHandle logical);
+/* CUDA_ERROR_INVALID_VALUE when address is not inside a multicast mapping. */
+CUresult cuinterpose_multicast_retain(CUmemGenericAllocationHandle* output, void* address);
+/* Drops and reacquires the lock around the driver call. */
+CUresult cuinterpose_multicast_map(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle logical, unsigned long long flags);
+CUresult cuinterpose_multicast_unmap(CUdeviceptr address, size_t size);
+CUresult cuinterpose_multicast_set_access(
+    CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count);
+CUresult cuinterpose_multicast_export(
+    void* shareable, CUmemGenericAllocationHandle logical, CUmemAllocationHandleType type, unsigned long long flags);
+CUresult cuinterpose_multicast_get_properties(CUmemAllocationProp* properties, CUmemGenericAllocationHandle logical);
+/* Lock NOT held: talks to the creator's listener and the driver first. */
+CUresult cuinterpose_multicast_import(CUmemGenericAllocationHandle* output, const struct cuinterpose_posix_ticket* ticket);
+
+/* INSPECT records for every live object: the object, its devices, its
+ * bindings, and its mappings, in that order. Lock held. */
+size_t cuinterpose_multicast_record_count(void);
+int cuinterpose_multicast_write_records(struct cuinterpose_record* records, size_t count, const char** error);
+
+/* Lifecycle, lock held. Errors are static strings (or written to message). */
+int cuinterpose_multicast_prepare(const char** error);
+int cuinterpose_multicast_restore_creators(const char** error);
+int cuinterpose_multicast_restore_importers(char* message, size_t message_size);
+int cuinterpose_multicast_restore_devices(const char** error);
+int cuinterpose_multicast_restore_bindings(const char** error);
 
 #endif

--- a/agent/cmd/cuinterpose/tests/fake_cuda.c
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.c
@@ -78,13 +78,34 @@ record(const char* function)
 #define FAKE_MAX_HANDLES 4096
 #define FAKE_MAX_MAPPINGS 4096
 #define FAKE_HANDLE_BASE 0x1000
+#define FAKE_MAX_MULTICAST_DEVICES 8
+#define FAKE_MAX_MULTICAST_BINDINGS 16
 #define FAKE_EXPORT_MAGIC "fake-cuda-export:"
+
+/* A multicast object's binding: which device bound which member slice where. */
+struct fake_binding {
+  int used;
+  CUdevice device;
+  size_t offset;
+  size_t size;
+  int member;
+  size_t member_offset;
+  CUdeviceptr member_address;
+  int kind; /* 1: BindMem, 2: BindAddr */
+};
 
 struct fake_allocation {
   int used;
   int refs;
   size_t size;
   CUmemAllocationProp properties;
+  /* Multicast objects share the handle/mapping/export machinery. */
+  int multicast;
+  size_t capacity; /* like the real driver, rounded up above the requested size */
+  CUmulticastObjectProp multicast_properties;
+  CUdevice devices[FAKE_MAX_MULTICAST_DEVICES];
+  int device_count;
+  struct fake_binding bindings[FAKE_MAX_MULTICAST_BINDINGS];
 };
 
 struct fake_handle {
@@ -165,6 +186,7 @@ new_allocation(size_t size, const CUmemAllocationProp* properties)
 
   for (index = 0; index < FAKE_MAX_ALLOCATIONS; index++) {
     if (!allocations[index].used) {
+      memset(&allocations[index], 0, sizeof(allocations[index]));
       allocations[index].used = 1;
       allocations[index].refs = 0;
       allocations[index].size = size;
@@ -478,7 +500,11 @@ fakeCuMemExportToShareableHandle(
       return CUDA_ERROR_INVALID_HANDLE;
     }
     export_calls++;
-    snprintf(text, sizeof(text), FAKE_EXPORT_MAGIC "%d", handles[index].allocation);
+    /* Enough for a foreign process to model the same object. */
+    snprintf(
+        text, sizeof(text), FAKE_EXPORT_MAGIC "%d:%d:%zu:%zu:%d", handles[index].allocation,
+        allocations[handles[index].allocation].multicast, allocations[handles[index].allocation].size,
+        allocations[handles[index].allocation].capacity, allocations[handles[index].allocation].properties.location.id);
     /* The real driver's descriptor holds a reference until it is closed; this
      * model cannot observe close(), so the descriptor is not counted here. */
     pthread_mutex_unlock(&model_lock);
@@ -507,8 +533,12 @@ fakeCuMemImportFromShareableHandle(
     CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
 {
   if (tracked) {
-    char text[64] = {0};
+    char text[128] = {0};
     int allocation = -1;
+    int multicast = 0;
+    int location = 0;
+    size_t size = 0;
+    size_t capacity = 0;
     CUmemGenericAllocationHandle handle = 0;
     record("cuMemImportFromShareableHandle");
     last.pointer = os_handle;
@@ -516,12 +546,20 @@ fakeCuMemImportFromShareableHandle(
     if (output == NULL)
       return CUDA_ERROR_INVALID_VALUE;
     if (pread((int)(uintptr_t)os_handle, text, sizeof(text) - 1, 0) > 0 &&
-        strncmp(text, FAKE_EXPORT_MAGIC, strlen(FAKE_EXPORT_MAGIC)) == 0)
-      allocation = atoi(text + strlen(FAKE_EXPORT_MAGIC));
+        strncmp(text, FAKE_EXPORT_MAGIC, strlen(FAKE_EXPORT_MAGIC)) == 0 &&
+        sscanf(text + strlen(FAKE_EXPORT_MAGIC), "%d:%d:%zu:%zu:%d", &allocation, &multicast, &size, &capacity,
+               &location) != 5)
+      allocation = -1;
     pthread_mutex_lock(&model_lock);
     if (allocation < 0 || allocation >= FAKE_MAX_ALLOCATIONS || !allocations[allocation].used) {
-      /* Not one of ours: model a descriptor from some other process. */
-      allocation = new_allocation(0, NULL);
+      /* Not one of ours: model the other process's object from its description. */
+      allocation = new_allocation(size, NULL);
+      if (allocation >= 0) {
+        allocations[allocation].multicast = multicast;
+        allocations[allocation].capacity = capacity;
+        allocations[allocation].properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        allocations[allocation].properties.location.id = location;
+      }
     }
     if (allocation >= 0)
       handle = new_handle(allocation);
@@ -573,9 +611,206 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGen
   return fakeCuMemGetAllocationPropertiesFromHandle(properties, handle);
 }
 
+/* Caller holds model_lock. The multicast allocation behind a handle, or -1. */
+static int
+multicast_index(CUmemGenericAllocationHandle handle)
+{
+  int index = handle_index(handle);
+
+  if (index < 0 || !handles[index].used || !allocations[handles[index].allocation].multicast)
+    return -1;
+  return handles[index].allocation;
+}
+
+static int
+multicast_has_device(const struct fake_allocation* object, CUdevice device)
+{
+  int index;
+
+  for (index = 0; index < object->device_count; index++) {
+    if (object->devices[index] == device)
+      return 1;
+  }
+  return 0;
+}
+
+/* Caller holds model_lock. Records a binding after the same checks the driver makes. */
+static CUresult
+multicast_bind(
+    int object_index, CUdevice device, size_t offset, int member, size_t member_offset, CUdeviceptr member_address,
+    size_t size, int kind)
+{
+  struct fake_allocation* object = &allocations[object_index];
+  int index;
+
+  if (!multicast_has_device(object, device))
+    return CUDA_ERROR_INVALID_VALUE; /* the driver: the device must be attached first */
+  if (size == 0 || offset > object->capacity || size > object->capacity - offset)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (member < 0 || !allocations[member].used || member_offset > allocations[member].size ||
+      size > allocations[member].size - member_offset)
+    return CUDA_ERROR_INVALID_VALUE;
+  for (index = 0; index < FAKE_MAX_MULTICAST_BINDINGS; index++) {
+    if (!object->bindings[index].used) {
+      object->bindings[index].used = 1;
+      object->bindings[index].device = device;
+      object->bindings[index].offset = offset;
+      object->bindings[index].size = size;
+      object->bindings[index].member = member;
+      object->bindings[index].member_offset = member_offset;
+      object->bindings[index].member_address = member_address;
+      object->bindings[index].kind = kind;
+      return CUDA_SUCCESS;
+    }
+  }
+  return CUDA_ERROR_OUT_OF_MEMORY;
+}
+
+/* Caller holds model_lock. The mapping holding [address, address + size), or -1. */
+static int
+mapping_containing(CUdeviceptr address, size_t size, size_t* offset_in_mapping)
+{
+  int index;
+
+  for (index = 0; index < FAKE_MAX_MAPPINGS; index++) {
+    if (mappings[index].used && address >= mappings[index].address && size <= mappings[index].size &&
+        address - mappings[index].address <= mappings[index].size - size) {
+      *offset_in_mapping = (size_t)(address - mappings[index].address);
+      return index;
+    }
+  }
+  return -1;
+}
+
+static CUresult
+tracked_bind_mem(
+    CUmemGenericAllocationHandle multicast, CUdevice device, int device_explicit, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size)
+{
+  int object;
+  int member;
+  CUresult result;
+
+  pthread_mutex_lock(&model_lock);
+  object = multicast_index(multicast);
+  member = handle_index(memory);
+  member = member >= 0 && handles[member].used ? handles[member].allocation : -1;
+  if (object < 0 || member < 0) {
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  if (!device_explicit)
+    device = allocations[member].properties.location.id;
+  result = multicast_bind(object, device, multicast_offset, member, memory_offset, 0, size, 1);
+  pthread_mutex_unlock(&model_lock);
+  return result;
+}
+
+static CUresult
+tracked_bind_address(
+    CUmemGenericAllocationHandle multicast, CUdevice device, int device_explicit, size_t multicast_offset,
+    CUdeviceptr memory, size_t size)
+{
+  int object;
+  int mapping;
+  size_t offset_in_mapping = 0;
+  CUresult result;
+
+  pthread_mutex_lock(&model_lock);
+  object = multicast_index(multicast);
+  mapping = mapping_containing(memory, size, &offset_in_mapping);
+  if (object < 0) {
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  if (mapping < 0) {
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (!device_explicit)
+    device = allocations[mappings[mapping].allocation].properties.location.id;
+  result = multicast_bind(
+      object, device, multicast_offset, mappings[mapping].allocation, offset_in_mapping, memory, size, 2);
+  pthread_mutex_unlock(&model_lock);
+  return result;
+}
+
+int
+fakeMulticastObjects(void)
+{
+  int index;
+  int count = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_ALLOCATIONS; index++)
+    count += allocations[index].used && allocations[index].multicast;
+  pthread_mutex_unlock(&model_lock);
+  return count;
+}
+
+int
+fakeMulticastDevices(void)
+{
+  int index;
+  int count = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_ALLOCATIONS; index++) {
+    if (allocations[index].used && allocations[index].multicast)
+      count += allocations[index].device_count;
+  }
+  pthread_mutex_unlock(&model_lock);
+  return count;
+}
+
+int
+fakeMulticastBindings(int kind)
+{
+  int index;
+  int binding;
+  int count = 0;
+
+  pthread_mutex_lock(&model_lock);
+  for (index = 0; index < FAKE_MAX_ALLOCATIONS; index++) {
+    if (!allocations[index].used || !allocations[index].multicast)
+      continue;
+    for (binding = 0; binding < FAKE_MAX_MULTICAST_BINDINGS; binding++) {
+      if (allocations[index].bindings[binding].used && (kind == 0 || allocations[index].bindings[binding].kind == kind))
+        count++;
+    }
+  }
+  pthread_mutex_unlock(&model_lock);
+  return count;
+}
+
 CUresult CUDAAPI
 fakeCuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
 {
+  if (tracked) {
+    int allocation;
+    CUmemGenericAllocationHandle handle = 0;
+
+    record("cuMulticastCreate");
+    if (output == NULL || properties == NULL || properties->size == 0)
+      return CUDA_ERROR_INVALID_VALUE;
+    if (should_fail("cuMulticastCreate"))
+      return CUDA_ERROR_UNKNOWN;
+    pthread_mutex_lock(&model_lock);
+    allocation = new_allocation(properties->size, NULL);
+    if (allocation >= 0) {
+      allocations[allocation].multicast = 1;
+      allocations[allocation].multicast_properties = *properties;
+      /* Like r615, which rounds a multicast object's capacity up. */
+      allocations[allocation].capacity =
+          (properties->size + FAKE_MULTICAST_GRANULARITY - 1) / FAKE_MULTICAST_GRANULARITY * FAKE_MULTICAST_GRANULARITY;
+      handle = new_handle(allocation);
+    }
+    pthread_mutex_unlock(&model_lock);
+    if (handle == 0)
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    *output = handle;
+    return CUDA_SUCCESS;
+  }
   record("cuMulticastCreate");
   last.pointer = (void*)properties;
   last.size = properties != NULL ? properties->size : 0;
@@ -592,6 +827,26 @@ cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectP
 CUresult CUDAAPI
 fakeCuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
 {
+  if (tracked) {
+    int object;
+    struct fake_allocation* allocation;
+
+    record("cuMulticastAddDevice");
+    pthread_mutex_lock(&model_lock);
+    object = multicast_index(multicast);
+    if (object < 0) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    allocation = &allocations[object];
+    if (multicast_has_device(allocation, device) || allocation->device_count == FAKE_MAX_MULTICAST_DEVICES) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    allocation->devices[allocation->device_count++] = device;
+    pthread_mutex_unlock(&model_lock);
+    return CUDA_SUCCESS;
+  }
   record("cuMulticastAddDevice");
   last.handle = multicast;
   last.device = device;
@@ -609,6 +864,11 @@ fakeCuMulticastBindMem(
     CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUmemGenericAllocationHandle memory,
     size_t memory_offset, size_t size, unsigned long long flags)
 {
+  if (tracked) {
+    record("cuMulticastBindMem");
+    (void)flags;
+    return tracked_bind_mem(multicast, 0, 0, multicast_offset, memory, memory_offset, size);
+  }
   record("cuMulticastBindMem");
   last.handle = multicast;
   last.offset = multicast_offset;
@@ -631,6 +891,11 @@ fakeCuMulticastBindAddr(
     CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory, size_t size,
     unsigned long long flags)
 {
+  if (tracked) {
+    record("cuMulticastBindAddr");
+    (void)flags;
+    return tracked_bind_address(multicast, 0, 0, multicast_offset, memory, size);
+  }
   record("cuMulticastBindAddr");
   last.handle = multicast;
   last.offset = multicast_offset;
@@ -653,6 +918,11 @@ fakeCuMulticastBindMem_v2(
     CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
     CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
 {
+  if (tracked) {
+    record("cuMulticastBindMem_v2");
+    (void)flags;
+    return tracked_bind_mem(multicast, device, 1, multicast_offset, memory, memory_offset, size);
+  }
   record("cuMulticastBindMem_v2");
   last.handle = multicast;
   last.device = device;
@@ -677,6 +947,11 @@ fakeCuMulticastBindAddr_v2(
     CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
     unsigned long long flags)
 {
+  if (tracked) {
+    record("cuMulticastBindAddr_v2");
+    (void)flags;
+    return tracked_bind_address(multicast, device, 1, multicast_offset, memory, size);
+  }
   record("cuMulticastBindAddr_v2");
   last.handle = multicast;
   last.device = device;
@@ -717,6 +992,29 @@ cuMulticastGetGranularity(
 CUresult CUDAAPI
 fakeCuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
 {
+  if (tracked) {
+    int object;
+    int index;
+    CUresult result = CUDA_ERROR_INVALID_VALUE;
+
+    record("cuMulticastUnbind");
+    pthread_mutex_lock(&model_lock);
+    object = multicast_index(multicast);
+    if (object < 0) {
+      pthread_mutex_unlock(&model_lock);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    for (index = 0; index < FAKE_MAX_MULTICAST_BINDINGS; index++) {
+      struct fake_binding* binding = &allocations[object].bindings[index];
+      if (binding->used && binding->device == device && binding->offset == offset && binding->size == size) {
+        binding->used = 0;
+        result = CUDA_SUCCESS;
+        break;
+      }
+    }
+    pthread_mutex_unlock(&model_lock);
+    return result;
+  }
   record("cuMulticastUnbind");
   last.handle = multicast;
   last.device = device;

--- a/agent/cmd/cuinterpose/tests/fake_cuda.h
+++ b/agent/cmd/cuinterpose/tests/fake_cuda.h
@@ -99,6 +99,20 @@ int fakePrimaryContextRetainCalls(void);
 int fakePrimaryContextsHeld(void);
 /* Number of cuMemSetAccess calls since the last reset. */
 int fakeAccessCalls(void);
+/*
+ * Multicast objects in tracked mode: cuMulticastCreate makes an allocation
+ * flagged as multicast whose capacity is rounded up to
+ * FAKE_MULTICAST_GRANULARITY (as r615 does), devices must be added before a
+ * bind names them, and bindings are checked against the capacity and the
+ * member's size. Handles, mappings, export and import work as for any
+ * allocation.
+ */
+#define FAKE_MULTICAST_GRANULARITY (4u << 20)
+int fakeMulticastObjects(void);
+/* Devices attached across all live multicast objects. */
+int fakeMulticastDevices(void);
+/* Bindings across all live objects; kind 0 = any, 1 = BindMem, 2 = BindAddr. */
+int fakeMulticastBindings(int kind);
 /* The fake's own implementation of `symbol`, bypassing any interposer. */
 void* fakeOriginal(const char* symbol);
 /* Same, for a caller that asked for a specific CUDA version. */

--- a/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/lifecycle_preload_test.cc
@@ -285,7 +285,7 @@ TEST_F(Lifecycle, FailedHostCopyLeavesTheWorkloadIntactAndFailsClosed) {
   EXPECT_NE(stat((checkpoint + "/" + CUINTERPOSE_STATE_FILENAME).c_str(), &st), 0) << "no state file on failure";
   EXPECT_EQ(fakeRegisteredHostRanges(), 0) << "partial host carriers were released";
   EXPECT_EQ(fakeMappedCount(), 1) << "the mapping was never touched";
-  // The shim is in the failed phase: IDENTIFY reports it, and the application
+  // The shim is in the failed phase: HANDSHAKE reports it, and the application
   // cannot continue with VMM calls. This is the documented fail-stop behavior.
   EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_FAILED));
   EXPECT_EQ(cuMemUnmap(0x10000000, 1 << 20), CUDA_ERROR_NOT_READY);

--- a/agent/cmd/cuinterpose/tests/multicast_preload_test.cc
+++ b/agent/cmd/cuinterpose/tests/multicast_preload_test.cc
@@ -1,0 +1,436 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Multicast objects through the shim over the fake driver: two processes (this
+// one and a forked child) build a two-device multicast group the way NCCL or
+// PyTorch symmetric memory does, then the real coordinator takes it apart and
+// puts it back. Also the effective extent (the driver accepting more than was
+// asked for), unbinding and rebinding by address, pass-through of non-POSIX
+// objects, and the order in which PREPARE_MULTICAST closes the cached
+// descriptor and releases the object.
+
+#include <cuda.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "../export.h"
+#include "../protocol.h"
+#include "coordinator_driver.h"
+#include "fake_cuda.h"
+
+// cuda.h maps these names to the _v2 entry points; the tests call the names.
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+extern "C" {
+CUresult cuMulticastBindMem(
+    CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+CUresult cuMulticastBindAddr(CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+}
+
+namespace {
+
+constexpr size_t kMiB = 1 << 20;
+
+struct cuinterpose_debug_stats stats() {
+  using fn = void (*)(struct cuinterpose_debug_stats*);
+  static fn read = reinterpret_cast<fn>(dlsym(RTLD_DEFAULT, "cuinterpose_debug_stats"));
+  struct cuinterpose_debug_stats s{};
+  if (read) read(&s);
+  return s;
+}
+
+CUmemAllocationProp posix_props(int device) {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = device;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+CUmulticastObjectProp multicast_props(unsigned devices, size_t size) {
+  CUmulticastObjectProp prop{};
+  prop.numDevices = devices;
+  prop.size = size;
+  prop.handleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+bool is_logical(CUmemGenericAllocationHandle handle) { return (handle >> 48) == 0xd94d; }
+
+// A mapped, device-accessible allocation.
+CUmemGenericAllocationHandle mapped_allocation(int device, CUdeviceptr address, size_t size) {
+  CUmemAllocationProp prop = posix_props(device);
+  CUmemGenericAllocationHandle handle = 0;
+  if (cuMemCreate(&handle, size, &prop, 0) != CUDA_SUCCESS) return 0;
+  if (cuMemMap(address, size, 0, handle, 0) != CUDA_SUCCESS) return 0;
+  CUmemAccessDesc access{};
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.location.id = device;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  if (cuMemSetAccess(address, size, &access, 1) != CUDA_SUCCESS) return 0;
+  return handle;
+}
+
+class Multicast : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { fakeEnableTrackedBehavior(); }
+  void SetUp() override {
+    ASSERT_NE(getenv("CUINTERPOSE_COORDINATOR"), nullptr) << "set CUINTERPOSE_COORDINATOR";
+    fakeResetModel();
+    char tmpl[] = "/tmp/cuinterpose-multicast-XXXXXX";
+    ASSERT_NE(mkdtemp(tmpl), nullptr);
+    checkpoint = tmpl;
+  }
+  void TearDown() override {
+    std::error_code ignored;
+    std::filesystem::remove_all(checkpoint, ignored);
+  }
+  std::string checkpoint;
+};
+
+enum Command : int { kJoin = 1, kCheckRestored = 2, kRelease = 3, kQuit = 4 };
+
+// Rank 0 (this process) creates a two-device object, attaches device 0, binds
+// its own memory with cuMulticastBindMem and maps the object. Rank 1 (the
+// child) imports the object through a ticket, attaches device 1, binds its
+// slice with cuMulticastBindAddr_v2 and maps it too. Both survive the round
+// trip: the fake driver on each side shows the object, its devices, its
+// binding and its mapping again, and the export cache holds the object again.
+TEST_F(Multicast, TwoRanksCheckpointAndRestoreAGroup) {
+#if CUDA_VERSION < 13010
+  GTEST_SKIP() << "needs the device-explicit bind entry points";
+#else
+  CUmemGenericAllocationHandle member = mapped_allocation(0, 0x10000000, kMiB);
+  ASSERT_NE(member, 0u);
+  CUmulticastObjectProp props = multicast_props(2, kMiB);
+  CUmemGenericAllocationHandle group = 0;
+  ASSERT_EQ(cuMulticastCreate(&group, &props), CUDA_SUCCESS);
+  EXPECT_TRUE(is_logical(group)) << "the application sees a logical handle";
+  ASSERT_EQ(cuMulticastAddDevice(group, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastBindMem(group, 0, member, 0, kMiB, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x70000000, kMiB, 0, group, 0), CUDA_SUCCESS);
+  CUmemAccessDesc access{};
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  ASSERT_EQ(cuMemSetAccess(0x70000000, kMiB, &access, 1), CUDA_SUCCESS);
+  int member_ticket = -1, group_ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&member_ticket, member, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemExportToShareableHandle(&group_ticket, group, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  EXPECT_EQ(stats().multicasts, 1u);
+  EXPECT_EQ(stats().cached_exports, 2u) << "one real export each for the member and the object";
+  EXPECT_EQ(fakeMulticastObjects(), 1);
+  EXPECT_EQ(fakeMulticastDevices(), 1);
+  EXPECT_EQ(fakeMulticastBindings(0), 1);
+  EXPECT_EQ(fakeExportCalls(), 2);
+
+  int to_child[2], from_child[2];
+  ASSERT_EQ(pipe(to_child), 0);
+  ASSERT_EQ(pipe(from_child), 0);
+  pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(to_child[1]);
+    close(from_child[0]);
+    fakeResetModel();
+    CUmemGenericAllocationHandle imported_member = 0, imported_group = 0;
+    for (;;) {
+      int command = 0;
+      if (read(to_child[0], &command, sizeof(command)) != static_cast<ssize_t>(sizeof(command))) _exit(2);
+      int result = 0;
+      switch (command) {
+        case kJoin: {
+          if (cuMemImportFromShareableHandle(&imported_member, reinterpret_cast<void*>(static_cast<intptr_t>(member_ticket)),
+                                             CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS)
+            result |= 1;
+          if (cuMemMap(0x30000000, kMiB, 0, imported_member, 0) != CUDA_SUCCESS) result |= 2;
+          CUmemAccessDesc peer{};
+          peer.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+          peer.location.id = 1;
+          peer.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+          if (cuMemSetAccess(0x30000000, kMiB, &peer, 1) != CUDA_SUCCESS) result |= 4;
+          if (cuMemImportFromShareableHandle(&imported_group, reinterpret_cast<void*>(static_cast<intptr_t>(group_ticket)),
+                                             CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS)
+            result |= 8;
+          if (!is_logical(imported_group)) result |= 16;
+          if (cuMulticastAddDevice(imported_group, 1) != CUDA_SUCCESS) result |= 32;
+          if (cuMulticastBindAddr_v2(imported_group, 1, 0, 0x30000000, kMiB, 0) != CUDA_SUCCESS) result |= 64;
+          if (cuMemMap(0x80000000, kMiB, 0, imported_group, 0) != CUDA_SUCCESS) result |= 128;
+          if (cuMemSetAccess(0x80000000, kMiB, &peer, 1) != CUDA_SUCCESS) result |= 256;
+          if (stats().multicasts != 1 || fakeMulticastObjects() != 1 || fakeMulticastDevices() != 1 ||
+              fakeMulticastBindings(2) != 1)
+            result |= 512;
+          break;
+        }
+        case kCheckRestored: {
+          struct cuinterpose_debug_stats s = stats();
+          if (s.phase != CUINTERPOSE_PHASE_ACTIVE) result |= 1;
+          if (s.multicasts != 1 || s.allocations != 1) result |= 2;
+          if (fakeMulticastObjects() != 1 || fakeMulticastDevices() != 1 || fakeMulticastBindings(2) != 1) result |= 4;
+          if (fakeMappedCount() != 2) result |= 8;  // the member and the object are mapped again
+          CUmemAllocationProp got{};
+          if (cuMemGetAllocationPropertiesFromHandle(&got, imported_group) != CUDA_SUCCESS) result |= 16;
+          break;
+        }
+        case kRelease:
+          if (cuMemUnmap(0x80000000, kMiB) != CUDA_SUCCESS) result |= 1;
+          if (cuMulticastUnbind(imported_group, 1, 0, kMiB) != CUDA_SUCCESS) result |= 2;
+          if (cuMemRelease(imported_group) != CUDA_SUCCESS) result |= 4;
+          if (stats().multicasts != 0 || fakeMulticastObjects() != 0) result |= 8;
+          if (cuMemUnmap(0x30000000, kMiB) != CUDA_SUCCESS) result |= 16;
+          if (cuMemRelease(imported_member) != CUDA_SUCCESS) result |= 32;
+          if (stats().allocations != 0) result |= 64;
+          break;
+        case kQuit:
+          _exit(0);
+      }
+      if (write(from_child[1], &result, sizeof(result)) != static_cast<ssize_t>(sizeof(result))) _exit(3);
+    }
+  }
+  close(to_child[0]);
+  close(from_child[1]);
+  auto tell = [&](int command) {
+    int result = -1;
+    EXPECT_EQ(write(to_child[1], &command, sizeof(command)), static_cast<ssize_t>(sizeof(command)));
+    EXPECT_EQ(read(from_child[0], &result, sizeof(result)), static_cast<ssize_t>(sizeof(result)));
+    return result;
+  };
+  EXPECT_EQ(tell(kJoin), 0) << "child could not join the group";
+
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid(), child});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_NE(prepare.out.find("phase=prepare_multicast status=ok"), std::string::npos) << prepare.out;
+  EXPECT_EQ(fakeMulticastObjects(), 0) << "the object was released for the native checkpoint";
+  EXPECT_EQ(fakeMulticastBindings(0), 0);
+  EXPECT_EQ(fakeMappedCount(), 0);
+  EXPECT_EQ(stats().multicasts, 1u) << "the record stays for restore";
+  EXPECT_EQ(stats().cached_exports, 0u);
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_PREPARED));
+
+  Outcome restore = coordinate("--restore", checkpoint, {getpid(), child});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_NE(restore.out.find("phase=restore_multicast status=ok"), std::string::npos) << restore.out;
+  EXPECT_EQ(stats().phase, static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE));
+  EXPECT_EQ(fakeMulticastObjects(), 1);
+  EXPECT_EQ(fakeMulticastDevices(), 1);
+  EXPECT_EQ(fakeMulticastBindings(1), 1) << "the BindMem binding is back";
+  EXPECT_EQ(fakeMappedCount(), 2) << "the member and the object are mapped again";
+  EXPECT_EQ(stats().cached_exports, 2u) << "both descriptors were exported again";
+  EXPECT_EQ(fakeExportCalls(), 4);
+  EXPECT_EQ(tell(kCheckRestored), 0) << "child did not see its group restored";
+
+  // Sharing goes on: the old ticket imports again (aliasing the driver handle here).
+  CUmemGenericAllocationHandle again = 0;
+  EXPECT_EQ(cuMemImportFromShareableHandle(&again, reinterpret_cast<void*>(static_cast<intptr_t>(group_ticket)),
+                                           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(again), CUDA_SUCCESS);
+
+  EXPECT_EQ(tell(kRelease), 0);
+  int quit = kQuit;
+  EXPECT_EQ(write(to_child[1], &quit, sizeof(quit)), static_cast<ssize_t>(sizeof(quit)));
+  int status = 0;
+  waitpid(child, &status, 0);
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0) << "child status " << status;
+
+  close(member_ticket);
+  close(group_ticket);
+  EXPECT_EQ(cuMemUnmap(0x70000000, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMulticastUnbind(group, 0, 0, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(group), CUDA_SUCCESS);
+  EXPECT_EQ(stats().multicasts, 0u);
+  EXPECT_EQ(fakeMulticastObjects(), 0);
+  EXPECT_EQ(cuMemUnmap(0x10000000, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(member), CUDA_SUCCESS);
+  EXPECT_EQ(stats().allocations, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+  EXPECT_EQ(stats().cached_exports, 0u);
+#endif
+}
+
+// r615 gives a multicast object more capacity than cuMulticastCreate asked
+// for, and NCCL binds and maps into that extra room. The shim reports the
+// extent actually used, so the coordinator's bounds checks accept it and the
+// same binding comes back after restore.
+TEST_F(Multicast, EffectiveExtentFollowsWhatTheDriverAccepted) {
+  CUmemGenericAllocationHandle member = mapped_allocation(0, 0x10000000, 2 * kMiB);
+  ASSERT_NE(member, 0u);
+  CUmulticastObjectProp props = multicast_props(1, kMiB);  // the fake rounds capacity up to 4 MiB
+  CUmemGenericAllocationHandle group = 0;
+  ASSERT_EQ(cuMulticastCreate(&group, &props), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastAddDevice(group, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastBindMem(group, kMiB, member, 0, kMiB, 0), CUDA_SUCCESS) << "binding beyond the requested size";
+  ASSERT_EQ(cuMemMap(0x70000000, 2 * kMiB, 0, group, 0), CUDA_SUCCESS) << "mapping beyond the requested size";
+
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeMulticastBindings(1), 1);
+  EXPECT_EQ(fakeMappedCount(), 2);
+
+  EXPECT_EQ(cuMemUnmap(0x70000000, 2 * kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMulticastUnbind(group, 0, kMiB, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(group), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemUnmap(0x10000000, 2 * kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(member), CUDA_SUCCESS);
+  EXPECT_EQ(stats().multicasts, 0u);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+// PyTorch's symmetric memory unbinds the slice cuMulticastBindMem bound and
+// binds it again by address. The record follows, and restore replays the
+// address binding.
+TEST_F(Multicast, UnbindThenBindByAddressIsRestored) {
+  CUmemGenericAllocationHandle member = mapped_allocation(0, 0x10000000, kMiB);
+  ASSERT_NE(member, 0u);
+  CUmulticastObjectProp props = multicast_props(1, kMiB);
+  CUmemGenericAllocationHandle group = 0;
+  ASSERT_EQ(cuMulticastCreate(&group, &props), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastAddDevice(group, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastBindMem(group, 0, member, 0, kMiB, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastUnbind(group, 0, 0, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(fakeMulticastBindings(0), 0);
+  ASSERT_EQ(cuMulticastBindAddr(group, 0, 0x10000000, kMiB, 0), CUDA_SUCCESS);
+  EXPECT_EQ(fakeMulticastBindings(2), 1);
+  ASSERT_EQ(cuMemMap(0x70000000, kMiB, 0, group, 0), CUDA_SUCCESS);
+
+  Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+  EXPECT_EQ(prepare.status, 0) << prepare.err << prepare.out;
+  EXPECT_EQ(fakeMulticastBindings(0), 0);
+  Outcome restore = coordinate("--restore", checkpoint, {getpid()});
+  EXPECT_EQ(restore.status, 0) << restore.err << restore.out;
+  EXPECT_EQ(fakeMulticastBindings(2), 1) << "the address binding came back";
+  EXPECT_EQ(fakeMulticastBindings(1), 0) << "the unbound BindMem binding did not";
+
+  EXPECT_EQ(cuMemUnmap(0x70000000, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(group), CUDA_SUCCESS);
+  EXPECT_EQ(fakeMulticastObjects(), 0) << "releasing the last handle of an unmapped object destroys it";
+  EXPECT_EQ(cuMemUnmap(0x10000000, kMiB), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(member), CUDA_SUCCESS);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+// Unsupported exportable multicast objects run normally, but checkpoint is
+// rejected before PREPARE_MULTICAST because they cannot yet be reconstructed.
+TEST_F(Multicast, UnsupportedExportableObjectsPassThroughButBlockCheckpoint) {
+  pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    CUmulticastObjectProp props = multicast_props(1, kMiB);
+    props.handleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+    CUmemGenericAllocationHandle raw = 0;
+    int result = 0;
+
+    result |= cuMulticastCreate(&raw, &props) != CUDA_SUCCESS;
+    result |= is_logical(raw);
+    result |= stats().multicasts != 0;
+    result |= stats().unsupported_exportable_creations != 1;
+    result |= cuMulticastAddDevice(raw, 0) != CUDA_SUCCESS;
+    result |= cuMemRelease(raw) != CUDA_SUCCESS;
+    Outcome prepare = coordinate("--prepare", checkpoint, {getpid()});
+    result |= prepare.status == 0;
+    result |= prepare.err.find("unsupported exportable handle types") == std::string::npos;
+    result |= stats().phase != static_cast<uint32_t>(CUINTERPOSE_PHASE_ACTIVE);
+    _exit(result);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0) << "child status " << status;
+}
+
+// Memory the shim does not track cannot be bound to a tracked object: it could
+// not be bound again after restore, so the bind is refused up front.
+TEST_F(Multicast, BindingUntrackedMemoryIsRefused) {
+  CUmemAllocationProp untracked = posix_props(0);
+  untracked.requestedHandleTypes = CU_MEM_HANDLE_TYPE_NONE;
+  CUmemGenericAllocationHandle raw = 0;
+  ASSERT_EQ(cuMemCreate(&raw, kMiB, &untracked, 0), CUDA_SUCCESS);
+  EXPECT_FALSE(is_logical(raw));
+  CUmulticastObjectProp props = multicast_props(1, kMiB);
+  CUmemGenericAllocationHandle group = 0;
+  ASSERT_EQ(cuMulticastCreate(&group, &props), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastAddDevice(group, 0), CUDA_SUCCESS);
+  EXPECT_EQ(cuMulticastBindMem(group, 0, raw, 0, kMiB, 0), CUDA_ERROR_NOT_SUPPORTED);
+  EXPECT_EQ(fakeMulticastBindings(0), 0) << "the driver never saw the bind";
+  EXPECT_EQ(cuMemRelease(group), CUDA_SUCCESS);
+  EXPECT_EQ(cuMemRelease(raw), CUDA_SUCCESS);
+  EXPECT_EQ(fakeLiveAllocations(), 0);
+}
+
+// One control request to this process's own socket, as the coordinator would send it.
+struct cuinterpose_header request_own_shim(uint16_t operation, const char* participant) {
+  struct cuinterpose_header request{};
+  struct cuinterpose_header reply{};
+  reply.status = -1;
+  request.magic = CUINTERPOSE_MAGIC;
+  request.version = CUINTERPOSE_VERSION;
+  request.operation = operation;
+  if (participant != nullptr) snprintf(request.participant_id, sizeof(request.participant_id), "%s", participant);
+  std::string path = std::string(getenv("SNAPSHOT_CONTROL_DIR")) + "/" + CUINTERPOSE_SOCKET_PREFIX + std::to_string(getpid()) + ".sock";
+  int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) return reply;
+  struct sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", path.c_str());
+  if (connect(fd, reinterpret_cast<struct sockaddr*>(&address), sizeof(address)) == 0 &&
+      send(fd, &request, sizeof(request), MSG_NOSIGNAL) == static_cast<ssize_t>(sizeof(request))) {
+    size_t got = 0;
+    while (got < sizeof(reply)) {
+      ssize_t n = recv(fd, reinterpret_cast<char*>(&reply) + got, sizeof(reply) - got, 0);
+      if (n <= 0) break;
+      got += static_cast<size_t>(n);
+    }
+  }
+  close(fd);
+  return reply;
+}
+
+// The cached export descriptor is an independent reference to the object in
+// the driver. PREPARE_MULTICAST must close it before releasing the object, or
+// the object would outlive the teardown. This test drives that one phase by
+// hand and leaves the shim mid-checkpoint, so it runs last in this binary
+// (gtest runs tests in definition order).
+TEST_F(Multicast, PrepareMulticastClosesTheCachedDescriptorBeforeReleasingTheObject) {
+  CUmemGenericAllocationHandle member = mapped_allocation(0, 0x10000000, kMiB);
+  ASSERT_NE(member, 0u);
+  CUmulticastObjectProp props = multicast_props(1, kMiB);
+  CUmemGenericAllocationHandle group = 0;
+  ASSERT_EQ(cuMulticastCreate(&group, &props), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastAddDevice(group, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMulticastBindMem(group, 0, member, 0, kMiB, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemMap(0x70000000, kMiB, 0, group, 0), CUDA_SUCCESS);
+  int member_ticket = -1, group_ticket = -1;
+  ASSERT_EQ(cuMemExportToShareableHandle(&member_ticket, member, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  ASSERT_EQ(cuMemExportToShareableHandle(&group_ticket, group, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0), CUDA_SUCCESS);
+  ASSERT_EQ(stats().cached_exports, 2u);
+
+  struct cuinterpose_header identity = request_own_shim(CUINTERPOSE_HANDSHAKE, nullptr);
+  ASSERT_EQ(identity.status, 0) << identity.message;
+  struct cuinterpose_header reply = request_own_shim(CUINTERPOSE_PREPARE_MULTICAST, identity.participant_id);
+  EXPECT_EQ(reply.status, 0) << reply.message;
+  EXPECT_EQ(stats().cached_exports, 1u) << "only the unicast descriptor is still cached; PREPARE_UNICAST closes that one";
+  EXPECT_EQ(fakeMulticastObjects(), 0) << "the object itself was released";
+  EXPECT_EQ(fakeMulticastBindings(0), 0);
+  EXPECT_EQ(fakeMappedCount(), 1) << "the member's own mapping is untouched until PREPARE_UNICAST";
+  EXPECT_EQ(stats().multicasts, 1u) << "the record waits for restore";
+  close(member_ticket);
+  close(group_ticket);
+}
+
+}  // namespace

--- a/agent/cmd/cuinterpose/util/table.c
+++ b/agent/cmd/cuinterpose/util/table.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "table.h"
+#include "util/table.h"
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary

Layer 10 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293), based on #218. Closed PR #214 is not in the active stack.

This PR extends logical handles, descriptor tickets, export-cache ownership, inspection, and lifecycle state to CUDA multicast objects used by NCCL NVLS and PyTorch symmetric memory.

Tracked objects use exactly the POSIX FD handle type. Private handle-type-0 multicast objects remain native. Unsupported nonzero handle types run normally but cause preflight refusal before teardown.

### Private versus shared VMM ownership

The updated #218 leaves private VMM allocations to native CUDA checkpoint, even if those allocations are POSIX-export-capable. This layer retains the important exception: successful binding of a tracked allocation into multicast marks that allocation shared. Such members still use the interposer's host-carrier and reconstruction path even when the application never exported a unicast ticket.

Private allocations never exported and never bound into tracked multicast remain mapped with their native handles intact during interposer preparation. Native CUDA owns their checkpoint and restore. Legacy `cuIpc*` ownership is unchanged.

### Multicast lifecycle

The shim records requested properties, observed extent, attached devices, `BindMem`/`BindAddr` bindings, maps, and access grants. Unsupported untracked handle bindings remain refused; address bindings retain their existing native-address contract.

```text
PREPARE_MULTICAST → SAVE_ALLOCATIONS → PREPARE_UNICAST
```

Multicast preparation runs concurrently across participants, closing exports, unmapping ranges, unbinding members, and releasing object handles before shared unicast teardown.

After creator and importer unicast reconstruction, multicast restore uses:

```text
RESTORE_MULTICAST_CREATORS
  → RESTORE_MULTICAST_IMPORTERS
  → RESTORE_MULTICAST_DEVICES
  → RESTORE_MULTICAST_BINDINGS
```

The barriers prevent descriptor-fetch and collective bind/add-device deadlocks. Collective driver calls execute without the main state lock, then revalidate object identity and lifecycle state before committing topology.

## Stack transport

The private-VMM ownership fix is introduced in #218 and merged forward here without rewriting the existing branch history. This update adds no NIXL transfer code, CustomStorage implementation, driver patch, or phase-batching experiment to the interposer stack.

## Validation

Source review confirms that successful tracked multicast binding still sets `allocation->shared`; the inherited shared-only predicate therefore preserves member content. Preparation checks passed: `git diff --check` and strict C syntax checking against CUDA 13.1 headers.

Candidate `a554da95b54d6f375a0f938f45be209b6ba3a986` passes all **74 native fake-driver tests**, including five lifecycle and six multicast tests, with the configured ASan/UBSan instrumentation. Tests used CUDA 13.1 headers, the system GCC/G++ toolchain, cached GoogleTest, and a short control-socket directory. Logs: `stack-private-vmm/pr219-final-tests.log`.

The full stack at exact #220 head `21008b50b93a9879a805665e331e777bb93abf49`, including this update, passed all **3 physical-GPU tests with 0 skips and 0 failures in 19.896 s** on two B200 GPUs on nscale-dev, 2026-09-12 UTC. This is full-stack GPU validation, not a standalone GPU run of #219. Historical results for 73 native tests refer to old stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a`, not this update.

## Contribution notes

This updates the existing stack rather than creating duplicate work. AI assistance was used; human review and actual test results remain required.

GPU compilation used the documented `ALLOW_OLD_CUDA_HEADERS=1` override with CUDA 13.0 headers. No CustomStorage, NIXL, or driver-experiment changes are included in this stack update.
