### PR TITLE
feat: enable cuinterpose for annotated Pods

### DIFF
--- a/api/podcontract/cuinterpose.go
+++ b/api/podcontract/cuinterpose.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// cuinterpose is the CUDA interposer: an LD_PRELOAD library that lets Snapshot
+// checkpoint and restore CUDA memory shared between processes on one node. A
+// Pod opts in with CuinterposeAnnotation. The CUDA tools contract
+// (cudatools.go) puts the shim in every checkpoint target independently of
+// that annotation; shaping only puts the already-mounted shim first in
+// LD_PRELOAD.
+const ldPreloadEnv = "LD_PRELOAD"
+
+// CuinterposeEnabled reports whether a workload opted into the CUDA interposer
+// through CuinterposeAnnotation. An absent annotation disables it; any value
+// other than "enabled" is an error rather than a silent no.
+func CuinterposeEnabled(annotations map[string]string) (bool, error) {
+	raw, found := annotations[CuinterposeAnnotation]
+	if !found {
+		return false, nil
+	}
+	if raw != strings.TrimSpace(raw) {
+		return false, fmt.Errorf("%s must not contain surrounding whitespace", CuinterposeAnnotation)
+	}
+	if raw != CuinterposeAnnotationEnabled {
+		return false, fmt.Errorf("%s must be %q", CuinterposeAnnotation, CuinterposeAnnotationEnabled)
+	}
+	return true, nil
+}
+
+// ShapeCuinterposeCapture preloads the shim in every target container when the
+// template opts in. CUDA tool delivery and launch-job wrapping are independent
+// concerns owned by ShapeCUDATools. Reapplying to an already shaped template is
+// a no-op. On error the template is left unchanged.
+func ShapeCuinterposeCapture(
+	podTemplate *corev1.PodTemplateSpec,
+	targetContainers []string,
+) error {
+	if podTemplate == nil {
+		return fmt.Errorf("cuinterpose requires a pod template")
+	}
+	enabled, err := CuinterposeEnabled(podTemplate.Annotations)
+	if err != nil || !enabled {
+		return err
+	}
+	if len(targetContainers) == 0 {
+		return fmt.Errorf("cuinterpose requires at least one target container")
+	}
+	shaped := podTemplate.DeepCopy()
+	targets := uniqueNames(targetContainers)
+	for _, name := range targets {
+		container := findContainer(&shaped.Spec, name)
+		if container == nil {
+			return fmt.Errorf("cuinterpose target container %q does not exist", name)
+		}
+		if err := setCuinterposePreload(container); err != nil {
+			return err
+		}
+	}
+	*podTemplate = *shaped
+	return nil
+}
+
+// VerifyCuinterposeCapture reports whether every target preloads the shim. The
+// operator verifies the independent CUDA tools and launch-job contracts
+// separately before calling this function.
+func VerifyCuinterposeCapture(spec *corev1.PodSpec, targetContainers []string) error {
+	for _, name := range targetContainers {
+		container := findContainer(spec, name)
+		if container == nil {
+			return fmt.Errorf("cuinterpose target container %q does not exist", name)
+		}
+		if !slices.Contains(preloadFields(envValue(container.Env, ldPreloadEnv)), CuinterposeLibraryPath) {
+			return fmt.Errorf("container %q does not preload %s", name, CuinterposeLibraryPath)
+		}
+	}
+	return nil
+}
+
+// setCuinterposePreload puts the shim first in LD_PRELOAD, keeping any entries
+// the workload already had. First position matters: the dynamic loader
+// resolves symbols in LD_PRELOAD order, and the shim must see CUDA calls
+// before any other interposer.
+func setCuinterposePreload(container *corev1.Container) error {
+	index := -1
+	for i := range container.Env {
+		if container.Env[i].Name != ldPreloadEnv {
+			continue
+		}
+		if index != -1 {
+			return fmt.Errorf("container %q has duplicate %s environment variables", container.Name, ldPreloadEnv)
+		}
+		index = i
+	}
+	if index == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  ldPreloadEnv,
+			Value: CuinterposeLibraryPath,
+		})
+		return nil
+	}
+	env := &container.Env[index]
+	if env.ValueFrom != nil {
+		return fmt.Errorf("container %q uses valueFrom for %s", container.Name, ldPreloadEnv)
+	}
+	fields := preloadFields(env.Value)
+	filtered := make([]string, 0, len(fields)+1)
+	filtered = append(filtered, CuinterposeLibraryPath)
+	for _, field := range fields {
+		if field != CuinterposeLibraryPath {
+			filtered = append(filtered, field)
+		}
+	}
+	env.Value = strings.Join(filtered, " ")
+	return nil
+}
+
+func preloadFields(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		return r == ':' || unicode.IsSpace(r)
+	})
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for i := range env {
+		if env[i].Name == name {
+			return env[i].Value
+		}
+	}
+	return ""
+}

--- a/api/podcontract/cuinterpose_test.go
+++ b/api/podcontract/cuinterpose_test.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package podcontract
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func enabledTemplate(containers ...corev1.Container) *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{CuinterposeAnnotation: CuinterposeAnnotationEnabled},
+		},
+		Spec: corev1.PodSpec{Containers: containers},
+	}
+}
+
+func TestShapeCuinterposeCapture(t *testing.T) {
+	template := enabledTemplate(
+		corev1.Container{
+			Name:    "worker-a",
+			Command: []string{"python3", "-m", "worker"},
+			Args:    []string{"--rank", "0"},
+			Env:     []corev1.EnvVar{{Name: ldPreloadEnv, Value: "/opt/first.so:/opt/second.so"}},
+		},
+		corev1.Container{Name: "worker-b", Command: []string{"/usr/bin/worker"}},
+		corev1.Container{Name: "helper"},
+	)
+	before := template.Spec.DeepCopy()
+
+	// Shaping twice must be a no-op the second time.
+	for range 2 {
+		if err := ShapeCuinterposeCapture(template, []string{"worker-a", "worker-b"}); err != nil {
+			t.Fatalf("ShapeCuinterposeCapture() failed: %v", err)
+		}
+	}
+
+	if !reflect.DeepEqual(template.Spec.Volumes, before.Volumes) ||
+		!reflect.DeepEqual(template.Spec.InitContainers, before.InitContainers) {
+		t.Fatalf("cuinterpose shaping changed CUDA tools delivery: %#v", template.Spec)
+	}
+	wantPreload := CuinterposeLibraryPath + " /opt/first.so /opt/second.so"
+	if got := envValue(findContainer(&template.Spec, "worker-a").Env, ldPreloadEnv); got != wantPreload {
+		t.Fatalf("%s = %q, want %q", ldPreloadEnv, got, wantPreload)
+	}
+	if got := envValue(findContainer(&template.Spec, "worker-b").Env, ldPreloadEnv); got != CuinterposeLibraryPath {
+		t.Fatalf("%s = %q, want %q", ldPreloadEnv, got, CuinterposeLibraryPath)
+	}
+	for i := range template.Spec.Containers {
+		got := &template.Spec.Containers[i]
+		want := &before.Containers[i]
+		if !reflect.DeepEqual(got.Command, want.Command) ||
+			!reflect.DeepEqual(got.Args, want.Args) ||
+			!reflect.DeepEqual(got.VolumeMounts, want.VolumeMounts) {
+			t.Fatalf("container %q delivery or command changed: %#v", got.Name, got)
+		}
+	}
+	if got := findContainer(&template.Spec, "helper").Env; len(got) != 0 {
+		t.Fatalf("non-target helper environment: %#v", got)
+	}
+	if err := VerifyCuinterposeCapture(&template.Spec, []string{"worker-a", "worker-b"}); err != nil {
+		t.Fatalf("VerifyCuinterposeCapture() on a shaped template failed: %v", err)
+	}
+
+	// Without the annotation nothing is touched.
+	plain := &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "worker"}}}}
+	plainBefore := plain.DeepCopy()
+	if err := ShapeCuinterposeCapture(plain, []string{"worker"}); err != nil ||
+		!reflect.DeepEqual(plain, plainBefore) {
+		t.Fatalf("disabled capture: err = %v, spec = %#v", err, plain.Spec)
+	}
+}
+
+func TestShapeCuinterposeCaptureRejectsInvalidContract(t *testing.T) {
+	worker := corev1.Container{Name: "worker", Command: []string{"worker"}}
+	tests := map[string]struct {
+		template *corev1.PodTemplateSpec
+		targets  []string
+	}{
+		"invalid annotation": {
+			template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CuinterposeAnnotation: "true"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{worker}},
+			},
+			targets: []string{"worker"},
+		},
+		"unknown target": {
+			template: enabledTemplate(worker),
+			targets:  []string{"other"},
+		},
+		"no targets": {
+			template: enabledTemplate(worker),
+			targets:  nil,
+		},
+		"LD_PRELOAD from valueFrom": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				Env: []corev1.EnvVar{{Name: ldPreloadEnv, ValueFrom: &corev1.EnvVarSource{}}},
+			}),
+			targets: []string{"worker"},
+		},
+		"duplicate LD_PRELOAD": {
+			template: enabledTemplate(corev1.Container{
+				Name: "worker", Command: []string{"worker"},
+				Env: []corev1.EnvVar{
+					{Name: ldPreloadEnv, Value: "/opt/first.so"},
+					{Name: ldPreloadEnv, Value: "/opt/second.so"},
+				},
+			}),
+			targets: []string{"worker"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			before := tc.template.DeepCopy()
+			if err := ShapeCuinterposeCapture(tc.template, tc.targets); err == nil {
+				t.Fatal("ShapeCuinterposeCapture() succeeded, want error")
+			}
+			if !reflect.DeepEqual(tc.template, before) {
+				t.Fatalf("failed shape mutated template:\ngot:  %#v\nwant: %#v", tc.template, before)
+			}
+		})
+	}
+}
+
+func TestVerifyCuinterposeCaptureRejectsUnshapedSpecs(t *testing.T) {
+	shaped := enabledTemplate(corev1.Container{Name: "worker", Command: []string{"worker"}})
+	if err := ShapeCuinterposeCapture(shaped, []string{"worker"}); err != nil {
+		t.Fatal(err)
+	}
+	mutations := map[string]func(*corev1.PodSpec){
+		"no preload":     func(s *corev1.PodSpec) { s.Containers[0].Env = nil },
+		"missing target": func(s *corev1.PodSpec) { s.Containers[0].Name = "other" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			spec := shaped.Spec.DeepCopy()
+			mutate(spec)
+			if err := VerifyCuinterposeCapture(spec, []string{"worker"}); err == nil {
+				t.Fatal("VerifyCuinterposeCapture() accepted an unshaped spec")
+			}
+		})
+	}
+}
+
+func TestCuinterposeEnabled(t *testing.T) {
+	for name, annotations := range map[string]map[string]string{
+		"absent":  nil,
+		"enabled": {CuinterposeAnnotation: CuinterposeAnnotationEnabled},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := CuinterposeEnabled(annotations)
+			if err != nil {
+				t.Fatalf("CuinterposeEnabled() failed: %v", err)
+			}
+			if got != (name == "enabled") {
+				t.Fatalf("CuinterposeEnabled() = %v", got)
+			}
+		})
+	}
+	for _, value := range []string{"", "true", " enabled ", "Enabled"} {
+		if _, err := CuinterposeEnabled(map[string]string{CuinterposeAnnotation: value}); err == nil {
+			t.Fatalf("CuinterposeEnabled() accepted %q", value)
+		}
+	}
+}

--- a/api/podcontract/protocol.go
+++ b/api/podcontract/protocol.go
@@ -22,6 +22,16 @@ const (
 	// uses the captured container name as the destination.
 	RestoreContainerMapAnnotation = "nvidia.com/restore-container-map"
 
+	// CuinterposeAnnotation opts a SnapshotJob's checkpoint targets into the
+	// CUDA interposer (cuinterpose), which lets Snapshot checkpoint and restore
+	// CUDA memory shared between processes. The only supported value is
+	// CuinterposeAnnotationEnabled. Snapshot supplies and mounts the shim in
+	// every checkpoint target; this annotation only adds it to LD_PRELOAD.
+	CuinterposeAnnotation = "nvidia.com/cuinterpose"
+
+	// CuinterposeAnnotationEnabled is the only accepted CuinterposeAnnotation value.
+	CuinterposeAnnotationEnabled = "enabled"
+
 	// DefaultSeccompLocalhostProfile is the kubelet-local profile installed by
 	// the Snapshot Helm chart to block io_uring for CRIU.
 	DefaultSeccompLocalhostProfile = "profiles/block-iouring.json"

--- a/operator/internal/controller/snapshotjob_job.go
+++ b/operator/internal/controller/snapshotjob_job.go
@@ -76,5 +76,11 @@ func buildShapedSourceJob(
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := podcontract.ShapeCuinterposeCapture(
+		&job.Spec.Template,
+		sj.Spec.PodSnapshotTemplate.TargetContainers,
+	); err != nil {
+		return nil, nil, err
+	}
 	return job, wrapped, nil
 }

--- a/operator/internal/controller/snapshotjob_job_test.go
+++ b/operator/internal/controller/snapshotjob_job_test.go
@@ -302,3 +302,34 @@ func TestBuildShapedSourceJobWrapsMultiGPUTargets(t *testing.T) {
 		assert.Equal(t, []string{"worker"}, wrapped)
 	})
 }
+
+func cuinterposeSnapshotJob() *snapshotv1alpha1.SnapshotJob {
+	sj := minimalSnapshotJob()
+	sj.Spec.PodTemplate.Annotations = map[string]string{
+		podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+	}
+	sj.Spec.PodTemplate.Spec.Containers[0].Command = []string{"python3", "-m", "worker"}
+	return sj
+}
+
+func TestBuildShapedSourceJobShapesCuinterpose(t *testing.T) {
+	sj := cuinterposeSnapshotJob()
+
+	job, wrapped, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, wrapped, "cuinterpose opt-in does not change the single-GPU launch rule")
+
+	require.NoError(t, podcontract.VerifyCUDATools(&job.Spec.Template.Spec, []string{"worker"}))
+	require.NoError(t, podcontract.VerifyCuinterposeCapture(&job.Spec.Template.Spec, []string{"worker"}))
+	main := requireContainer(t, job.Spec.Template.Spec.Containers, "worker")
+	assert.Equal(t, []string{"python3", "-m", "worker"}, main.Command,
+		"the annotation only enables LD_PRELOAD")
+	requireContainer(t, job.Spec.Template.Spec.InitContainers, podcontract.CUDAToolsInitContainerName)
+
+	t.Run("a SnapshotJob without the annotation does not preload the shim", func(t *testing.T) {
+		job, _, err := buildShapedSourceJob(multiGPUSnapshotJob(), testCUDAToolsDelivery(), nil)
+		require.NoError(t, err)
+		require.NoError(t, podcontract.VerifyCUDATools(&job.Spec.Template.Spec, []string{"worker"}))
+		require.Error(t, podcontract.VerifyCuinterposeCapture(&job.Spec.Template.Spec, []string{"worker"}))
+	})
+}

--- a/operator/internal/controller/snapshotjob_podsnapshot.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -194,6 +195,20 @@ func buildPodSnapshot(sj *snapshotv1alpha1.SnapshotJob, pod *corev1.Pod) (*snaps
 	labels, annotations, err := podSnapshotTemplateMetadata(sj)
 	if err != nil {
 		return nil, err
+	}
+	// Record on the PodSnapshot whether the source ran with cuinterpose, so
+	// the artifact says what it was captured with.
+	cuinterposeEnabled, err := podcontract.CuinterposeEnabled(pod.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	if cuinterposeEnabled {
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[podcontract.CuinterposeAnnotation] = podcontract.CuinterposeAnnotationEnabled
+	} else {
+		delete(annotations, podcontract.CuinterposeAnnotation)
 	}
 	return &snapshotv1alpha1.PodSnapshot{
 		TypeMeta: metav1.TypeMeta{

--- a/operator/internal/controller/snapshotjob_podsnapshot_test.go
+++ b/operator/internal/controller/snapshotjob_podsnapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ai-dynamo/snapshot/api/podcontract"
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
@@ -35,7 +36,14 @@ func TestBuildPodSnapshot(t *testing.T) {
 		Annotations: map[string]string{"dynamo.nvidia.com/gms-mode": "enabled"},
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "warm-worker-abcde", Namespace: "inference", UID: types.UID("pod-uid")},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-worker-abcde",
+			Namespace: "inference",
+			UID:       types.UID("pod-uid"),
+			Annotations: map[string]string{
+				podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+			},
+		},
 	}
 
 	snap, err := buildPodSnapshot(sj, pod)
@@ -54,6 +62,10 @@ func TestBuildPodSnapshot(t *testing.T) {
 	t.Run("propagates caller metadata", func(t *testing.T) {
 		assert.Equal(t, "abc123", snap.Labels["dynamo.nvidia.com/worker-generation"])
 		assert.Equal(t, "enabled", snap.Annotations["dynamo.nvidia.com/gms-mode"])
+	})
+
+	t.Run("records cuinterpose", func(t *testing.T) {
+		assert.Equal(t, podcontract.CuinterposeAnnotationEnabled, snap.Annotations[podcontract.CuinterposeAnnotation])
 	})
 
 	t.Run("pins the source pod name and UID", func(t *testing.T) {
@@ -800,4 +812,16 @@ func TestMapPodSnapshotToSnapshotJob(t *testing.T) {
 func TestSnapshotJobOwnerFromPodSnapshotObjRejectsWrongType(t *testing.T) {
 	_, err := snapshotJobOwnerFromPodSnapshotObj(&corev1.Pod{})
 	require.Error(t, err)
+}
+
+func TestBuildPodSnapshotRejectsInvalidCuinterposeAnnotation(t *testing.T) {
+	sj := minimalSnapshotJob()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "warm-worker-abcde", Namespace: "inference", UID: types.UID("pod-uid"),
+			Annotations: map[string]string{podcontract.CuinterposeAnnotation: "true"},
+		},
+	}
+	_, err := buildPodSnapshot(sj, pod)
+	require.Error(t, err, "an unrecognized value must not silently produce a PodSnapshot without the shim recorded")
 }

--- a/operator/internal/controller/snapshotjob_reconciler_test.go
+++ b/operator/internal/controller/snapshotjob_reconciler_test.go
@@ -847,3 +847,56 @@ func TestSnapshotJobReconcileAdoptsShapedMultiGPUJob(t *testing.T) {
 	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
 	assert.Equal(t, job.UID, updated.Status.SourceJobUID, "a correctly shaped Job is adopted")
 }
+
+func TestSnapshotJobReconcileRejectsUnshapedJobWhenCuinterposeEnabled(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := cuinterposeSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	// A Job created by an operator that had no agent image: the Pod template is
+	// annotated but carries none of the capture contract.
+	plain := sj.DeepCopy()
+	delete(plain.Spec.PodTemplate.Annotations, podcontract.CuinterposeAnnotation)
+	job, err := buildSourceJob(plain)
+	require.NoError(t, err)
+	job.Spec.Template.Annotations = map[string]string{
+		podcontract.CuinterposeAnnotation: podcontract.CuinterposeAnnotationEnabled,
+	}
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.CUDATools = testCUDAToolsDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	failed := meta.FindStatusCondition(updated.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
+	require.NotNil(t, failed, "adopting a Job without the shim would checkpoint without interposition")
+	assert.Equal(t, snapshotv1alpha1.ReasonJobNameConflict, failed.Reason)
+	assert.Contains(t, failed.Message, "cuinterpose capture contract")
+	assert.Empty(t, updated.Status.SourceJobUID)
+}
+
+func TestSnapshotJobReconcileAdoptsShapedJobWhenCuinterposeEnabled(t *testing.T) {
+	s := snapshotJobReconcilerScheme()
+	sj := cuinterposeSnapshotJob()
+	sj.UID = types.UID("sj-uid")
+
+	job, _, err := buildShapedSourceJob(sj, testCUDAToolsDelivery(), nil)
+	require.NoError(t, err)
+	require.NoError(t, controllerutil.SetControllerReference(sj, job, s))
+	job.UID = types.UID("source-job-uid")
+
+	r := makeSnapshotJobReconciler(s, sj, job)
+	r.CUDATools = testCUDAToolsDelivery()
+
+	_, err = r.Reconcile(context.Background(), reconcileRequest(sj))
+	require.NoError(t, err)
+
+	updated := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, r.Get(context.Background(), reconcileRequest(sj).NamespacedName, updated))
+	assert.Equal(t, job.UID, updated.Status.SourceJobUID, "a correctly shaped Job is adopted")
+}

--- a/operator/internal/controller/snapshotjob_source_job.go
+++ b/operator/internal/controller/snapshotjob_source_job.go
@@ -158,6 +158,19 @@ func (r *SnapshotJobReconciler) classifyExistingSourceJob(
 			}, nil
 		}
 	}
+	// The same for the shim: a Job created without it would produce a
+	// checkpoint whose PodSnapshot claims interposition that never happened.
+	if enabled, err := podcontract.CuinterposeEnabled(desired.Spec.Template.Annotations); err == nil && enabled {
+		if err := podcontract.VerifyCuinterposeCapture(
+			&job.Spec.Template.Spec,
+			sj.Spec.PodSnapshotTemplate.TargetContainers,
+		); err != nil {
+			return &snapshotJobFailure{
+				reason: snapshotv1alpha1.ReasonJobNameConflict,
+				cause:  fmt.Errorf("existing source Job %q lacks the cuinterpose capture contract: %w", job.Name, err),
+			}, nil
+		}
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

Layer 3 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293). Closed PR #214 is intentionally not in the active stack.

This PR introduces the explicit workload opt-in and makes the shim part of each target process from startup:

```yaml
metadata:
  annotations:
    nvidia.com/cuinterpose: enabled
```

An absent annotation disables interposition; any other present value is rejected. CUDA tool delivery and multi-GPU launch wrapping are independent contracts owned by #213. For an enabled template, `ShapeCuinterposeCapture` only places `/tmp/snapshot-cuda/libcuinterpose.so` first in each target's `LD_PRELOAD`. Existing preload entries are retained, duplicates are removed, and a `valueFrom`-backed `LD_PRELOAD` is rejected because it cannot be rewritten safely. The annotation does not cause a one-GPU target to use `cuda-checkpoint --launch-job`.

The shape is idempotent and mutates only a deep copy until every check succeeds. The operator verifies the immutable contract before adopting an existing source Job and records the opt-in annotation on the generated `PodSnapshot`.

At this layer the packaged shim is still a placeholder. The durable contribution is the process-start contract: later layers can intercept each target process and CUDA-using fork child from its first CUDA operation.

## Stack boundary

Based on #213. #223 adds agent-side detection and coordinator invocation. This PR does not start shim sockets, assign participant identities, or alter CUDA behavior.

## Validation

On the final stack, `make test` passes in `api`, `agent`, and `operator`. The pinned CUDA 13.1 builder compiles the production binaries and passes all cuinterpose fake-driver suites. The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its physical-GPU suite passed all 3 tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.




