### PR TITLE
docs: add release process, review process, and secrets guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,29 @@ Both require Docker.
    `make capture-base-packages` so the committed package baseline matches;
    `verify-base-packages` enforces this.
 
+## Secrets and credentials
+
+**Never commit credentials, secrets, API keys, tokens, kubeconfigs, or `.env`
+files.** This repository contains none, and no change should introduce any.
+Specifically:
+
+- Do not add a `.env` file, a kubeconfig, a cloud credential file, or a private
+  key to the tree, and do not paste any of them into code, tests, fixtures,
+  comments, commit messages, or pull request descriptions.
+- Do not hardcode a registry password, GitHub token, or NGC/NVIDIA API key.
+  Workflows read credentials from GitHub Actions secrets
+  (`${{ secrets.* }}`); local runs read them from your own environment.
+- Do not echo secrets in workflow `run:` blocks or test output — a value printed
+  in a public CI log is disclosed.
+- Test fixtures use obviously fake placeholders. Never copy a real token into
+  one, even an expired one.
+- If you find a committed secret, do not fix it in a public pull request. Treat
+  it as a vulnerability and follow [SECURITY.md](SECURITY.md); the credential
+  needs rotating, and a public commit reverting it advertises the leak.
+
+When a task genuinely needs a credential, read it from an environment variable
+and document the variable name — never the value.
+
 ## Working style
 
 - Match the surrounding code. The repository favors explanatory comments on

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **contact the project maintainers privately — they are listed in [MAINTAINERS.md](MAINTAINERS.md). If your report concerns a maintainer, send it to any other maintainer instead.** Reports are handled confidentially.
+When an incident does occur, it is important to report it promptly. To report a possible violation, **email <dbar@nvidia.com>.** Reports are handled confidentially. If your report concerns the person at that address, contact any other maintainer listed in [MAINTAINERS.md](MAINTAINERS.md) directly instead.
 
 Do not use a code of conduct report to disclose a security vulnerability. Security issues follow a separate process described in [SECURITY.md](SECURITY.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,39 @@ Questions and open-ended design discussions belong in
 an issue. Security vulnerabilities are never reported in a public issue; see
 [SECURITY.md](SECURITY.md).
 
+## How pull requests are reviewed
+
+**Who reviews.** Every pull request is reviewed by a maintainer. The maintainers
+are the code owners for the whole repository — see
+[`.github/CODEOWNERS`](.github/CODEOWNERS) and [MAINTAINERS.md](MAINTAINERS.md) —
+so GitHub requests review from that group automatically. At least one maintainer
+approval is required before a pull request can merge.
+
+**What has to pass.** Alongside the approval, CI must be green: the `check`,
+`build`, and `test` jobs, the DCO check, and `Validate Issue Reference`. A
+maintainer will not usually start a detailed review while CI is red, so fix
+failing checks first.
+
+**Turnaround.** Maintainers aim to give a first response within a week. Reviews
+are best-effort alongside other work, and larger or more invasive changes take
+longer than small ones — another reason to agree on the approach in the issue
+before writing code.
+
+**Addressing feedback.** Push follow-up commits to the same branch rather than
+force-pushing over the history under review, so reviewers can see what changed;
+squashing happens at merge. Reply to each review comment, and re-request review
+when you have addressed them.
+
+**Following up.** If a pull request has had no response after a week, comment on
+it to bump it. If it stays quiet after that, raise it in
+[Discussions](https://github.com/ai-dynamo/snapshot/discussions) or mention a
+maintainer from [MAINTAINERS.md](MAINTAINERS.md) directly. Pinging is welcome —
+a stalled review is a maintainer oversight, not an imposition.
+
+**Merging.** Maintainers merge; contributors do not need to (and cannot) merge
+their own pull requests. A pull request that goes 90 days without activity is
+labeled `lifecycle/stale` and closed 30 days later, as described below.
+
 ## Triage, priority, and inactivity
 
 Maintainers triage new issues weekly and set a priority label. Only maintainers

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -75,6 +75,9 @@ built and published by the `release` workflow. Because Snapshot's APIs may still
 change, releases are currently pre-1.0 and API stability is not yet guaranteed —
 see the note at the top of the [README](README.md).
 
+[RELEASE.md](RELEASE.md) documents the versioning scheme, the tagging
+convention, and the mechanics of cutting a release.
+
 ## Becoming a maintainer
 
 Maintainers are added by consensus of the existing maintainers. The usual path

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -51,7 +51,7 @@ owners for `agent/`, `operator/`, `api/`, `charts/`, and `docs/` individually.
   [Discussions](https://github.com/ai-dynamo/snapshot/discussions).
 - **Security vulnerabilities** — never in a public issue. Follow
   [SECURITY.md](SECURITY.md).
-- **Code of conduct reports** — contact a maintainer privately, as described in
+- **Code of conduct reports** — email <dbar@nvidia.com>, as described in
   [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## Becoming a maintainer

--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ Contributions are welcome under the project's [Apache 2.0 license](LICENSE). See
 
 Participation in this project is governed by our
 [Code of Conduct](CODE_OF_CONDUCT.md). [MAINTAINERS.md](MAINTAINERS.md) lists
-who reviews and merges changes, and [GOVERNANCE.md](GOVERNANCE.md) describes how
-decisions are made. AI coding agents should also read [AGENTS.md](AGENTS.md).
+who reviews and merges changes, [GOVERNANCE.md](GOVERNANCE.md) describes how
+decisions are made, and [RELEASE.md](RELEASE.md) covers versioning and how
+releases are cut. AI coding agents should also read [AGENTS.md](AGENTS.md).
 
 ## Security
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,9 +32,11 @@ change, so minor versions can carry breaking changes until 1.0. Release
 candidates (`-rcN`) are published ahead of a stable release for integration
 testing.
 
-There is no fixed calendar cadence. Releases are cut when the maintainers judge
-that enough has landed to be worth shipping, and release candidates precede any
-release that changes the CRDs or the checkpoint or restore contract.
+Snapshot releases monthly. The maintainers cut a release once a month from
+whatever has landed on `main`; a month with nothing user-visible to ship can be
+skipped rather than padded. Release candidates precede any release that changes
+the CRDs or the checkpoint or restore contract, so integrators have a version to
+test against before the stable tag.
 
 ## Who can cut a release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,92 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Release Process
+
+How Snapshot releases are versioned, who can cut one, and what happens when they
+do.
+
+## Versioning
+
+Snapshot follows [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`,
+with optional pre-release suffixes such as `v0.1.0-rc2`. The release workflow
+validates the tag against `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$` and fails
+on anything that does not match.
+
+Snapshot is pre-1.0. As noted in the [README](README.md), the APIs may still
+change, so minor versions can carry breaking changes until 1.0. Release
+candidates (`-rcN`) are published ahead of a stable release for integration
+testing.
+
+There is no fixed calendar cadence. Releases are cut when the maintainers judge
+that enough has landed to be worth shipping, and release candidates precede any
+release that changes the CRDs or the checkpoint or restore contract.
+
+## Who can cut a release
+
+Maintainers listed in [MAINTAINERS.md](MAINTAINERS.md). Publishing a release
+requires write access to the repository, so contributors cannot trigger one.
+The decision to cut a release is made by maintainer consensus, per
+[GOVERNANCE.md](GOVERNANCE.md).
+
+## Tagging and branches
+
+Releases are cut from `main`. There are no long-lived release branches; a patch
+for an older release is branched from that release's tag only if the need
+arises.
+
+Every release produces four tags. You create one — the rest are automatic:
+
+| Tag | Created by | Why |
+| --- | --- | --- |
+| `vX.Y.Z` | the maintainer, when publishing the release | The release itself |
+| `api/vX.Y.Z` | the `Release` workflow | Go module proxy resolution |
+| `operator/vX.Y.Z` | the `Release` workflow | Go module proxy resolution |
+| `agent/vX.Y.Z` | the `Release` workflow | Go module proxy resolution |
+
+The sub-path tags are required because `api`, `operator`, and `agent` are
+separate Go modules that do not live at the repository root. Without them,
+`go get` of any submodule at a version fails. They are created only after
+artifact publication succeeds, and published module versions are immutable — the
+workflow validates every existing tag before pushing any new one, and refuses to
+move a tag that already points elsewhere.
+
+## Cutting a release
+
+1. Confirm `main` is green and contains everything intended for the release.
+2. Publish a [GitHub Release](https://github.com/ai-dynamo/snapshot/releases/new)
+   with a new tag `vX.Y.Z` targeting `main`, and write user-facing release notes
+   (see below).
+3. The `Release` workflow triggers on `release: published` and:
+   - runs the full validation gate against the release commit,
+   - builds and pushes the operator and agent images to
+     `ghcr.io/ai-dynamo/snapshot`,
+   - packages and pushes the Helm chart to GHCR as an OCI artifact,
+   - creates the three Go module sub-path tags.
+4. Verify the workflow succeeded and that the images and chart are pullable at
+   the new version.
+
+Artifacts are always built and published by CI from the release commit. Never
+build and push release artifacts from a local machine.
+
+## Release notes
+
+Every release gets user-facing notes describing what changed for someone
+operating Snapshot — new capabilities, behavior changes, breaking changes, and
+required upgrade actions — not a raw commit log. Call out CRD changes and any
+change to checkpoint or restore semantics explicitly, since those affect
+existing stored checkpoints.


### PR DESCRIPTION
#### What type of PR is this?

- [x] documentation

#### What this PR does / why we need it:

Follow-up to #256. Closes the four documentation gaps that only became visible once content-level scoring was working — a file-existence check can see that `CONTRIBUTING.md` exists, but not that it never describes what happens after a pull request is opened.

| File | Change |
| --- | --- |
| `RELEASE.md` (new) | Versioning (SemVer, pre-1.0, `-rcN`), the monthly release cadence, who can cut a release, the tag convention including the three Go module sub-path tags, the publish sequence, and release-note expectations. |
| `CONTRIBUTING.md` | New "How pull requests are reviewed" section: who reviews, what CI must pass, expected turnaround, how to address feedback, how to follow up on a stalled review, who merges. |
| `AGENTS.md` | New "Secrets and credentials" section — never commit keys, tokens, kubeconfigs, or `.env` files; read credentials from the environment; report a committed secret through `SECURITY.md` rather than a public revert. |
| `CODE_OF_CONDUCT.md` | Replaces the generic "contact a maintainer privately" with a specific reporting address, dbar@nvidia.com. |

`README.md` and `GOVERNANCE.md` link the new `RELEASE.md`, and `MAINTAINERS.md` carries the same reporting address as the code of conduct.

`RELEASE.md` documents the process as it exists today, read from `.github/workflows/release.yaml`: the trigger is a published GitHub Release rather than a raw tag push, the tag is validated against `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$`, and the sub-path tags are created only after artifact publication succeeds.

#### Which issue(s) this PR fixes:

Fixes #259

#### How was this tested?

Documentation only. `make verify-license-headers helm-lint verify-crds` passes locally. Full `make check` is blocked in my environment by an unrelated local protoc problem, as in #256; CI ran it green there.

#### Special notes for your reviewer:

The release cadence is confirmed: monthly, skipping a month with nothing user-visible to ship.

Two statements still describe current practice rather than facts read out of the repository, and a maintainer should confirm them:

1. **Branching** — I wrote that releases are cut from `main` with no long-lived release branches. True of the repository as it stands; correct me if a maintenance branch is planned.
2. **Release-candidate policy** — I wrote that RCs precede any release changing the CRDs or the checkpoint/restore contract. That matches the `-rc` tags in the history, but it is an inference.

Likewise the review turnaround in `CONTRIBUTING.md` is written as "aim to give a first response within a week." Adjust it to whatever the maintainers actually want to commit to — it is deliberately soft, but it is still a commitment.

#### Does this PR introduce an API change?

```release-note
NONE
```

#### Additional documentation, e.g. enhancement proposals, usage docs:
```docs

```

#### Checklist

- [x] Commits are signed off (`git commit -s`), per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `make check test` passes locally — see "How was this tested?"
- [x] Documentation is updated where behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for safely handling secrets and credentials, including storage, fixtures, and disclosure response.
  - Expanded pull request review guidance with CI requirements, reviewer responsibilities, feedback handling, and stale request procedures.
  - Added comprehensive release procedures covering versioning, cadence, release candidates, tagging, artifacts, and release notes.
  - Updated contribution and governance documentation to reference release procedures.
  - Clarified confidential conduct-violation reporting instructions and alternate contact guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->