### PR TITLE
ci: pin actions by SHA, add CodeQL, and widen Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,49 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# `cooldown` holds a newly published version back for a few days — the window in
+# which a compromised release is most likely to still be undetected. It applies
+# to version updates only; Dependabot security updates ignore it and open
+# immediately.
+
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+
+  # One entry covering all three modules: gomod resolves manifests per
+  # directory and does not follow go.work.
+  - package-ecosystem: gomod
+    directories:
+      - /api
+      - /agent
+      - /operator
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      # Minor and patch bumps land as one pull request per module. Majors stay
+      # ungrouped so each gets its own review.
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # operator/ only. agent/Dockerfile pins its CUDA base through an ARG that
+  # Dependabot cannot parse, and its ubuntu:24.04 CRIU builder must stay on the
+  # release the committed package baseline was captured against — see
+  # `make verify-base-packages`.
+  - package-ecosystem: docker
+    directory: /operator
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26.6"
           cache: true
@@ -37,8 +37,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26.6"
           cache: true
@@ -50,8 +50,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26.6"
           cache: true
@@ -68,7 +68,7 @@ jobs:
     env:
       UV_LINK_MODE: copy
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.11"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/*'
+  pull_request:
+    branches:
+      - main
+      - 'release/*'
+  # A weekly run re-analyses main against updated CodeQL queries, so a newly
+  # published rule surfaces without waiting for the next commit.
+  schedule:
+    - cron: "37 5 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Check out the source under analysis.
+      contents: read
+      # Upload the SARIF results to the code scanning API.
+      security-events: write
+      # CodeQL reads workflow run metadata to attribute results to a run.
+      actions: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # cache: false — CodeQL extracts Go source by observing the build. A warm
+      # Go build cache would make `make build` a no-op and the analysis would
+      # find no code.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.6"
+          cache: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
+        with:
+          languages: go
+          # autobuild does not resolve the api/agent/operator modules behind
+          # go.work, so the build below is the same one the CI workflow runs.
+          build-mode: manual
+
+      - name: Build
+        run: make build
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
+        with:
+          category: "/language:go"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-stale: 90
           stale-issue-label: 'lifecycle/stale'


### PR DESCRIPTION
Three supply-chain gaps found while scoring the repo against the OSS Health Scorecard.

Fixes https://github.com/ai-dynamo/snapshot/issues/270

## Pin actions by SHA

`ci.yml` and `stale.yaml` still referenced `actions/checkout`, `actions/setup-go`, and `actions/stale` by mutable tag, while `push-artifacts.yaml`, `e2e.yaml`, and `validate-issue-references.yaml` already pin by commit. A moved tag on any of those three would execute unreviewed code with the workflow's token. Every SHA here was resolved from its tag via the GitHub API.

## Add CodeQL

The repo has no SAST tool of any kind. Two details worth reviewing:

- `build-mode: manual` running `make build`, rather than `autobuild` — autobuild does not resolve the `api`/`agent`/`operator` modules behind `go.work`.
- `cache: false` on `setup-go`. CodeQL extracts Go source by observing the build; a warm Go build cache makes `make build` a no-op and the analysis then finds no code.

Runs on push and PR to `main` and `release/*`, plus weekly so a newly published query surfaces without waiting for the next commit.

## Widen Dependabot

It covered `github-actions` only, so no Go module or base-image update has ever been proposed — `govulncheck` reports Go CVEs in CI but cannot bump anything. This adds `gomod` for all three modules and `docker` for `operator/`.

`cooldown` holds a freshly published version back through the window in which a compromised release is most likely to still be undetected. It applies to version updates only; Dependabot security updates ignore it and open immediately.

`agent/Dockerfile` is deliberately excluded from the `docker` ecosystem: its CUDA base is an `ARG` Dependabot cannot parse, and its `ubuntu:24.04` CRIU builder must stay on the release the committed package baseline was captured against (`make verify-base-packages`).

## Validation

- `actionlint` clean on all three workflows
- `make verify-license-headers` passes (the new workflow carries the SPDX header `make check` requires over `.github/workflows`)
- `build-mode` and `category` confirmed as valid inputs at the pinned codeql-action SHA
- `cooldown` / `directories` schema confirmed against the Dependabot options reference

## Repo settings this depends on

Not part of this PR, but the changes are only half-effective without them:

- **Dependabot security updates are currently disabled.** This PR configures *version* updates; the security updates that bypass the cooldown on a CVE are a separate toggle.
- **CodeQL default setup must stay off** — it conflicts with this workflow-based setup.
- Separately: the `main` ruleset has no `required_status_checks` rule, so `build`/`test`/`check` are not actually enforced on `main` the way they are on `release/0.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated CodeQL scanning for Go code on key changes and a weekly schedule.
  * Strengthened CI workflows by pinning automation components to verified versions.

* **Maintenance**
  * Improved dependency update scheduling with cooldown periods and grouped updates for supported project areas.
  * Enabled scheduled Docker dependency updates for the operator component.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->