### PR TITLE
docs: add code of conduct, governance, maintainers, and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Human contributors
+should start with [CONTRIBUTING.md](CONTRIBUTING.md); everything there applies
+here too.
+
+> Note: "agent" in this file means an AI coding assistant. The `agent/` module
+> is a different thing entirely — the node-level Snapshot agent daemon.
+
+## What this project is
+
+Snapshot is a Kubernetes-native checkpoint and restore system for NVIDIA GPU
+workloads. It checkpoints a fully initialized GPU pod — running process, CPU and
+GPU memory — and restores that state on another compatible node. It provides
+primitives, not orchestration.
+
+## Repository layout
+
+| Path | Go module | What lives there |
+| --- | --- | --- |
+| `api/` | yes | CRD types (`PodSnapshot`, `PodSnapshotContent`, `SnapshotJob`) and generated CRD YAML in `api/v1alpha1/crds` |
+| `agent/` | yes | Node-level daemon that drives CRIU and CUDA checkpointing. **Linux/amd64 only** |
+| `operator/` | yes | Cluster controller that reconciles the CRDs |
+| `charts/snapshot/` | — | Helm chart; `charts/snapshot/crds` is a generated copy of the CRDs |
+| `e2e/` | — | Python end-to-end suite (uv/pyproject), not Go |
+| `docs/` | — | User and developer documentation |
+| `hack/` | — | Build tooling, license boilerplate, base-package capture |
+
+Three separate Go modules — `api`, `agent`, and `operator` — each with its own
+`go.mod` and its own `Makefile`. The root `Makefile` fans out to all three.
+
+## Build and test
+
+Run everything from the repository root. Go 1.26.6.
+
+```bash
+make check        # default goal: the full local gate (see below)
+make test         # unit tests across api, agent, operator
+make build        # build agent and operator binaries
+make lint         # golangci-lint across all three modules
+make fmt          # format
+make generate     # regenerate CRDs from api/ types
+```
+
+`make check` is the one that matters before opening a pull request. It runs, in
+order: `verify-crds`, `install-tools`, `generate`, `pagebroker-check-generated`,
+`add-license-headers`, `fmt`, `tidy`, `verify-license-headers`, `lint`,
+`govulncheck`, and `helm-lint`. It deliberately does not run in parallel
+(`.NOTPARALLEL:`) because the stages mutate files that later stages read.
+
+To scope work to one module, use its own Makefile — `make -C operator test`.
+
+### Building the agent from macOS
+
+The agent is Linux/amd64-only (`cuda-checkpoint` ships no other architecture),
+so it does not build natively on a Mac. Use the containerized targets:
+
+```bash
+make linux-build   # builds agent/ inside a golang container
+make linux-test    # runs agent/ tests inside a golang container
+```
+
+Both require Docker.
+
+## Conventions that will fail CI if you miss them
+
+1. **Every commit must be signed off (DCO).** Use `git commit -s`. Unsigned
+   commits fail the DCO check and cannot be merged. See
+   [CONTRIBUTING.md](CONTRIBUTING.md#developer-certificate-of-origin-dco).
+
+2. **Every pull request must link an approved issue.** The
+   `Validate Issue Reference` check fails when a pull request references no
+   issue, or only issues that are closed or not yet labeled `approved`. Open the
+   issue first and wait for a maintainer to apply `approved` before investing
+   significant work. Do not open a pull request that skips this step.
+
+3. **SPDX license headers are required on new files.** `make add-license-headers`
+   adds them from `hack/boilerplate.addlicense.txt`; `verify-license-headers`
+   checks them in CI. Generated CRDs are exempt.
+
+4. **CRDs are generated, not hand-edited.** Edit the types under `api/v1alpha1`,
+   then run `make generate`. The chart copy in `charts/snapshot/crds` must stay
+   in sync with `api/v1alpha1/crds` — `verify-crds` fails on drift and tells you
+   to run `make generate` and commit the result.
+
+5. **The agent base image is pinned in one place.** `AGENT_BASE_IMAGE` is read
+   out of `agent/Dockerfile`. If you change it, re-run
+   `make capture-base-packages` so the committed package baseline matches;
+   `verify-base-packages` enforces this.
+
+## Working style
+
+- Match the surrounding code. The repository favors explanatory comments on
+  non-obvious decisions — see the `.NOTPARALLEL:` and `AGENT_BASE_IMAGE`
+  comments in the root `Makefile` for the register to aim for.
+- Add or update tests alongside behavior changes. Controller logic under
+  `agent/internal` and `operator/internal` has substantial table-driven test
+  coverage; follow the existing patterns rather than inventing new harnesses.
+- Do not edit generated files (`zz_generated*.go`, both CRD directories).
+- Do not bump dependencies as a side effect of an unrelated change; Dependabot
+  handles routine updates.
+- Never put a security vulnerability in a public issue or pull request — follow
+  [SECURITY.md](SECURITY.md).
+
+## Where to look first
+
+- [README.md](README.md) — what the system does and how it is used
+- [docs/development/build-from-source.md](docs/development/build-from-source.md) — full build instructions
+- [docs/reference](docs/reference) — API reference
+- [docs/operations](docs/operations) — install, storage, and operational guides
+- [e2e/README.md](e2e/README.md) — running the end-to-end suite

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,91 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **contact the project maintainers privately — they are listed in [MAINTAINERS.md](MAINTAINERS.md). If your report concerns a maintainer, send it to any other maintainer instead.** Reports are handled confidentially.
+
+Do not use a code of conduct report to disclose a security vulnerability. Security issues follow a separate process described in [SECURITY.md](SECURITY.md).
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, including the Snapshot repository, its issues, pull requests, and discussions, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ limitations under the License.
 Thank you for your interest in contributing to Snapshot! Contributions are
 welcome under the project's [Apache 2.0 license](LICENSE).
 
+Participation in this project is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md). By taking part, you agree to uphold it —
+please report unacceptable behavior as described there.
+[MAINTAINERS.md](MAINTAINERS.md) lists the maintainers, and
+[GOVERNANCE.md](GOVERNANCE.md) describes how decisions get made.
+
 ## Start with an issue
 
 Every change starts as an issue, and every pull request must link to one.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,105 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Governance
+
+Snapshot is an open source project maintained by NVIDIA and open to outside
+contributors. This document describes who makes decisions, how those decisions
+are made, and how the set of decision-makers changes.
+
+## Roles
+
+| Role | Who | What they do |
+| --- | --- | --- |
+| **Contributor** | Anyone who opens an issue, a pull request, or a discussion | Proposes and implements changes |
+| **Maintainer** | Listed in [MAINTAINERS.md](MAINTAINERS.md) and [`.github/CODEOWNERS`](.github/CODEOWNERS) | Reviews and merges pull requests, triages issues, sets priorities, cuts releases |
+
+There is no separate committer tier. Maintainers hold write access; everyone
+else contributes through pull requests from forks.
+
+## How decisions are made
+
+The project runs on **lazy consensus**: a proposal is accepted if no maintainer
+objects. In practice this means:
+
+1. **Routine changes** — bug fixes, documentation, tests, dependency updates.
+   Decided in code review. One maintainer approval is required to merge, as
+   enforced by `CODEOWNERS` and branch protection. No wider discussion needed.
+
+2. **User-visible or architectural changes** — new APIs or CRD fields, changes
+   to checkpoint or restore semantics, new dependencies, anything that changes
+   behavior for existing users. These start as an issue, which a maintainer
+   triages and labels `approved` before significant work begins. The `approved`
+   label is the project's signal that it wants the change, and the
+   `Validate Issue Reference` check enforces the link from the pull request. See
+   [CONTRIBUTING.md](CONTRIBUTING.md#start-with-an-issue).
+
+3. **Disagreement** — if a maintainer objects to a change, the objection is
+   resolved in the issue or pull request discussion. Any maintainer may block a
+   merge by requesting changes; the block stands until it is withdrawn or the
+   maintainers reach agreement. Consensus is preferred over voting.
+
+4. **Deadlock** — if maintainers cannot reach consensus, the decision escalates
+   to a simple majority vote of the maintainers, recorded in the relevant issue.
+   A tie means the change is not made.
+
+Open-ended design questions belong in
+[Discussions](https://github.com/ai-dynamo/snapshot/discussions) rather than in
+an issue.
+
+## Issue triage and priority
+
+Maintainers triage new issues weekly and set a priority label. Only maintainers
+apply labels and priorities. The priority ladder and the stale-issue policy are
+documented in
+[CONTRIBUTING.md](CONTRIBUTING.md#triage-priority-and-inactivity).
+
+## Releases
+
+Maintainers decide when to cut a release and what goes into it. Releases are
+built and published by the `release` workflow. Because Snapshot's APIs may still
+change, releases are currently pre-1.0 and API stability is not yet guaranteed —
+see the note at the top of the [README](README.md).
+
+## Becoming a maintainer
+
+Maintainers are added by consensus of the existing maintainers. The usual path
+is a sustained record of merged contributions, useful code review, and issue
+triage — roughly a few months of steady participation rather than any fixed
+count of pull requests.
+
+To propose a new maintainer, an existing maintainer opens an issue naming the
+candidate. If no maintainer objects within two weeks, the candidate is added to
+[MAINTAINERS.md](MAINTAINERS.md) and `.github/CODEOWNERS` in a pull request.
+
+## Stepping down and inactivity
+
+Maintainers may step down at any time by opening a pull request removing
+themselves. Maintainers who have been inactive for six months may be moved to
+emeritus status by consensus of the remaining maintainers; this is not a
+judgment on past contributions, and returning maintainers can be reinstated by
+the same process that added them.
+
+## Changing this document
+
+Changes to this document follow the same process as any other user-visible
+change: an issue, then a pull request, approved by maintainer consensus.
+
+## Code of conduct
+
+Participation in the project is governed by
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), which applies to every project space.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Maintainers
+
+Maintainers review and merge pull requests, triage issues, set priorities, and
+cut releases. See [GOVERNANCE.md](GOVERNANCE.md) for how decisions are made and
+how maintainers are added or retired.
+
+## Current maintainers
+
+The maintainers below are the code owners for the whole repository, as recorded
+in [`.github/CODEOWNERS`](.github/CODEOWNERS). Every pull request requires
+review from at least one of them.
+
+- [@shmuel-runai](https://github.com/shmuel-runai)
+- [@shayasoolin](https://github.com/shayasoolin)
+- [@danbar2](https://github.com/danbar2)
+- [@Ronkahn21](https://github.com/Ronkahn21)
+- [@oleg-kushniriov](https://github.com/oleg-kushniriov)
+- [@yoedgin](https://github.com/yoedgin)
+- [@dfeigin-nv](https://github.com/dfeigin-nv)
+- [@galletas1712](https://github.com/galletas1712)
+- [@julienmancuso](https://github.com/julienmancuso)
+- [@Hutm](https://github.com/Hutm)
+- [@hhzhang16](https://github.com/hhzhang16)
+
+Ownership is currently repository-wide rather than split per component. As the
+project grows, `.github/CODEOWNERS` and this table should be narrowed to name
+owners for `agent/`, `operator/`, `api/`, `charts/`, and `docs/` individually.
+
+## Contacting maintainers
+
+- **Bugs and feature requests** — [open an issue](https://github.com/ai-dynamo/snapshot/issues)
+  using one of the [issue templates](.github/ISSUE_TEMPLATE).
+- **Questions and design discussions** — use
+  [Discussions](https://github.com/ai-dynamo/snapshot/discussions).
+- **Security vulnerabilities** — never in a public issue. Follow
+  [SECURITY.md](SECURITY.md).
+- **Code of conduct reports** — contact a maintainer privately, as described in
+  [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Becoming a maintainer
+
+Maintainers are added by consensus of the existing maintainers, normally after a
+sustained record of reviewed contributions and issue triage. The process is
+described in [GOVERNANCE.md](GOVERNANCE.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Snapshot
 
+[![CI](https://github.com/ai-dynamo/snapshot/actions/workflows/ci.yml/badge.svg)](https://github.com/ai-dynamo/snapshot/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/ai-dynamo/snapshot?include_prereleases&sort=semver)](https://github.com/ai-dynamo/snapshot/releases)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Contributors](https://img.shields.io/github/contributors/ai-dynamo/snapshot)](https://github.com/ai-dynamo/snapshot/graphs/contributors)
+
 Snapshot is a Kubernetes-native checkpoint and restore system for NVIDIA GPU
 workloads. It checkpoints a fully initialized GPU pod — its running process, with
 CPU and GPU memory — and restores that state on any compatible node, so a pod
@@ -189,6 +194,11 @@ in the Dynamo docs.
 
 Contributions are welcome under the project's [Apache 2.0 license](LICENSE). See
 [CONTRIBUTING.md](CONTRIBUTING.md) — all commits must be signed off (DCO).
+
+Participation in this project is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md). [MAINTAINERS.md](MAINTAINERS.md) lists
+who reviews and merges changes, and [GOVERNANCE.md](GOVERNANCE.md) describes how
+decisions are made. AI coding agents should also read [AGENTS.md](AGENTS.md).
 
 ## Security
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] documentation

#### What this PR does / why we need it:

Adds the standard community files this repository was missing, and links them from the README and CONTRIBUTING.md.

An OSS health assessment scored `main` at 60.6/100 with all three lifecycle gates failing. The gaps were not process gaps — DCO enforcement, CODEOWNERS, Dependabot, issue and PR templates, branch protection, and the approved-issue CI gate are all already here. What was missing were the documents that contributors and automated assessments look for.

| File | What it contains |
| --- | --- |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 3.0, verbatim from the upstream source, with the two official placeholders (reporting route, enforcement ladder) filled in for this project. CC BY-SA 4.0 attribution preserved. |
| `MAINTAINERS.md` | The `.github/CODEOWNERS` list, which contact route to use for which kind of report, and a pointer to the maintainer process. |
| `GOVERNANCE.md` | Roles, lazy consensus, the routine-vs-architectural decision split, how objections and deadlocks resolve, and how maintainers are added or retire. |
| `AGENTS.md` | Guidance for AI coding agents: the three-module layout, build and test commands, the containerized `linux-build` path for the amd64-only agent, and the five conventions that fail CI. |

`README.md` also gains CI, release, license, and contributor badges, and both `README.md` and `CONTRIBUTING.md` now link the code of conduct.

`GOVERNANCE.md` is derived from the process already written down in `CONTRIBUTING.md` — the `approved` label gate, the weekly triage cadence, the priority ladder — rather than describing a new process.

#### Which issue(s) this PR fixes:

Fixes #255

#### How was this tested?

Documentation only — no code, CI workflow, or chart changes.

`make verify-crds verify-license-headers helm-lint` passes locally. Full `make check` could not be completed in this environment: it fails at `pagebroker-check-generated` with `/Users/dbar/go/bin/protoc: cannot execute binary file`, a local toolchain problem unrelated to this change.

All internal links in the new files were written against paths that exist in the tree.

#### Special notes for your reviewer:

Two points need a maintainer decision rather than review of the prose:

1. **The code of conduct reporting route is generic.** It currently says to contact a maintainer privately, per `MAINTAINERS.md`. No email alias was invented for this. If there is a real CoC contact, naming it explicitly would be stronger.
2. **Parts of `GOVERNANCE.md` are proposals, not existing practice.** The pieces drawn from `CONTRIBUTING.md` describe what the project already does. The maintainer lifecycle details — a two-week lazy-consensus window for adding maintainers, six months of inactivity before emeritus, majority vote to break a deadlock — are defaults that the maintainers should agree to before this merges.

`MAINTAINERS.md` lists GitHub handles only, not human names, since the handles are what `CODEOWNERS` records.

Separately, and not part of this PR: five open issues were labeled `good first issue` (#242, #241, #243, #151, #233) and five `help wanted` (#127, #44, #45, #240, #248) to give new contributors an entry point.

#### Does this PR introduce an API change?

```release-note
NONE
```

#### Additional documentation, e.g. enhancement proposals, usage docs:
```docs

```

#### Checklist

- [x] Commits are signed off (`git commit -s`), per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `make check test` passes locally — see "How was this tested?"; blocked by a local protoc issue, not by this change
- [x] Documentation is updated where behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering project governance, maintainer responsibilities, community conduct, security reporting, and contribution processes.
  * Added guidance for AI coding agents, including project structure, development commands, conventions, and working practices.
  * Updated the README with project status badges and links to contributor and governance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->