### PR TITLE
ci: require an approved issue link on every PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Bug Report
+description: Tell us about a problem you are experiencing with Snapshot
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not report security vulnerabilities here - see
+        [SECURITY.md](https://github.com/ai-dynamo/snapshot/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much detail as possible. Incomplete reports may not be
+        addressed in a timely manner.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce it?
+      description: Minimal steps, manifests, or commands that trigger the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - Snapshot version (operator and agent):
+        - Kubernetes version:
+        - GPU model and driver version:
+        - Container runtime:
+        - Cloud provider or hardware configuration:
+        - Anything else that is relevant:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs, events, or resource YAML
+      description: Output is rendered as a code block, so no backticks are needed.
+      render: shell
+
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched the existing issues and found no duplicate of this report
+          required: true
+
+  - type: markdown
+    attributes:
+      value: Impacted by this bug? Give it a 👍 above.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+#
+# The "New issue" chooser is limited to bug reports, feature requests,
+# documentation requests, and the security vulnerability contact link. Blank
+# issues stay off so every issue arrives with the fields triage needs, and
+# questions belong in Discussions rather than an issue template.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Ask a question
+    url: https://github.com/ai-dynamo/snapshot/discussions
+    about: Please ask questions and start design conversations in Discussions.
+  - name: Report a security vulnerability
+    url: https://www.nvidia.com/en-us/support/submit-security-vulnerability/
+    about: Never open a public issue for a security vulnerability. Report it to NVIDIA PSIRT - see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Documentation Request or Correction
+description: Request new Snapshot documentation, or a correction to existing documentation
+title: "[DOC]: "
+labels: ["documentation"]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to improve our documentation!
+
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: What kind of request is this?
+      options:
+        - Correction or update to existing documentation
+        - New documentation that does not exist yet
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Link to the relevant docs, or where you looked for them
+      placeholder: "ex: https://github.com/ai-dynamo/snapshot/blob/main/README.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem or the missing documentation
+      placeholder: The docs say to put the restore-from annotation on the namespace, but it belongs on the pod.
+    validations:
+      required: true
+
+  - type: textarea
+    id: correction
+    attributes:
+      label: (Optional) Propose a correction or an outline of the new content
+
+  - type: dropdown
+    id: criticality
+    attributes:
+      label: How would you describe the impact of this documentation gap?
+      description: Maintainers set the final priority label during triage.
+      options:
+        - Critical (currently preventing usage)
+        - High
+        - Medium
+        - Low (would be nice)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched the existing issues and found no duplicate of this request
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,9 +11,9 @@ body:
       value: |
         Thanks for taking the time to propose a feature.
 
-        A maintainer labels accepted proposals `approved`. Pull requests can only
-        merge once they reference an issue carrying that label, so please wait for
-        approval before starting significant work.
+        A maintainer labels accepted proposals `approved`. A pull request has to
+        pass a check confirming that it references an issue carrying that label,
+        so please wait for approval before starting significant work.
 
   - type: textarea
     id: feature

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Feature Request
+description: Suggest a feature or an enhancement for Snapshot
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to propose a feature.
+
+        A maintainer labels accepted proposals `approved`. Pull requests can only
+        merge once they reference an issue carrying that label, so please wait for
+        approval before starting significant work.
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: A clear and concise description of the feature you want in Snapshot.
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+      description: The problem this solves and who it affects.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this affect?
+      multiple: true
+      options:
+        - operator
+        - agent
+        - api
+        - charts
+        - e2e tests
+        - build and CI
+        - documentation
+        - other or not sure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched the existing issues and found no duplicate of this request
+          required: true
+
+  - type: markdown
+    attributes:
+      value: Want this feature? Give it a 👍 above.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+#### What type of PR is this?
+<!-- Keep the line(s) that apply, delete the rest. -->
+
+- [ ] bug
+- [ ] cleanup
+- [ ] documentation
+- [ ] enhancement
+- [ ] api change
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:
+<!--
+Every pull request must reference an open issue that a maintainer has labeled
+`approved`; the "Validate Issue Reference" check enforces this. Using `Fixes`
+closes the issue automatically when the PR merges.
+
+Usage: `Fixes #<issue number>` or `Fixes https://github.com/ai-dynamo/snapshot/issues/<issue number>`.
+-->
+Fixes #
+
+#### How was this tested?
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce an API change?
+<!--
+If no, write "NONE" in the release-note block below. If yes, a release note is
+required. If the change requires action from users upgrading to the new release,
+include the string "action required".
+-->
+```release-note
+
+```
+
+#### Additional documentation, e.g. enhancement proposals, usage docs:
+```docs
+
+```
+
+#### Checklist
+
+- [ ] Commits are signed off (`git commit -s`), per [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] `make check test` passes locally
+- [ ] Documentation is updated where behavior changed

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration for the DCO app: every commit needs a Signed-off-by trailer,
+# including commits from organization members. See CONTRIBUTING.md.
+require:
+  members: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,26 +11,35 @@ on:
   schedule:
     - cron: "21 4 * * *"
 
+# A manual run must not overlap the nightly one; two passes over the same issue
+# would duplicate its stale comment.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   stale:
+    name: Mark and close inactive issues and pull requests
     permissions:
-      actions: write
+      # Label, comment on, and close inactive issues and pull requests.
       issues: write
       pull-requests: write
+      # Required by actions/stale to persist its cursor between runs.
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-stale: 90
           stale-issue-label: 'lifecycle/stale'
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
           close-issue-message: 'This issue was automatically closed due to inactivity.'
           days-before-issue-close: 30
-          exempt-issue-labels: 'lifecycle/frozen,feature,enhancement'
+          exempt-issue-labels: 'lifecycle/frozen'
           stale-pr-label: 'lifecycle/stale'
           stale-pr-message: 'This pull request is stale because it has been open 90 days with no activity. It will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
           close-pr-message: 'This pull request was automatically closed due to inactivity.'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Stale policy: no activity for 90 days marks an item stale, and 30 more days of
+# silence closes it. The `lifecycle/frozen` label exempts an item from the
+# policy. See CONTRIBUTING.md.
+name: Stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "21 4 * * *"
+
+permissions: {}
+
+jobs:
+  stale:
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/stale@v11
+        with:
+          days-before-stale: 90
+          stale-issue-label: 'lifecycle/stale'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
+          close-issue-message: 'This issue was automatically closed due to inactivity.'
+          days-before-issue-close: 30
+          exempt-issue-labels: 'lifecycle/frozen,feature,enhancement'
+          stale-pr-label: 'lifecycle/stale'
+          stale-pr-message: 'This pull request is stale because it has been open 90 days with no activity. It will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
+          close-pr-message: 'This pull request was automatically closed due to inactivity.'
+          days-before-pr-close: 30
+          exempt-pr-labels: 'lifecycle/frozen'
+          remove-stale-when-updated: true
+          operations-per-run: 1000

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+      - uses: actions/stale@v11
         with:
           days-before-stale: 90
           stale-issue-label: 'lifecycle/stale'

--- a/.github/workflows/validate-issue-references.yaml
+++ b/.github/workflows/validate-issue-references.yaml
@@ -30,7 +30,7 @@ concurrency:
 permissions: {}
 
 env:
-  # Label an issue must carry before pull requests referencing it can merge.
+  # Label an issue must carry for a pull request referencing it to pass.
   APPROVED_LABEL: approved
   # Label on a pull request that waives the issue requirement.
   BYPASS_LABEL: skip-issue-check
@@ -40,6 +40,7 @@ jobs:
     name: PR links an approved issue
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       # Read the pull request body and the issues it references.
       contents: read
@@ -47,7 +48,7 @@ jobs:
       issues: read
     steps:
       - name: Validate issue reference
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -162,6 +163,7 @@ jobs:
     name: Re-run validation for linked pull requests
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       # Re-run this workflow for the pull requests affected by the issue change.
       actions: write
@@ -169,7 +171,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Re-run affected pull request checks
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -194,16 +196,44 @@ jobs:
               return;
             }
 
+            // A run that is still executing may have read the issue labels
+            // before this change landed, and GitHub offers no completion event
+            // to retry on, so wait for it rather than dropping the request.
+            const waitForCompletion = async (runId, prNumber) => {
+              const deadline = Date.now() + 10 * 60 * 1000;
+              while (Date.now() < deadline) {
+                await new Promise(resolve => setTimeout(resolve, 15000));
+                const { data: run } = await github.rest.actions.getWorkflowRun({
+                  owner, repo, run_id: runId,
+                });
+                if (run.status === 'completed') {
+                  return run;
+                }
+              }
+              core.warning(
+                `PR #${prNumber}: validation run ${runId} did not finish in time. ` +
+                'Re-run it by hand to pick up the label change.');
+              return null;
+            };
+
             for (const pr of affected) {
               const runs = await github.rest.actions.listWorkflowRuns({
                 owner, repo, workflow_id: workflowFile, head_sha: pr.head.sha, per_page: 20,
               });
               // Runs come back newest first; only the latest one shows on the PR.
-              const latest = runs.data.workflow_runs.find(
-                run => run.event === 'pull_request' && run.status === 'completed');
+              let latest = runs.data.workflow_runs.find(run => run.event === 'pull_request');
               if (!latest) {
-                core.info(`PR #${pr.number}: no completed validation run to re-run.`);
+                core.info(`PR #${pr.number}: no validation run to re-run.`);
                 continue;
+              }
+              if (latest.status !== 'completed') {
+                core.info(
+                  `PR #${pr.number}: validation run ${latest.id} is ${latest.status}; ` +
+                  'waiting for it to finish before re-running.');
+                latest = await waitForCompletion(latest.id, pr.number);
+                if (!latest) {
+                  continue;
+                }
               }
               try {
                 await github.rest.actions.reRunWorkflow({ owner, repo, run_id: latest.id });

--- a/.github/workflows/validate-issue-references.yaml
+++ b/.github/workflows/validate-issue-references.yaml
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Validate Issue Reference
+
+# Every pull request must link at least one open issue that carries the
+# approval label. The check re-runs automatically when the label is added to or
+# removed from an issue, so contributors do not need to push an empty commit.
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+  issues:
+    types:
+      - labeled
+      - unlabeled
+      - closed
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || format('issue-{0}', github.event.issue.number) }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  # Label an issue must carry before pull requests referencing it can merge.
+  APPROVED_LABEL: approved
+  # Label on a pull request that waives the issue requirement.
+  BYPASS_LABEL: skip-issue-check
+
+jobs:
+  validate:
+    name: PR links an approved issue
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      # Read the pull request body and the issues it references.
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Validate issue reference
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const approvedLabel = process.env.APPROVED_LABEL;
+            const bypassLabel = process.env.BYPASS_LABEL;
+
+            const labels = (pr.labels || []).map(l => l.name);
+            if (labels.includes(bypassLabel)) {
+              core.info(`Pull request is labeled "${bypassLabel}" - skipping the issue requirement.`);
+              return;
+            }
+            if (pr.user && pr.user.type === 'Bot') {
+              core.info(`Pull request was opened by ${pr.user.login} (bot) - skipping the issue requirement.`);
+              return;
+            }
+            if (pr.draft) {
+              core.info('Pull request is a draft - the check runs again when it is marked ready for review.');
+              return;
+            }
+
+            // Drop HTML comments, fenced code blocks, and inline code spans so
+            // template boilerplate, pasted logs, and prose such as `#123` are
+            // not mistaken for an issue reference. GitHub does not render a
+            // reference inside backticks as a link either.
+            const body = (pr.body || '')
+              .replace(/<!--[\s\S]*?-->/g, ' ')
+              .replace(/```[\s\S]*?```/g, ' ')
+              .replace(/`[^`\n]*`/g, ' ');
+
+            const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const references = new Set();
+            for (const m of body.matchAll(/#(\d+)\b/g)) {
+              references.add(Number(m[1]));
+            }
+            const urlPattern = new RegExp(
+              `https?://github\\.com/${escapeRegExp(owner)}/${escapeRegExp(repo)}/issues/(\\d+)`, 'gi');
+            for (const m of body.matchAll(urlPattern)) {
+              references.add(Number(m[1]));
+            }
+
+            const howTo =
+              `Link the issue from the pull request description, for example \`Fixes #123\` ` +
+              `or \`Fixes https://github.com/${owner}/${repo}/issues/123\`. ` +
+              `The issue must be open and labeled \`${approvedLabel}\` by a maintainer. ` +
+              `Maintainers can waive this by adding the \`${bypassLabel}\` label to the pull request.`;
+
+            if (references.size === 0) {
+              await core.summary
+                .addHeading('Issue reference missing')
+                .addRaw(howTo)
+                .write();
+              core.setFailed(`This pull request does not reference an issue. ${howTo}`);
+              return;
+            }
+
+            const numbers = [...references].sort((a, b) => a - b);
+            core.info(`Found issue reference(s): ${numbers.map(n => `#${n}`).join(', ')}`);
+
+            const problems = [];
+            let approvedIssue = null;
+
+            for (const number of numbers) {
+              let issue;
+              try {
+                issue = (await github.rest.issues.get({ owner, repo, issue_number: number })).data;
+              } catch (error) {
+                problems.push(error.status === 404
+                  ? `#${number} does not exist`
+                  : `#${number} could not be read: ${error.message}`);
+                continue;
+              }
+
+              if (issue.pull_request) {
+                problems.push(`#${number} is a pull request, not an issue`);
+                continue;
+              }
+              if (issue.state === 'closed') {
+                problems.push(`#${number} is closed`);
+                continue;
+              }
+
+              const issueLabels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+              if (!issueLabels.includes(approvedLabel)) {
+                problems.push(`#${number} is open but is not labeled \`${approvedLabel}\``);
+                continue;
+              }
+
+              approvedIssue = number;
+              break;
+            }
+
+            if (approvedIssue === null) {
+              const details = problems.map(p => `- ${p}`).join('\n');
+              await core.summary
+                .addHeading('No approved issue referenced')
+                .addRaw(details, true)
+                .addRaw(howTo)
+                .write();
+              core.setFailed(
+                `None of the referenced issues are open and labeled "${approvedLabel}":\n${details}\n\n${howTo}`);
+              return;
+            }
+
+            core.info(`Issue #${approvedIssue} is open and labeled "${approvedLabel}".`);
+            await core.summary
+              .addHeading('Approved issue referenced')
+              .addRaw(`This pull request references #${approvedIssue}, which is open and labeled \`${approvedLabel}\`.`)
+              .write();
+
+  revalidate:
+    name: Re-run validation for linked pull requests
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      # Re-run this workflow for the pull requests affected by the issue change.
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Re-run affected pull request checks
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const workflowFile = 'validate-issue-references.yaml';
+
+            const referencesIssue = (body) => {
+              const text = (body || '')
+                .replace(/<!--[\s\S]*?-->/g, ' ')
+                .replace(/```[\s\S]*?```/g, ' ')
+                .replace(/`[^`\n]*`/g, ' ');
+              return new RegExp(`(?:#|/issues/)${issueNumber}\\b`).test(text);
+            };
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            const affected = pulls.filter(pr => referencesIssue(pr.body));
+
+            if (affected.length === 0) {
+              core.info(`No open pull request references issue #${issueNumber}.`);
+              return;
+            }
+
+            for (const pr of affected) {
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: workflowFile, head_sha: pr.head.sha, per_page: 20,
+              });
+              // Runs come back newest first; only the latest one shows on the PR.
+              const latest = runs.data.workflow_runs.find(
+                run => run.event === 'pull_request' && run.status === 'completed');
+              if (!latest) {
+                core.info(`PR #${pr.number}: no completed validation run to re-run.`);
+                continue;
+              }
+              try {
+                await github.rest.actions.reRunWorkflow({ owner, repo, run_id: latest.id });
+                core.info(`PR #${pr.number}: re-running validation (run ${latest.id}).`);
+              } catch (error) {
+                core.warning(`PR #${pr.number}: could not re-run ${latest.id}: ${error.message}`);
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,47 @@ limitations under the License.
 Thank you for your interest in contributing to Snapshot! Contributions are
 welcome under the project's [Apache 2.0 license](LICENSE).
 
+## Start with an issue
+
+Every change starts as an issue, and every pull request must link to one.
+
+1. Open an issue using one of the [issue templates](.github/ISSUE_TEMPLATE),
+   or find an existing one that covers the change.
+2. Wait for a maintainer to triage it and apply the `approved` label. The label
+   is the signal that the project wants the change, so please wait for it before
+   investing significant work.
+3. Reference the issue in the pull request description, for example
+   `Fixes #123` or
+   `Fixes https://github.com/ai-dynamo/snapshot/issues/123`.
+
+The `Validate Issue Reference` check fails while a pull request references no
+issue, or references only issues that are closed or not yet labeled `approved`.
+It re-runs on its own when the label is added, so there is no need to push an
+empty commit. Maintainers can waive the requirement for a specific pull request
+by adding the `skip-issue-check` label; pull requests opened by bots, such as
+Dependabot, are exempt automatically.
+
+Questions and open-ended design discussions belong in
+[Discussions](https://github.com/ai-dynamo/snapshot/discussions) rather than in
+an issue. Security vulnerabilities are never reported in a public issue; see
+[SECURITY.md](SECURITY.md).
+
+## Triage, priority, and inactivity
+
+Maintainers triage new issues weekly and set a priority label. Only maintainers
+apply labels and priorities.
+
+| Label | Meaning | Target fix |
+| --- | --- | --- |
+| `priority/P0` | Major functionality broken, significant user impact, no workaround | 30 days |
+| `priority/P1` | Usable but does not work as documented, workaround exists | 6 months |
+| `priority/P2` | Minor defect with minor impact | No commitment |
+| `needs-triage` | Not yet prioritized | Triaged within 7 days |
+
+Issues and pull requests with no activity for 90 days are labeled
+`lifecycle/stale` and closed 30 days later unless the discussion resumes. Add
+the `lifecycle/frozen` label to exempt an item from this.
+
 ## Developer Certificate of Origin (DCO)
 
 Snapshot requires all contributions to be signed off with the


### PR DESCRIPTION
#### What type of PR is this?

- [x] enhancement

#### What this PR does / why we need it:

Brings the repository's GitHub workflows in line with the project's issue and
pull request policy.

**Required issue link, gated on approval** (`.github/workflows/validate-issue-references.yaml`)

A pull request fails the check unless its description links at least one issue
that is **open and labeled `approved`**.

- Accepts `#123` and full `https://github.com/ai-dynamo/snapshot/issues/123` URLs.
- Ignores references inside HTML comments and fenced code blocks, so template
  boilerplate and pasted logs cannot satisfy the check by accident.
- Fails on: no reference, a nonexistent issue, a closed issue, a pull request
  number, or an open issue that is not labeled `approved`.
- A second job listens on issue `labeled`/`unlabeled`/`closed`/`reopened` events
  and re-runs the check for every open pull request referencing that issue.
  Applying `approved` therefore clears a blocked pull request on its own, with
  no empty commit, and removing the label re-blocks it.
- Exempt: bot-authored pull requests (Dependabot), drafts (re-checked when
  marked ready for review), and pull requests labeled `skip-issue-check`.

**Stale policy** (`.github/workflows/stale.yaml`)

90 days of inactivity marks an item `lifecycle/stale`, 30 more days close it, and `lifecycle/frozen` exempts
it. Pull request staling is set explicitly rather than inheriting the action's
7-day default, so issues and pull requests follow the same documented cadence.

**Issue and pull request templates**

The "New issue" chooser is limited to the four entries the policy allows - bug
report, feature request, documentation request or correction, and the security
vulnerability contact link. Blank issues are off, there is no question template,
and questions are routed to Discussions. The pull request template asks for the
issue link.

**DCO** (`.github/dco.yml`)

Records the sign-off requirement in the repo rather than relying on the DCO
app's defaults. `require.members: true` matches CONTRIBUTING.md, which asks
every contributor to sign off, org members included.

**CONTRIBUTING.md**

Documents the issue-first rule, the P0/P1/P2 priority definitions and their
SLAs, and the inactivity policy.

#### Which issue(s) this PR fixes:

Fixes #249

#### How was this tested?

Both `github-script` bodies were extracted and exercised against stubbed GitHub
API responses: 14 cases for the validator (missing reference, template
boilerplate only, `#N` and URL forms, cross-repo URL, unlabeled issue, closed
issue, nonexistent issue, reference to a pull request, multiple references where
only the second qualifies, reference inside a code fence, bypass label, bot
author, draft) and the re-run matcher (URL and `#N` matching, `#12` not matching
`#120`, comment-only references ignored, picking the latest completed
`pull_request` run). All YAML parses.

#### Does this PR introduce an API change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added contributor guidance covering issue approval, pull request references, support channels, priority labels, security reporting, and stale-item handling.
  - Added structured templates for bug reports, documentation requests, feature requests, and pull requests.
  - Added contact links for community questions and private security reports.
  - Disabled blank issue submissions to guide requests through available templates.

- **Chores**
  - Added automated validation for approved issue references in applicable pull requests, including updates when referenced issues change.
  - Added scheduled stale-item management for inactive issues and pull requests.
  - Added commit sign-off requirements for contributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


