### PR TITLE
📝 docs(guides): verify TensorRT-LLM without a GPU driver

### DIFF
--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -86,11 +86,15 @@ docker run --rm \
   --platform linux/amd64 \
   --entrypoint python3 \
   "$TENSORRT_LLM_SNAPSHOT_IMAGE" \
-  -c 'import pathlib; import tensorrt_llm; assert pathlib.Path("/app/app.py").is_file()'
+  -c 'import importlib.util, pathlib; assert importlib.util.find_spec("tensorrt_llm"); assert pathlib.Path("/app/app.py").is_file()'
 ```
 
 The command produces no output when both TensorRT-LLM and `/app/app.py` are
-present. Any failure prints an error and returns a non-zero exit status.
+present. Any failure prints an error and returns a non-zero exit status. The
+check locates the TensorRT-LLM package rather than importing it: importing it
+loads bindings that link against the CUDA driver library, which the NVIDIA
+container runtime injects only when the container runs with a GPU, so an
+import-based check fails on a build host that has none.
 
 ### 3. Deploy TensorRT-LLM
 


### PR DESCRIPTION
`import tensorrt_llm` loads bindings linked against `libcuda.so.1`, which the NVIDIA container runtime injects only when the container is given GPU access. The documented `docker run` requests none, so the verify step fails on any build host without a GPU:

```
ImportError: libcuda.so.1: cannot open shared object file: No such file or directory
```

Use `importlib.util.find_spec` to resolve the package without importing it.

Verified on macOS with no NVIDIA driver: exits 0 against an image built from this guide, and exits 1 against an image lacking the package. vLLM and SGLang need no change, as neither import touches the driver.

Pre-existing since #132. Backport to `release/0.1` in #225.