### PR TITLE
feat(agent): orchestrate the cuinterpose coordinator around checkpoint and restore

### DIFF
--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -585,18 +585,23 @@ func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *
 func (w *NodeController) executorCheckpoint(ctx context.Context, params CheckpointParams) error {
 	log := logr.FromContextOrDiscard(ctx)
 
+	cuinterposeRequested, err := podcontract.CuinterposeEnabled(params.Pod.Annotations)
+	if err != nil {
+		return fmt.Errorf("source pod %s/%s: %w", params.Pod.Namespace, params.Pod.Name, err)
+	}
 	req := executor.CheckpointRequest{
-		ContainerID:         params.ContainerID,
-		ContainerName:       params.ContainerName,
-		ContentUID:          params.ContentUID,
-		StartedAt:           params.StartedAt,
-		NodeName:            w.config.NodeName,
-		PodName:             params.Pod.Name,
-		PodNamespace:        params.Pod.Namespace,
-		PodIP:               params.Pod.Status.PodIP,
-		Clientset:           w.clientset,
-		PageBrokerRequested: params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
-		CUDAToolsDelivered:  podcontract.CUDAToolsDelivered(&params.Pod.Spec, params.ContainerName),
+		ContainerID:          params.ContainerID,
+		ContainerName:        params.ContainerName,
+		ContentUID:           params.ContentUID,
+		StartedAt:            params.StartedAt,
+		NodeName:             w.config.NodeName,
+		PodName:              params.Pod.Name,
+		PodNamespace:         params.Pod.Namespace,
+		PodIP:                params.Pod.Status.PodIP,
+		Clientset:            w.clientset,
+		PageBrokerRequested:  params.Pod.Annotations[snapshotv1alpha1.PageBrokerAnnotation] == snapshotv1alpha1.PageBrokerAnnotationEnabled,
+		CUDAToolsDelivered:   podcontract.CUDAToolsDelivered(&params.Pod.Spec, params.ContainerName),
+		CuinterposeRequested: cuinterposeRequested,
 	}
 	if err := executor.Checkpoint(ctx, w.runtime, log, req, w.config); err != nil {
 		if executor.CheckpointNeedsSourceKill(err) {

--- a/agent/internal/cuda/cuinterpose.go
+++ b/agent/internal/cuda/cuinterpose.go
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+)
+
+// cuinterpose is the CUDA interposer shim (agent/cmd/cuinterpose). Each CUDA
+// process running it listens on a Unix socket under the pod's snapshot control
+// directory. The agent never talks to those sockets itself; it runs the
+// cuinterpose-coordinator binary, which does, once before the native CUDA
+// checkpoint (prepare) and once after the native CUDA restore (restore).
+//
+// The string constants below mirror agent/cmd/cuinterpose/protocol.h; a test
+// checks they agree.
+const (
+	// CoordinatorBinaryName is the cuinterpose-coordinator executable name.
+	CoordinatorBinaryName = "cuinterpose-coordinator"
+	// DefaultCoordinatorBinaryPath is where the agent image installs the
+	// coordinator, used for prepare. Restore runs inside the restored
+	// container's mount namespace, which does not contain the agent bundle, so
+	// that call site passes a /proc/self/fd path opened before CRIU ran.
+	DefaultCoordinatorBinaryPath = "/usr/local/bin/" + CoordinatorBinaryName
+	// CuinterposeStateFile is the topology sidecar the coordinator writes into
+	// the checkpoint directory during prepare and reads during restore.
+	CuinterposeStateFile = "cuinterpose.state"
+
+	cuinterposeSocketPrefix = "cuinterpose-"
+	cuinterposeSocketSuffix = ".sock"
+	coordinatorReportPrefix = "cuinterpose-coordinator "
+)
+
+// cuinterposeEndpointPath is the shim's control socket for one CUDA process,
+// reached through the host's /proc mount: <procRoot>/<pid>/root is the
+// process's own root filesystem.
+func cuinterposeEndpointPath(procRoot string, observedPID, namespacePID int) string {
+	return filepath.Join(
+		procRoot,
+		strconv.Itoa(observedPID),
+		"root",
+		strings.TrimPrefix(podcontract.SnapshotControlMountPath, string(os.PathSeparator)),
+		cuinterposeSocketName(namespacePID),
+	)
+}
+
+func cuinterposeSocketName(namespacePID int) string {
+	return fmt.Sprintf("%s%d%s", cuinterposeSocketPrefix, namespacePID, cuinterposeSocketSuffix)
+}
+
+// DetectCuinterpose reports whether the live CUDA processes run the shim. The
+// signal is the shim's control socket, one per CUDA process, not the process
+// environment: Python's setproctitle (vLLM, SGLang) overwrites what /proc
+// shows as the environment while the sockets remain. No sockets at all means
+// the workload is not interposed and is checkpointed natively. Some but not
+// all sockets, or a non-socket file in a socket's place, is an error: a
+// half-interposed process tree cannot be checkpointed consistently.
+func DetectCuinterpose(procRoot string, observedPIDs, namespacePIDs []int) (bool, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return false, fmt.Errorf(
+			"cuinterpose PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return false, nil
+	}
+	valid := 0
+	seen := 0
+	for index, observedPID := range observedPIDs {
+		endpoint := cuinterposeEndpointPath(procRoot, observedPID, namespacePIDs[index])
+		info, err := os.Lstat(endpoint)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("stat cuinterpose endpoint %q: %w", endpoint, err)
+		}
+		seen++
+		if info.Mode()&os.ModeSocket != 0 {
+			valid++
+		}
+	}
+	if seen == 0 {
+		return false, nil
+	}
+	if valid != len(observedPIDs) {
+		return false, fmt.Errorf(
+			"cuinterpose endpoint missing or invalid for %d of %d CUDA processes",
+			len(observedPIDs)-valid,
+			len(observedPIDs),
+		)
+	}
+	return true, nil
+}
+
+// CheckCuinterposeEnablement is the rule for what the Pod asked for versus what
+// the CUDA processes are running. Both disagreements are refused:
+//
+//   - requested but no process exposes a socket: the shim never loaded (wrong
+//     path, glibc too old, LD_PRELOAD stripped). A native checkpoint would look
+//     fine and restore with stale sharing, so it must not be taken.
+//   - not requested but sockets are present: something other than Snapshot
+//     preloaded the shim; the restore side would not mount it.
+//
+// With no CUDA processes there is nothing to interpose and nothing to check.
+func CheckCuinterposeEnablement(requested, detected bool, cudaProcesses int) error {
+	if cudaProcesses == 0 {
+		return nil
+	}
+	if requested && !detected {
+		return fmt.Errorf(
+			"cuinterpose was requested (%s) but no CUDA process exposes a control socket; the shim did not load, refusing to checkpoint without it",
+			podcontract.CuinterposeAnnotation)
+	}
+	if !requested && detected {
+		return fmt.Errorf(
+			"CUDA processes run the cuinterpose shim but the source Pod did not request it (%s); restore would not mount the shim",
+			podcontract.CuinterposeAnnotation)
+	}
+	return nil
+}
+
+// HasCuinterposeState reports whether the checkpoint directory holds the
+// coordinator's state file.
+func HasCuinterposeState(checkpointDir string) (bool, error) {
+	_, err := os.Stat(filepath.Join(checkpointDir, CuinterposeStateFile))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// RemoveStaleCuinterposeSockets deletes leftover shim sockets from an earlier
+// incarnation of the pod. Each shim binds its socket by namespace PID, and
+// CRIU recreates the checkpointed process with the same namespace PID, so a
+// stale file at that path makes the restored bind() fail. Called inside the
+// container's mount namespace before CRIU runs. Returns how many were removed.
+func RemoveStaleCuinterposeSockets(controlDir string) (int, error) {
+	entries, err := os.ReadDir(controlDir)
+	if err != nil {
+		return 0, fmt.Errorf("list cuinterpose control directory %s: %w", controlDir, err)
+	}
+	removed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, cuinterposeSocketPrefix) || !strings.HasSuffix(name, cuinterposeSocketSuffix) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(controlDir, name)); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("remove stale cuinterpose socket %s: %w", name, err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// CoordinatorPhase is one progress line the coordinator printed:
+// "cuinterpose-coordinator phase=<name> status=ok key=value ...".
+type CoordinatorPhase struct {
+	Phase  string
+	Fields map[string]string
+}
+
+// PrepareCuinterpose runs the coordinator in the live target container's mount,
+// UTS, IPC, network, and PID namespaces before the native CUDA checkpoint. The
+// executable and checkpoint directory are opened by the agent first and passed
+// through file descriptors, so neither depends on a path supplied by the
+// workload. On success the coordinator has written CuinterposeStateFile into
+// checkpointDir.
+//
+// There is no undo: once prepare has torn down shared mappings the source
+// workload can only continue by being restored, so a later checkpoint failure
+// is fail-stop for the source (the caller terminates it).
+func PrepareCuinterpose(
+	ctx context.Context,
+	checkpointDir string,
+	procRoot string,
+	targetPID int,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) ([]CoordinatorPhase, error) {
+	if targetPID <= 0 {
+		return nil, fmt.Errorf("invalid cuinterpose target PID %d", targetPID)
+	}
+
+	const (
+		binaryFD     = 3
+		checkpointFD = 4
+		mountNSFD    = 5
+		utsNSFD      = 6
+		ipcNSFD      = 7
+		networkNSFD  = 8
+		pidNSFD      = 9
+	)
+	args, err := cuinterposeArgs(
+		"prepare",
+		fmt.Sprintf("/proc/self/fd/%d", checkpointFD),
+		"",
+		podcontract.SnapshotControlMountPath,
+		observedPIDs,
+		namespacePIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]*os.File, 0, 7)
+	defer func() {
+		for _, file := range files {
+			_ = file.Close()
+		}
+	}()
+	for _, path := range []string{
+		coordinatorBinaryPath,
+		checkpointDir,
+		filepath.Join(procRoot, strconv.Itoa(targetPID), "ns", "mnt"),
+		filepath.Join(procRoot, strconv.Itoa(targetPID), "ns", "uts"),
+		filepath.Join(procRoot, strconv.Itoa(targetPID), "ns", "ipc"),
+		filepath.Join(procRoot, strconv.Itoa(targetPID), "ns", "net"),
+		filepath.Join(procRoot, strconv.Itoa(targetPID), "ns", "pid"),
+	} {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("open cuinterpose prepare input %q: %w", path, err)
+		}
+		files = append(files, file)
+	}
+
+	nsenterArgs := []string{
+		fmt.Sprintf("--mount=/proc/self/fd/%d", mountNSFD),
+		fmt.Sprintf("--uts=/proc/self/fd/%d", utsNSFD),
+		fmt.Sprintf("--ipc=/proc/self/fd/%d", ipcNSFD),
+		fmt.Sprintf("--net=/proc/self/fd/%d", networkNSFD),
+		fmt.Sprintf("--pid=/proc/self/fd/%d", pidNSFD),
+		"--",
+		fmt.Sprintf("/proc/self/fd/%d", binaryFD),
+	}
+	nsenterArgs = append(nsenterArgs, args...)
+	cmd := exec.CommandContext(ctx, "nsenter", nsenterArgs...)
+	cmd.ExtraFiles = files
+	return executeCoordinator(cmd, coordinatorBinaryPath, args[0], log)
+}
+
+// RestoreCuinterpose runs from nsrestore, which already occupies the restored
+// container's mount, UTS, IPC, network, and PID namespaces. procRoot is empty,
+// so the control sockets are addressed directly under the control directory.
+func RestoreCuinterpose(
+	ctx context.Context,
+	checkpointDir string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	coordinatorBinaryPath string,
+	log logr.Logger,
+) ([]CoordinatorPhase, error) {
+	args, err := cuinterposeArgs("restore", checkpointDir, "", podcontract.SnapshotControlMountPath, observedPIDs, namespacePIDs)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, coordinatorBinaryPath, args...)
+	return executeCoordinator(cmd, coordinatorBinaryPath, args[0], log)
+}
+
+func executeCoordinator(cmd *exec.Cmd, binary, operation string, log logr.Logger) ([]CoordinatorPhase, error) {
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	phases := parseCoordinatorReports(stdout.String())
+	for _, phase := range phases {
+		values := make([]any, 0, 2+2*len(phase.Fields))
+		values = append(values, "operation", operation, "phase", phase.Phase)
+		for key, value := range phase.Fields {
+			values = append(values, key, value)
+		}
+		log.Info("cuinterpose coordinator phase", values...)
+	}
+	if runErr != nil {
+		completed := make([]string, 0, len(phases))
+		for _, phase := range phases {
+			completed = append(completed, phase.Phase)
+		}
+		return phases, fmt.Errorf(
+			"%s %s failed: %w (completed phases: %s; stderr: %s)",
+			binary, operation, runErr,
+			strings.Join(completed, ","),
+			strings.TrimSpace(stderr.String()),
+		)
+	}
+	return phases, nil
+}
+
+// parseCoordinatorReports extracts progress lines from the coordinator's
+// stdout; anything else on stdout is ignored.
+func parseCoordinatorReports(output string) []CoordinatorPhase {
+	var phases []CoordinatorPhase
+	for _, line := range strings.Split(output, "\n") {
+		if phase, ok := parseCoordinatorReport(line); ok {
+			phases = append(phases, phase)
+		}
+	}
+	return phases
+}
+
+func parseCoordinatorReport(line string) (CoordinatorPhase, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, coordinatorReportPrefix) {
+		return CoordinatorPhase{}, false
+	}
+	phase := CoordinatorPhase{Fields: map[string]string{}}
+	for _, field := range strings.Fields(strings.TrimPrefix(line, coordinatorReportPrefix)) {
+		key, value, found := strings.Cut(field, "=")
+		if !found {
+			continue
+		}
+		if key == "phase" {
+			phase.Phase = value
+			continue
+		}
+		phase.Fields[key] = value
+	}
+	if phase.Phase == "" {
+		return CoordinatorPhase{}, false
+	}
+	return phase, true
+}
+
+func cuinterposeArgs(operation, checkpointDir, procRoot, controlDir string, observedPIDs, namespacePIDs []int) ([]string, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return nil, fmt.Errorf(
+			"cuinterpose PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	if len(observedPIDs) == 0 {
+		return nil, errors.New("cuinterpose coordinator requires at least one CUDA process")
+	}
+	args := []string{
+		"--" + operation,
+		"--proc-root", procRoot,
+		"--checkpoint-dir", checkpointDir,
+		"--control-dir", controlDir,
+	}
+	for index, observedPID := range observedPIDs {
+		args = append(args, "--process", strconv.Itoa(observedPID), strconv.Itoa(namespacePIDs[index]))
+	}
+	return args, nil
+}

--- a/agent/internal/cuda/cuinterpose_test.go
+++ b/agent/internal/cuda/cuinterpose_test.go
@@ -1,0 +1,402 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cuda
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+
+	"github.com/ai-dynamo/snapshot/api/podcontract"
+)
+
+func TestDetectCuinterpose(t *testing.T) {
+	cases := map[string]struct {
+		setup        func(t *testing.T, procRoot string)
+		pids, nsPIDs []int
+		want         bool
+		wantErr      bool
+	}{
+		"no CUDA processes": {},
+		"pid list mismatch": {pids: []int{101}, wantErr: true},
+		"no sockets": {
+			setup: func(t *testing.T, root string) { mustControlDir(t, root, 101, 1) },
+			pids:  []int{101, 102}, nsPIDs: []int{1, 2},
+		},
+		"procfs environ is not evidence": {
+			setup: func(t *testing.T, root string) {
+				mustControlDir(t, root, 101, 1)
+				mustEnviron(t, root, 101, "LD_PRELOAD="+podcontract.CuinterposeLibraryPath+"\x00")
+			},
+			pids: []int{101}, nsPIDs: []int{1},
+		},
+		"one of two sockets missing": {
+			setup: func(t *testing.T, root string) { listenUnix(t, cuinterposeEndpointPath(root, 101, 1)) },
+			pids:  []int{101, 102}, nsPIDs: []int{1, 2}, wantErr: true,
+		},
+		"every process has a socket": {
+			setup: func(t *testing.T, root string) {
+				listenUnix(t, cuinterposeEndpointPath(root, 101, 1))
+				listenUnix(t, cuinterposeEndpointPath(root, 102, 2))
+			},
+			pids: []int{101, 102}, nsPIDs: []int{1, 2}, want: true,
+		},
+		"endpoint is not a socket": {
+			setup: func(t *testing.T, root string) {
+				listenUnix(t, cuinterposeEndpointPath(root, 101, 1))
+				path := cuinterposeEndpointPath(root, 102, 2)
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("not a socket"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			pids: []int{101, 102}, nsPIDs: []int{1, 2}, wantErr: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			procRoot := shortTempDir(t)
+			if tc.setup != nil {
+				tc.setup(t, procRoot)
+			}
+			got, err := DetectCuinterpose(procRoot, tc.pids, tc.nsPIDs)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("DetectCuinterpose() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("DetectCuinterpose() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrepareCuinterposeRejectsInvalidTargetPIDBeforeOpeningInputs(t *testing.T) {
+	_, err := PrepareCuinterpose(
+		context.Background(),
+		"/missing-checkpoint",
+		"/missing-proc",
+		0,
+		[]int{1},
+		[]int{1},
+		"/missing-coordinator",
+		logr.Discard(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid cuinterpose target PID") {
+		t.Fatalf("PrepareCuinterpose() error = %v, want invalid target PID", err)
+	}
+}
+
+func TestHasCuinterposeState(t *testing.T) {
+	checkpointDir := t.TempDir()
+	present, err := HasCuinterposeState(checkpointDir)
+	if err != nil || present {
+		t.Fatalf("HasCuinterposeState() = %v, %v for a missing file", present, err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, CuinterposeStateFile), []byte("state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	present, err = HasCuinterposeState(checkpointDir)
+	if err != nil || !present {
+		t.Fatalf("HasCuinterposeState() = %v, %v, want true", present, err)
+	}
+}
+
+func TestRemoveStaleCuinterposeSockets(t *testing.T) {
+	control := shortTempDir(t)
+	listenUnix(t, filepath.Join(control, cuinterposeSocketName(7)))
+	listenUnix(t, filepath.Join(control, cuinterposeSocketName(8)))
+	for _, keep := range []string{"restore-complete", "cuda-checkpoint-job", "other-1.sock"} {
+		if err := os.WriteFile(filepath.Join(control, keep), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, err := RemoveStaleCuinterposeSockets(control)
+	if err != nil {
+		t.Fatalf("RemoveStaleCuinterposeSockets() error = %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed %d, want 2", removed)
+	}
+	entries, _ := os.ReadDir(control)
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if strings.Join(names, ",") != "cuda-checkpoint-job,other-1.sock,restore-complete" {
+		t.Fatalf("unexpected leftovers: %v", names)
+	}
+	if _, err := RemoveStaleCuinterposeSockets(filepath.Join(control, "missing")); err == nil {
+		t.Fatal("a missing control directory must be an error, not a silent no-op")
+	}
+}
+
+func TestParseCoordinatorReport(t *testing.T) {
+	phase, ok := parseCoordinatorReport("cuinterpose-coordinator phase=save_allocations status=ok elapsed_ms=12.5 participants=8 allocation_count=3 allocation_bytes=1610612736 gb_per_s=41.20")
+	if !ok || phase.Phase != "save_allocations" {
+		t.Fatalf("parse = %+v, %v", phase, ok)
+	}
+	if phase.Fields["allocation_bytes"] != "1610612736" || phase.Fields["gb_per_s"] != "41.20" || phase.Fields["status"] != "ok" {
+		t.Fatalf("fields = %v", phase.Fields)
+	}
+	for _, junk := range []string{"", "prepare failed: participant inspect", "cuinterpose-coordinator status=ok", "phase=inspect"} {
+		if _, ok := parseCoordinatorReport(junk); ok {
+			t.Fatalf("parsed %q as a report", junk)
+		}
+	}
+}
+
+// A shell script standing in for the coordinator: records its argv, prints
+// two progress lines, and exits as told.
+func fakeCoordinator(t *testing.T, exitCode int) (binary, argvFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	argvFile = filepath.Join(dir, "argv")
+	binary = filepath.Join(dir, "coordinator.sh")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > " + argvFile + "\n" +
+		"echo 'cuinterpose-coordinator phase=inspect status=ok elapsed_ms=1.0 participants=2 records=4'\n" +
+		"echo 'not a report line'\n" +
+		"echo 'cuinterpose-coordinator phase=validate status=ok elapsed_ms=0.2 participants=2'\n" +
+		"echo 'prepare failed: participant prepare' >&2\n" +
+		"exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(binary, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return binary, argvFile
+}
+
+func fakeNSenter(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	argvFile := filepath.Join(dir, "nsenter-argv")
+	binary := filepath.Join(dir, "nsenter")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > " + argvFile + "\n" +
+		"while [ \"$1\" != -- ]; do shift; done\n" +
+		"shift\n" +
+		"exec \"$@\"\n"
+	if err := os.WriteFile(binary, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	return argvFile
+}
+
+func fakeProcessNamespaces(t *testing.T, procRoot string, pid int) {
+	t.Helper()
+	dir := filepath.Join(procRoot, strconv.Itoa(pid), "ns")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, namespace := range []string{"mnt", "uts", "ipc", "net", "pid"} {
+		if err := os.Symlink(filepath.Join("/proc/self/ns", namespace), filepath.Join(dir, namespace)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestCoordinatorArgvContractAndReports(t *testing.T) {
+	binary, argvFile := fakeCoordinator(t, 0)
+	nsenterArgvFile := fakeNSenter(t)
+	procRoot := t.TempDir()
+	fakeProcessNamespaces(t, procRoot, 4242)
+	phases, err := PrepareCuinterpose(
+		context.Background(),
+		t.TempDir(),
+		procRoot,
+		4242,
+		[]int{4242, 4243},
+		[]int{7, 9},
+		binary,
+		testr.New(t),
+	)
+	if err != nil {
+		t.Fatalf("PrepareCuinterpose() error = %v", err)
+	}
+	argv, _ := os.ReadFile(argvFile)
+	want := strings.Join([]string{
+		"--prepare", "--proc-root", "", "--checkpoint-dir", "/proc/self/fd/4",
+		"--control-dir", podcontract.SnapshotControlMountPath,
+		"--process", "4242", "7", "--process", "4243", "9", "",
+	}, "\n")
+	if string(argv) != want {
+		t.Fatalf("argv:\n%s\nwant:\n%s", argv, want)
+	}
+	if len(phases) != 2 || phases[0].Phase != "inspect" || phases[1].Phase != "validate" || phases[0].Fields["records"] != "4" {
+		t.Fatalf("phases = %+v", phases)
+	}
+	nsenterArgv, _ := os.ReadFile(nsenterArgvFile)
+	wantNSenterPrefix := strings.Join([]string{
+		"--mount=/proc/self/fd/5",
+		"--uts=/proc/self/fd/6",
+		"--ipc=/proc/self/fd/7",
+		"--net=/proc/self/fd/8",
+		"--pid=/proc/self/fd/9",
+		"--",
+		"/proc/self/fd/3",
+		"",
+	}, "\n")
+	if !strings.HasPrefix(string(nsenterArgv), wantNSenterPrefix) {
+		t.Fatalf("nsenter argv:\n%s\nwant prefix:\n%s", nsenterArgv, wantNSenterPrefix)
+	}
+
+	// Restore already runs inside the restored namespaces: no proc root.
+	binary, argvFile = fakeCoordinator(t, 0)
+	if _, err := RestoreCuinterpose(context.Background(), "/tmp/checkpoint", []int{100}, []int{1}, binary, logr.Discard()); err != nil {
+		t.Fatalf("RestoreCuinterpose() error = %v", err)
+	}
+	argv, _ = os.ReadFile(argvFile)
+	if !strings.HasPrefix(string(argv), "--restore\n--proc-root\n\n--checkpoint-dir\n/tmp/checkpoint\n--control-dir\n"+podcontract.SnapshotControlMountPath+"\n") {
+		t.Fatalf("restore argv:\n%s", argv)
+	}
+}
+
+func TestCoordinatorFailureReportsStderrAndCompletedPhases(t *testing.T) {
+	binary, _ := fakeCoordinator(t, 3)
+	args, err := cuinterposeArgs("prepare", "/c", "/p", podcontract.SnapshotControlMountPath, []int{1}, []int{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.CommandContext(context.Background(), binary, args...)
+	phases, err := executeCoordinator(cmd, binary, args[0], logr.Discard())
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if len(phases) != 2 {
+		t.Fatalf("phases before failure = %d, want 2", len(phases))
+	}
+	for _, want := range []string{"exit status 3", "completed phases: inspect,validate", "prepare failed: participant prepare"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q lacks %q", err, want)
+		}
+	}
+}
+
+func TestCuinterposeArgsRejectsEmptyOrMismatchedPIDs(t *testing.T) {
+	if _, err := cuinterposeArgs("prepare", "/c", "/p", "/snapshot-control", nil, nil); err == nil {
+		t.Fatal("no processes must be an error")
+	}
+	if _, err := cuinterposeArgs("prepare", "/c", "/p", "/snapshot-control", []int{1, 2}, []int{1}); err == nil {
+		t.Fatal("mismatched PID lists must be an error")
+	}
+}
+
+// The Go constants and the coordinator's command line mirror the C sources.
+// This test reads them so a rename on one side cannot silently turn
+// interposition off.
+func TestGoConstantsMatchTheCSources(t *testing.T) {
+	protocol, err := os.ReadFile(filepath.Join("..", "..", "cmd", "cuinterpose", "protocol.h"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator, err := os.ReadFile(filepath.Join("..", "..", "cmd", "cuinterpose", "coordinator.c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	define := func(name string) string {
+		match := regexp.MustCompile(`(?m)^#define ` + name + ` "([^"]*)"`).FindSubmatch(protocol)
+		if match == nil {
+			t.Fatalf("protocol.h lacks #define %s", name)
+		}
+		return string(match[1])
+	}
+	if got := define("CUINTERPOSE_SOCKET_PREFIX"); got != cuinterposeSocketPrefix {
+		t.Errorf("socket prefix: C %q, Go %q", got, cuinterposeSocketPrefix)
+	}
+	if got := define("CUINTERPOSE_STATE_FILENAME"); got != CuinterposeStateFile {
+		t.Errorf("state file: C %q, Go %q", got, CuinterposeStateFile)
+	}
+	if got := define("CUINTERPOSE_CONTROL_DIR"); got != podcontract.SnapshotControlMountPath {
+		t.Errorf("control dir: C %q, podcontract %q", got, podcontract.SnapshotControlMountPath)
+	}
+	if got := define("CUINTERPOSE_CONTROL_DIR_ENV"); got != podcontract.SnapshotControlDirEnv {
+		t.Errorf("control dir env: C %q, podcontract %q", got, podcontract.SnapshotControlDirEnv)
+	}
+	if strings.Contains(string(coordinator), "this build carries no coordinator") {
+		t.Log("coordinator.c is the packaging placeholder; the argument contract is pinned once the coordinator lands")
+		return
+	}
+	for _, flag := range []string{"--prepare", "--restore", "--proc-root", "--checkpoint-dir", "--control-dir", "--process"} {
+		if !strings.Contains(string(coordinator), `"`+flag+`"`) {
+			t.Errorf("coordinator.c does not parse %s", flag)
+		}
+	}
+	if !strings.Contains(string(coordinator), `"cuinterpose-coordinator phase=%s status=ok`) {
+		t.Error("coordinator.c progress line format changed; update parseCoordinatorReport")
+	}
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	// Unix socket paths are limited to 108 bytes; t.TempDir() paths are long.
+	dir, err := os.MkdirTemp("", "cui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func mustControlDir(t *testing.T, procRoot string, observedPID, namespacePID int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(cuinterposeEndpointPath(procRoot, observedPID, namespacePID)), 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustEnviron(t *testing.T, procRoot string, observedPID int, content string) {
+	t.Helper()
+	path := filepath.Join(procRoot, strconv.Itoa(observedPID), "environ")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listenUnix(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+}
+
+func TestCheckCuinterposeEnablement(t *testing.T) {
+	cases := []struct {
+		requested, detected bool
+		cuda                int
+		wantErr             bool
+	}{
+		{false, false, 0, false},
+		{true, false, 0, false}, // no CUDA processes: nothing to interpose
+		{false, false, 4, false},
+		{true, true, 4, false},
+		{true, false, 4, true}, // asked for, shim never loaded
+		{false, true, 4, true}, // shim present without the opt-in
+	}
+	for _, tc := range cases {
+		err := CheckCuinterposeEnablement(tc.requested, tc.detected, tc.cuda)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("CheckCuinterposeEnablement(%v, %v, %d) = %v, wantErr %v", tc.requested, tc.detected, tc.cuda, err, tc.wantErr)
+		}
+	}
+}

--- a/agent/internal/executor/checkpoint.go
+++ b/agent/internal/executor/checkpoint.go
@@ -59,12 +59,16 @@ type CheckpointRequest struct {
 	// CUDA tools (podcontract.CUDAToolsDelivered); recorded in the manifest so
 	// restore mounts them at the same path.
 	CUDAToolsDelivered bool
+	// CuinterposeRequested is the source Pod's nvidia.com/cuinterpose opt-in.
+	// Detection is checked against it and it is recorded in the manifest.
+	CuinterposeRequested bool
 }
 
 type checkpointPhaseTimings struct {
-	CUDACheckpointDuration time.Duration
-	CRIUDumpDuration       time.Duration
-	OverlayCaptureDuration time.Duration
+	CuinterposePrepareDuration time.Duration
+	CUDACheckpointDuration     time.Duration
+	CRIUDumpDuration           time.Duration
+	OverlayCaptureDuration     time.Duration
 }
 
 // Checkpoint performs a CRIU dump of a container.
@@ -162,6 +166,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	wall := time.Since(checkpointStart)
 	unaccounted := remainingDuration(wall,
 		gpuDeviceMapDuration,
+		captureTimings.CuinterposePrepareDuration,
 		captureTimings.CUDACheckpointDuration,
 		captureTimings.CRIUDumpDuration,
 		captureTimings.OverlayCaptureDuration,
@@ -171,6 +176,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 		"duration": wall.String(),
 		"phases": map[string]string{
 			"gpu_device_map":                gpuDeviceMapDuration.String(),
+			"cuinterpose_prepare":           captureTimings.CuinterposePrepareDuration.String(),
 			"cuda_checkpoint":               captureTimings.CUDACheckpointDuration.String(),
 			"criu_dump":                     captureTimings.CRIUDumpDuration.String(),
 			"overlay_capture":               captureTimings.OverlayCaptureDuration.String(),
@@ -247,6 +253,13 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	if len(cudaHostPIDs) > 0 {
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
+	cuinterpose, err := cuda.DetectCuinterpose(snapshotruntime.HostProcPath, cudaHostPIDs, cudaNamespacePIDs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("detect cuinterpose: %w", err)
+	}
+	if err := cuda.CheckCuinterposeEnablement(req.CuinterposeRequested, cuinterpose, len(cudaHostPIDs)); err != nil {
+		return nil, 0, err
+	}
 	var gpuUUIDs []string
 	var gpuDeviceMapDuration time.Duration
 	if len(cudaHostPIDs) > 0 {
@@ -279,6 +292,7 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		CUDAHostPIDs:   cudaHostPIDs,
 		CUDANSPIDs:     cudaNamespacePIDs,
 		GPUUUIDs:       gpuUUIDs,
+		Cuinterpose:    cuinterpose,
 	}, gpuDeviceMapDuration, nil
 }
 
@@ -305,6 +319,7 @@ func configureCheckpoint(
 		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs)
 	}
 	m.CUDATools.Delivered = req.CUDAToolsDelivered
+	m.Cuinterpose.Requested = req.CuinterposeRequested
 
 	if err := types.WriteManifest(checkpointDir, m); err != nil {
 		return nil, nil, fmt.Errorf("failed to write checkpoint manifest: %w", err)
@@ -318,6 +333,31 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 
 	// CUDA lock+checkpoint must happen before CRIU dump
 	if len(state.CUDAHostPIDs) > 0 {
+		if state.Cuinterpose {
+			// Prepare runs on the live workload before the native CUDA lock: it
+			// tears down shared mappings so the native checkpoint sees plain
+			// memory. There is no rollback; if anything after this fails the
+			// caller terminates the source (checkpointNeedsSourceKill).
+			prepareStart := time.Now()
+			_, err := cuda.PrepareCuinterpose(
+				ctx,
+				checkpointDir,
+				snapshotruntime.HostProcPath,
+				state.PID,
+				state.CUDAHostPIDs,
+				state.CUDANSPIDs,
+				cuda.DefaultCoordinatorBinaryPath,
+				log,
+			)
+			timings.CuinterposePrepareDuration = time.Since(prepareStart)
+			if err != nil {
+				return nil, fmt.Errorf("prepare cuinterpose: %w", err)
+			}
+			data.Cuinterpose.Prepared = true
+			if err := types.WriteManifest(checkpointDir, data); err != nil {
+				return nil, fmt.Errorf("record cuinterpose prepare in checkpoint manifest: %w", err)
+			}
+		}
 		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)

--- a/agent/internal/executor/nsrestore.go
+++ b/agent/internal/executor/nsrestore.go
@@ -38,6 +38,9 @@ type RestoreInNamespaceResult struct {
 	CRIUPrepareDuration    time.Duration `json:"criuPrepareDuration"`
 	CRIURestoreDuration    time.Duration `json:"criuRestoreDuration"`
 	CUDARestoreDuration    time.Duration `json:"cudaRestoreDuration"`
+	// CuinterposeRestoreDuration is the coordinator's restore step, which runs
+	// after the native CUDA restore and rebuilds shared memory topology.
+	CuinterposeRestoreDuration time.Duration `json:"cuinterposeRestoreDuration"`
 }
 
 // CleanupError is the wire representation of a successful restore whose
@@ -94,11 +97,12 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	}
 
 	result := &RestoreInNamespaceResult{
-		RestoredPID:            restoredPID,
-		OverlayCaptureDuration: executeTimings.overlayCaptureDuration,
-		CRIUPrepareDuration:    executeTimings.criuPrepareDuration,
-		CRIURestoreDuration:    executeTimings.criuRestoreDuration,
-		CUDARestoreDuration:    executeTimings.cudaRestoreDuration,
+		RestoredPID:                restoredPID,
+		OverlayCaptureDuration:     executeTimings.overlayCaptureDuration,
+		CRIUPrepareDuration:        executeTimings.criuPrepareDuration,
+		CRIURestoreDuration:        executeTimings.criuRestoreDuration,
+		CUDARestoreDuration:        executeTimings.cudaRestoreDuration,
+		CuinterposeRestoreDuration: executeTimings.cuinterposeRestoreDuration,
 	}
 	if cleanupErr != nil {
 		result.CleanupError = &CleanupError{
@@ -110,10 +114,11 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 }
 
 type nsrestorePhaseTimings struct {
-	overlayCaptureDuration time.Duration
-	criuPrepareDuration    time.Duration
-	criuRestoreDuration    time.Duration
-	cudaRestoreDuration    time.Duration
+	overlayCaptureDuration     time.Duration
+	criuPrepareDuration        time.Duration
+	criuRestoreDuration        time.Duration
+	cudaRestoreDuration        time.Duration
+	cuinterposeRestoreDuration time.Duration
 }
 
 func executeRestore(
@@ -168,6 +173,7 @@ func executeRestore(
 	// opening the binary now and exec'ing via /proc/self/fd/N after CRIU returns,
 	// the fd remains valid even if the mount is gone.
 	var cudaHelperFdPath string
+	var coordinatorFdPath string
 	if !m.CUDA.IsEmpty() {
 		helperPath := filepath.Join(opts.BundleDir, cuda.HelperBinaryName)
 		f, err := os.Open(helperPath)
@@ -177,6 +183,17 @@ func executeRestore(
 		defer f.Close()
 		cudaHelperFdPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
 	}
+	if m.Cuinterpose.Prepared {
+		if err := requireCuinterposeState(m, opts.CheckpointPath); err != nil {
+			return nil, 0, nil, err
+		}
+		coordinator, err := os.Open(filepath.Join(opts.BundleDir, cuda.CoordinatorBinaryName))
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("failed to open %s before CRIU restore: %w", cuda.CoordinatorBinaryName, err)
+		}
+		defer coordinator.Close()
+		coordinatorFdPath = fmt.Sprintf("/proc/self/fd/%d", coordinator.Fd())
+	}
 
 	// The restore-complete sentinel lives on the pod emptyDir mounted at
 	// SnapshotControlMountPath. Clear it here, in that mount namespace, so a
@@ -185,6 +202,18 @@ func executeRestore(
 	// a missing mount is a hard error.
 	if err := snapshotruntime.RemoveControlSentinel(podcontract.SnapshotControlMountPath, podcontract.RestoreCompleteFile); err != nil {
 		return nil, 0, nil, fmt.Errorf("remove stale restore-complete sentinel: %w", err)
+	}
+	if m.Cuinterpose.Requested {
+		// The shim binds its control socket by namespace PID, which CRIU
+		// reproduces exactly; a socket file left by an earlier incarnation of
+		// this pod (agent restart, replaced container) would make that bind fail.
+		removed, err := cuda.RemoveStaleCuinterposeSockets(podcontract.SnapshotControlMountPath)
+		if err != nil {
+			return nil, 0, nil, fmt.Errorf("remove stale cuinterpose sockets: %w", err)
+		}
+		if removed > 0 {
+			log.Info("Removed stale cuinterpose control sockets before restore", "count", removed)
+		}
 	}
 
 	criuPID, cleanup, prepare, restore, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, opts.BundleDir, log)
@@ -253,7 +282,42 @@ func executeRestore(
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("CUDA restore failed: %w", err)
 		}
+		if m.Cuinterpose.Prepared {
+			// The driver is unlocked so the shims can issue CUDA calls, but the
+			// application itself is still parked in its restore-complete poll
+			// loop, so nothing else touches the shared memory while the
+			// coordinator rebuilds it.
+			cuinterposeStart := time.Now()
+			_, err := cuda.RestoreCuinterpose(ctx, opts.CheckpointPath, restorePIDs, m.CUDA.PIDs, coordinatorFdPath, log)
+			timings.cuinterposeRestoreDuration = time.Since(cuinterposeStart)
+			if err != nil {
+				return nil, 0, nil, fmt.Errorf("restore cuinterpose: %w", err)
+			}
+		}
 	}
 
 	return timings, restoredPID, nil, nil
+}
+
+// requireCuinterposeState checks that a checkpoint whose manifest records a
+// cuinterpose prepare also carries the coordinator's state file. Without it
+// the shims inside the restored processes would stay frozen mid-checkpoint
+// forever, so restoring such an artifact is refused up front.
+func requireCuinterposeState(m *types.CheckpointManifest, checkpointPath string) error {
+	if !m.Cuinterpose.Prepared {
+		return nil
+	}
+	if m.CUDA.IsEmpty() {
+		return fmt.Errorf("checkpoint manifest records a cuinterpose prepare but no CUDA processes")
+	}
+	hasState, err := cuda.HasCuinterposeState(checkpointPath)
+	if err != nil {
+		return fmt.Errorf("stat cuinterpose state: %w", err)
+	}
+	if !hasState {
+		return fmt.Errorf(
+			"checkpoint manifest records a cuinterpose prepare but %s is missing from %s; the artifact is incomplete",
+			cuda.CuinterposeStateFile, checkpointPath)
+	}
+	return nil
 }

--- a/agent/internal/executor/restore.go
+++ b/agent/internal/executor/restore.go
@@ -220,19 +220,21 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		result.CRIUPrepareDuration,
 		result.CRIURestoreDuration,
 		result.CUDARestoreDuration,
+		result.CuinterposeRestoreDuration,
 	)
 	summary := map[string]any{
 		"duration": wall.String(),
 		"phases": map[string]string{
-			"pagebroker_stage":  pageBrokerStageDuration.String(),
-			"pagebroker_mount":  pageBrokerMountDuration.String(),
-			"pagebroker_commit": pageBrokerCommitDuration.String(),
-			"gpu_device_map":    gpuDeviceMapDuration.String(),
-			"overlay_capture":   result.OverlayCaptureDuration.String(),
-			"criu_prepare":      result.CRIUPrepareDuration.String(),
-			"criu_restore":      result.CRIURestoreDuration.String(),
-			"cuda_restore":      result.CUDARestoreDuration.String(),
-			"unaccounted":       unaccounted.String(),
+			"pagebroker_stage":    pageBrokerStageDuration.String(),
+			"pagebroker_mount":    pageBrokerMountDuration.String(),
+			"pagebroker_commit":   pageBrokerCommitDuration.String(),
+			"gpu_device_map":      gpuDeviceMapDuration.String(),
+			"overlay_capture":     result.OverlayCaptureDuration.String(),
+			"criu_prepare":        result.CRIUPrepareDuration.String(),
+			"criu_restore":        result.CRIURestoreDuration.String(),
+			"cuda_restore":        result.CUDARestoreDuration.String(),
+			"cuinterpose_restore": result.CuinterposeRestoreDuration.String(),
+			"unaccounted":         unaccounted.String(),
 		},
 	}
 	if !req.StartedAt.IsZero() {
@@ -390,7 +392,7 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	nsFd := mp.NsFd()
 	if nsFd != nil {
 		// Use the pinned ns fd for the mount namespace; keep -t for the other
-		// namespaces (user, ipc, net, pid). This decouples mount-ns entry from
+		// namespaces (UTS, IPC, network, PID). This decouples mount-ns entry from
 		// PID liveness.
 		args = []string{
 			fmt.Sprintf("--mount=/proc/self/fd/%d", nsFdChild),

--- a/agent/internal/executor/restore_test.go
+++ b/agent/internal/executor/restore_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/ai-dynamo/snapshot/agent/internal/cuda"
 	"github.com/ai-dynamo/snapshot/agent/internal/nsmount"
 	"github.com/ai-dynamo/snapshot/agent/internal/types"
 )
@@ -270,5 +271,30 @@ func TestMountRestoreInputsReturnsEarlierMountsOnFailure(t *testing.T) {
 	}
 	if len(mounted) != 1 || mounted[0].action != "unmount CUDA tools from placeholder" {
 		t.Fatalf("earlier mounts must be returned for cleanup, got %+v", mounted)
+	}
+}
+
+func TestRequireCuinterposeState(t *testing.T) {
+	dir := t.TempDir()
+	plain := &types.CheckpointManifest{}
+	if err := requireCuinterposeState(plain, dir); err != nil {
+		t.Fatalf("a checkpoint without cuinterpose needs no state file: %v", err)
+	}
+	prepared := &types.CheckpointManifest{
+		CUDA:        types.NewCUDAManifest([]int{1}, nil),
+		Cuinterpose: types.CuinterposeManifest{Requested: true, Prepared: true},
+	}
+	if err := requireCuinterposeState(prepared, dir); err == nil {
+		t.Fatal("a prepared checkpoint without its state file must be refused")
+	}
+	if err := os.WriteFile(dir+"/"+cuda.CuinterposeStateFile, []byte("cuinterpose-state-v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireCuinterposeState(prepared, dir); err != nil {
+		t.Fatalf("state present: %v", err)
+	}
+	noCUDA := &types.CheckpointManifest{Cuinterpose: types.CuinterposeManifest{Prepared: true}}
+	if err := requireCuinterposeState(noCUDA, dir); err == nil {
+		t.Fatal("prepared without CUDA processes is inconsistent")
 	}
 }

--- a/agent/internal/types/inspect.go
+++ b/agent/internal/types/inspect.go
@@ -31,6 +31,7 @@ type CheckpointContainerSnapshot struct {
 	CUDAHostPIDs   []int    // host-visible PIDs used for checkpoint-side CUDA actions
 	CUDANSPIDs     []int    // namespace-relative PIDs stored in the checkpoint manifest
 	GPUUUIDs       []string // source GPU UUIDs from kubelet PodResources API
+	Cuinterpose    bool     // every CUDA process runs the cuinterpose shim (its control socket is present)
 }
 
 // RestoreContainerSnapshot holds inspected state for the restore target.

--- a/agent/internal/types/manifest.go
+++ b/agent/internal/types/manifest.go
@@ -29,6 +29,23 @@ type CheckpointManifest struct {
 	// CUDATools records whether the source ran with Snapshot's CUDA tools
 	// (cuda-checkpoint, the cuinterpose shim) delivered into the container.
 	CUDATools CUDAToolsManifest `yaml:"cudaTools,omitempty"`
+	// Cuinterpose records whether the CUDA interposer shim was in play. It is
+	// the restore side's only source of truth: the restore Pod's annotations
+	// may be absent or edited, and the state file alone cannot say whether
+	// prepare was supposed to have run.
+	Cuinterpose CuinterposeManifest `yaml:"cuinterpose,omitempty"`
+}
+
+// CuinterposeManifest carries two separate facts about the shim.
+type CuinterposeManifest struct {
+	// Requested is true when the source Pod opted in. Restore then removes
+	// stale shim sockets before CRIU recreates the processes. The shim itself
+	// is mounted through the CUDA tools delivery (CUDAToolsManifest).
+	Requested bool `yaml:"requested"`
+	// Prepared is true when the coordinator's prepare step completed and wrote
+	// the state file. Restore then runs the coordinator, and a missing state
+	// file is an error rather than a plain restore.
+	Prepared bool `yaml:"prepared"`
 }
 
 // CUDAToolsManifest is the restore side's source of truth for the tools mount.

--- a/agent/internal/types/manifest_test.go
+++ b/agent/internal/types/manifest_test.go
@@ -201,3 +201,27 @@ func TestManifestRoundTripsCUDATools(t *testing.T) {
 		t.Fatalf("cudaTools = %+v, err = %v, want zero", read.CUDATools, err)
 	}
 }
+
+func TestManifestRoundTripsCuinterpose(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCheckpointManifest("content-uid", "main", CRIUDumpManifest{}, SourcePodManifest{}, OverlayManifest{})
+	m.Cuinterpose = CuinterposeManifest{Requested: true, Prepared: true}
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	read, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !read.Cuinterpose.Requested || !read.Cuinterpose.Prepared {
+		t.Fatalf("cuinterpose = %+v, want both true", read.Cuinterpose)
+	}
+	// Older manifests without the section read as not requested, not prepared.
+	m.Cuinterpose = CuinterposeManifest{}
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if read, err = ReadManifest(dir); err != nil || read.Cuinterpose.Requested || read.Cuinterpose.Prepared {
+		t.Fatalf("cuinterpose = %+v, err = %v, want zero", read.Cuinterpose, err)
+	}
+}


### PR DESCRIPTION
## Summary

Layer 4 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293). This PR replaces the closed #214 in the active stack; #214 remains closed and unstacked.

This PR connects the Snapshot agent to the short-lived C coordinator. The Go agent never implements the shim wire protocol. It maps host-observed CUDA PIDs to namespace PIDs, verifies the shim's per-process Unix sockets, invokes coordinator prepare immediately before native CUDA capture, and invokes coordinator restore after CRIU/native CUDA restore while the workload remains parked.

Detection is fail closed. An opted-in workload must expose one real socket for every CUDA process; an unannotated workload must expose none. Partial coverage, a non-socket path, a missing shim after opt-in, or an unexpected shim without opt-in prevents capture. Procfs environment is not accepted as evidence because workloads can overwrite it.

The manifest keeps three separate facts: `cudaTools.delivered` recreates file-backed tool paths, `cuinterpose.requested` records source opt-in and triggers stale-socket cleanup, and `cuinterpose.prepared` means destructive prepare completed and requires `cuinterpose.state` on restore.

For capture, the agent opens the trusted coordinator executable, checkpoint directory, and target mount, UTS, IPC, network, and PID namespace descriptors. It enters those pinned namespaces and executes the coordinator through `/proc/self/fd/<n>`; inside that context the coordinator addresses `/snapshot-control` directly and writes its state through the already-open checkpoint-directory descriptor. Restore uses the same namespace set through `nsrestore`, with the coordinator binary opened before CRIU and later executed through its descriptor. User and cgroup context deliberately remain with the agent.

The control directory is a Pod-local `emptyDir`, mounted with `subPath=<container-name>` so Snapshot-managed target containers have isolated views, and shim socket paths are mode `0600`. Source and restore shaping reject reserved-volume collisions unless they match that exact private contract, so a workload cannot substitute a PVC or `hostPath`. A filesystem UDS is not exposed over the Pod network, so another ordinary Pod cannot see or connect to it. The workload Pod remains one trust domain: a sidecar deliberately given the reserved volume can reach it. Node root and equivalently privileged workloads remain inside the trusted node boundary; the Snapshot agent itself must have that privilege to checkpoint containers.

There is no rollback after successful destructive prepare: a later native checkpoint or CRIU failure is fail-stop. During restore, native CUDA is unlocked so shim CUDA calls can run, but application threads remain behind Snapshot's restore-complete sentinel until coordinator reconstruction succeeds.

## Stack boundary

Based on #222. #215 adds transparent CUDA forwarding, #216 implements coordinator logic, and #217 is the first layer that starts participant sockets and tracks state.

## Validation

On the final stack, `make test` passes in all three Go modules. The agent tests cover detection, manifest state, stale-socket cleanup, progress parsing, all five pinned namespace descriptors, and the executable/checkpoint descriptor and coordinator argv contract. The pinned CUDA 13.1 builder passes all C/C++ fake-driver suites. The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its standalone physical-GPU suite passed all 3 data-plane tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.



