### PR TITLE
📝 docs(guides): verify TensorRT-LLM without a GPU driver (backport #224)

### DIFF
--- a/docs/guides/tensorrt-llm.md
+++ b/docs/guides/tensorrt-llm.md
@@ -86,11 +86,15 @@ docker run --rm \
   --platform linux/amd64 \
   --entrypoint python3 \
   "$TENSORRT_LLM_SNAPSHOT_IMAGE" \
-  -c 'import pathlib; import tensorrt_llm; assert pathlib.Path("/app/app.py").is_file()'
+  -c 'import importlib.util, pathlib; assert importlib.util.find_spec("tensorrt_llm"); assert pathlib.Path("/app/app.py").is_file()'
 ```
 
 The command produces no output when both TensorRT-LLM and `/app/app.py` are
-present. Any failure prints an error and returns a non-zero exit status.
+present. Any failure prints an error and returns a non-zero exit status. The
+check locates the TensorRT-LLM package rather than importing it: importing it
+loads bindings that link against the CUDA driver library, which the NVIDIA
+container runtime injects only when the container runs with a GPU, so an
+import-based check fails on a build host that has none.
 
 ### 3. Deploy TensorRT-LLM
 


### PR DESCRIPTION
Backport of #224 to `release/0.1`. Clean cherry-pick of 4009e4a — the branch carried the identical pre-fix text, so no adaptation.

`import tensorrt_llm` needs `libcuda.so.1`, which the NVIDIA container runtime injects only when the container is given GPU access, so the verify step fails on any build host without a GPU. `importlib.util.find_spec` resolves the package without importing it.

See #224 for details.