### PR TITLE
fix(agent): prevent snapshot content informer blocking

### DIFF
--- a/agent/internal/controller/controller.go
+++ b/agent/internal/controller/controller.go
@@ -53,9 +53,9 @@ import (
 
 // NodeController watches local-node pods with checkpoint metadata and reconciles
 // snapshot execution for checkpoint and restore requests. The restore path is
-// driven by a client-go pod informer; the capture path is driven by a dynamic
-// informer over PodSnapshotContent work orders filtered to this node, with typed
-// reads/writes via an uncached controller-runtime client.
+// driven by a client-go pod informer; PodSnapshotContent events feed content
+// workqueue workers, which perform typed reads/writes via an uncached controller-runtime
+// client.
 type NodeController struct {
 	config                  *types.AgentConfig
 	clientset               kubernetes.Interface
@@ -70,6 +70,7 @@ type NodeController struct {
 	writeControlSentinelFn  func(int, string) error
 	controlSentinelExistsFn func(int, string) (bool, error)
 	sendSignalFn            func(logr.Logger, int, syscall.Signal, string) error
+	contentQueue            workqueue.TypedDelayingInterface[string]
 	restoreQueue            workqueue.TypedDelayingInterface[client.ObjectKey]
 	restorePodLister        corev1listers.PodLister
 
@@ -153,6 +154,10 @@ const (
 	// snapshotContentResyncInterval re-drives every PodSnapshotContent work order so a
 	// not-yet-Ready source pod is re-checked for quiesce without a busy loop.
 	snapshotContentResyncInterval = 10 * time.Second
+	// contentWorkerCount keeps informer delivery independent of live API calls while allowing
+	// unrelated work orders to make progress when one reconciliation is stalled.
+	// When all workers are stalled, later work orders wait in the queue until a worker frees.
+	contentWorkerCount = 2
 )
 
 // podSnapshotContentGVR is the cluster-scoped resource the capture informer watches.
@@ -212,6 +217,9 @@ func newDefaultController(
 		holderID:  "snapshot-agent/" + uuid.NewString(),
 		inFlight:  make(map[string]struct{}),
 		stopCh:    make(chan struct{}),
+		contentQueue: workqueue.NewTypedDelayingQueueWithConfig(
+			workqueue.TypedDelayingQueueConfig[string]{Name: "snapshot-contents"},
+		),
 		restoreQueue: workqueue.NewTypedDelayingQueueWithConfig(
 			workqueue.TypedDelayingQueueConfig[client.ObjectKey]{Name: "restore-pods"},
 		),
@@ -227,6 +235,7 @@ func newDefaultController(
 
 // Run starts the local pod informers and processes checkpoint/restore events.
 func (w *NodeController) Run(ctx context.Context) error {
+	defer w.contentQueue.ShutDown()
 	defer w.restoreQueue.ShutDown()
 	// Seed the agent logger onto ctx so the capture path resolves it via log.FromContext.
 	ctx = logr.NewContext(ctx, w.log)
@@ -280,15 +289,9 @@ func (w *NodeController) Run(ctx context.Context) error {
 	}
 	w.contentIndexer = contentInformer.GetIndexer()
 	if _, err := contentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			if name, ok := contentNameFromInformerObj(obj); ok {
-				w.reconcilePodSnapshotContent(ctx, name)
-			}
-		},
+		AddFunc: w.enqueuePodSnapshotContent,
 		UpdateFunc: func(_, newObj interface{}) {
-			if name, ok := contentNameFromInformerObj(newObj); ok {
-				w.reconcilePodSnapshotContent(ctx, name)
-			}
+			w.enqueuePodSnapshotContent(newObj)
 		},
 	}); err != nil {
 		return fmt.Errorf("failed to add snapshot-content informer handler: %w", err)
@@ -337,6 +340,7 @@ func (w *NodeController) Run(ctx context.Context) error {
 	var stopOnce sync.Once
 	go func() {
 		<-ctx.Done()
+		w.contentQueue.ShutDown()
 		w.restoreQueue.ShutDown()
 		stopOnce.Do(func() { close(w.stopCh) })
 	}()
@@ -345,11 +349,56 @@ func (w *NodeController) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to sync informer caches")
 	}
 
+	for i := 0; i < contentWorkerCount; i++ {
+		go w.runContentQueue(ctx)
+	}
 	go w.runRestoreQueue(ctx)
 	w.log.Info("PodSnapshot node controller started and caches synced")
 	<-ctx.Done()
 	stopOnce.Do(func() { close(w.stopCh) })
 	return nil
+}
+
+// enqueuePodSnapshotContent keeps informer callbacks limited to cache-to-queue work. The live
+// client calls happen in runContentQueue workers, so one stalled reconciliation cannot block later
+// informer notifications. Filtering here also keeps terminal or foreign work out of the queue.
+func (w *NodeController) enqueuePodSnapshotContent(obj interface{}) {
+	content, ok := contentFromInformerObj(obj)
+	if !ok {
+		if name, nameOK := contentNameFromInformerObj(obj); nameOK {
+			w.log.Error(errors.New("failed to convert PodSnapshotContent informer object"),
+				"Queuing PodSnapshotContent after informer conversion failure", "content", name)
+			w.contentQueue.Add(name)
+		} else {
+			w.log.Error(errors.New("failed to identify PodSnapshotContent informer object"),
+				"Dropping unidentified PodSnapshotContent informer object")
+		}
+		return
+	}
+	if content.Spec.Source.NodeName != w.config.NodeName || !contentActionable(content) {
+		return
+	}
+	w.contentQueue.Add(content.Name)
+}
+
+// contentActionable reports whether a PodSnapshotContent can still be reconciled.
+func contentActionable(content *snapshotv1alpha1.PodSnapshotContent) bool {
+	return content.DeletionTimestamp.IsZero() && !isContentTerminal(content)
+}
+
+func (w *NodeController) runContentQueue(ctx context.Context) {
+	for {
+		name, shutdown := w.contentQueue.Get()
+		if shutdown {
+			return
+		}
+		w.processContentQueueItem(ctx, name)
+	}
+}
+
+func (w *NodeController) processContentQueueItem(ctx context.Context, name string) {
+	defer w.contentQueue.Done(name)
+	w.reconcilePodSnapshotContent(ctx, name)
 }
 
 func tweakNodePodListOptions(nodeName string) func(*metav1.ListOptions) {
@@ -1111,6 +1160,19 @@ func contentFromInformerObj(obj interface{}) (*snapshotv1alpha1.PodSnapshotConte
 	return content, true
 }
 
+// contentNameFromInformerObj extracts the name used to re-drive a work order when its cached
+// representation cannot be converted. The live typed read in the worker remains authoritative.
+func contentNameFromInformerObj(obj interface{}) (string, bool) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil || accessor.GetName() == "" {
+		return "", false
+	}
+	return accessor.GetName(), true
+}
+
 // chooseActiveContent returns the name of the oldest non-terminal PodSnapshotContent among the indexed
 // objects (oldest first by CreationTimestamp, ties broken by Name), or "" when none are active.
 // Driving the oldest until it finishes gives deterministic, stable selection across pod events.
@@ -1118,7 +1180,7 @@ func chooseActiveContent(objs []interface{}) string {
 	var chosen *snapshotv1alpha1.PodSnapshotContent
 	for _, obj := range objs {
 		content, ok := contentFromInformerObj(obj)
-		if !ok || !content.DeletionTimestamp.IsZero() || isContentTerminal(content) {
+		if !ok || !contentActionable(content) {
 			continue
 		}
 		if chosen == nil ||

--- a/agent/internal/controller/controller_test.go
+++ b/agent/internal/controller/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -21,9 +22,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	clientgotesting "k8s.io/client-go/testing"
@@ -112,10 +116,361 @@ func TestNewDefaultControllerSetsDefaultOperations(t *testing.T) {
 		noopInjector{},
 		testr.New(t),
 	)
+	t.Cleanup(w.contentQueue.ShutDown)
 	t.Cleanup(w.restoreQueue.ShutDown)
-	if w.checkpointFn == nil || w.restoreFn == nil || w.writeControlSentinelFn == nil || w.controlSentinelExistsFn == nil || w.sendSignalFn == nil || w.restoreQueue == nil {
+	if w.checkpointFn == nil || w.restoreFn == nil || w.writeControlSentinelFn == nil || w.controlSentinelExistsFn == nil || w.sendSignalFn == nil || w.contentQueue == nil || w.restoreQueue == nil {
 		t.Fatal("default controller operations must be initialized")
 	}
+}
+
+type contentInformerBarrierHarness struct {
+	t                   *testing.T
+	controller          *NodeController
+	dynamicClient       *dynamicfake.FakeDynamicClient
+	cancel              context.CancelFunc
+	runDone             chan error
+	watchStarted        chan struct{}
+	podWatchesStarted   chan struct{}
+	controllerStarted   chan struct{}
+	contentAGet         chan struct{}
+	contentBGet         chan struct{}
+	releaseContentA     chan struct{}
+	releaseContentB     chan struct{}
+	checkpointEntered   chan struct{}
+	releaseCheckpoint   chan struct{}
+	leaseCreated        chan struct{}
+	leaseDeleted        chan struct{}
+	contentReady        chan struct{}
+	contentAGetOnce     sync.Once
+	contentBGetOnce     sync.Once
+	contentBBlockOnce   sync.Once
+	checkpointOnce      sync.Once
+	leaseCreatedOnce    sync.Once
+	leaseDeletedOnce    sync.Once
+	contentReadyOnce    sync.Once
+	captureContentB     bool
+	controllerReady     atomic.Bool
+	checkpointCalls     atomic.Int32
+	contentStatusWrites atomic.Int32
+}
+
+func newContentInformerBarrierHarness(t *testing.T, captureContentB bool) *contentInformerBarrierHarness {
+	t.Helper()
+
+	h := &contentInformerBarrierHarness{
+		t:                 t,
+		watchStarted:      make(chan struct{}),
+		podWatchesStarted: make(chan struct{}),
+		controllerStarted: make(chan struct{}),
+		contentAGet:       make(chan struct{}),
+		contentBGet:       make(chan struct{}),
+		releaseContentA:   make(chan struct{}),
+		releaseContentB:   make(chan struct{}),
+		checkpointEntered: make(chan struct{}),
+		releaseCheckpoint: make(chan struct{}),
+		leaseCreated:      make(chan struct{}),
+		leaseDeleted:      make(chan struct{}),
+		contentReady:      make(chan struct{}),
+		captureContentB:   captureContentB,
+		runDone:           make(chan error, 1),
+	}
+
+	contentA := informerRaceContent("content-a", "snapshot-a")
+	contentB := informerRaceContent("content-b", "snapshot-b")
+	typedObjects := []client.Object{contentA, contentB}
+	coreObjects := []runtime.Object{}
+	if captureContentB {
+		sourcePod := informerRaceSourcePod(contentB)
+		typedObjects = append(typedObjects, sourcePod)
+		coreObjects = append(coreObjects, sourcePod.DeepCopy())
+	}
+	coreClient := fake.NewClientset(coreObjects...)
+	typedClient := ctrlfake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(typedObjects...).
+		WithStatusSubresource(&snapshotv1alpha1.PodSnapshotContent{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				content, ok := obj.(*snapshotv1alpha1.PodSnapshotContent)
+				if !ok {
+					return c.Get(ctx, key, obj, opts...)
+				}
+				if err := c.Get(ctx, key, content, opts...); err != nil {
+					return err
+				}
+				if content.UID == "" || content.Spec.PodSnapshotRef.UID == "" ||
+					content.Spec.Source.NodeName != testNodeName {
+					return fmt.Errorf("content %q is not fully node-bound", content.Name)
+				}
+				switch content.Name {
+				case contentA.Name:
+					h.contentAGetOnce.Do(func() { close(h.contentAGet) })
+					<-h.releaseContentA
+				case contentB.Name:
+					block := false
+					h.contentBBlockOnce.Do(func() {
+						block = true
+						h.contentBGetOnce.Do(func() { close(h.contentBGet) })
+					})
+					if h.captureContentB {
+						return nil
+					}
+					if block {
+						<-h.releaseContentB
+						return errors.New("injected live content Get failure")
+					}
+					return nil
+				}
+				return errors.New("injected live content Get failure")
+			},
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if err := c.Patch(ctx, obj, patch, opts...); err != nil {
+					return err
+				}
+				pod, ok := obj.(*corev1.Pod)
+				if !ok || !h.captureContentB {
+					return nil
+				}
+				stored := &corev1.Pod{}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(pod), stored); err != nil {
+					return err
+				}
+				_, err := coreClient.CoreV1().Pods(stored.Namespace).Update(ctx, stored, metav1.UpdateOptions{})
+				return err
+			},
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if _, ok := obj.(*snapshotv1alpha1.PodSnapshotContent); ok && subResourceName == "status" {
+					h.contentStatusWrites.Add(1)
+				}
+				if err := c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...); err != nil {
+					return err
+				}
+				if content, ok := obj.(*snapshotv1alpha1.PodSnapshotContent); ok &&
+					content.Name == contentB.Name && isContentReady(content) {
+					h.contentReadyOnce.Do(func() { close(h.contentReady) })
+				}
+				return nil
+			},
+		}).Build()
+
+	h.dynamicClient = dynamicfake.NewSimpleDynamicClient(testScheme(t))
+	var signalWatch sync.Once
+	h.dynamicClient.PrependWatchReactor("podsnapshotcontents", func(clientgotesting.Action) (bool, watch.Interface, error) {
+		signalWatch.Do(func() { close(h.watchStarted) })
+		return false, nil, nil
+	})
+	var podWatchCount atomic.Int32
+	var signalPodWatches sync.Once
+	coreClient.PrependWatchReactor("pods", func(clientgotesting.Action) (bool, watch.Interface, error) {
+		if podWatchCount.Add(1) == 2 {
+			signalPodWatches.Do(func() { close(h.podWatchesStarted) })
+		}
+		return false, nil, nil
+	})
+	coreClient.PrependReactor("create", "leases", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		h.leaseCreatedOnce.Do(func() { close(h.leaseCreated) })
+		return false, nil, nil
+	})
+	coreClient.PrependReactor("delete", "leases", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		h.leaseDeletedOnce.Do(func() { close(h.leaseDeleted) })
+		return false, nil, nil
+	})
+
+	h.controller = newDefaultController(
+		&types.AgentConfig{NodeName: testNodeName, Storage: types.StorageSpec{Type: "pvc", BasePath: t.TempDir()}},
+		coreClient,
+		typedClient,
+		h.dynamicClient,
+		&fakeRuntime{resolveContainerPID: 1234},
+		noopInjector{},
+		logr.New(&controllerStartedLogSink{started: h.controllerStarted, ready: &h.controllerReady}),
+	)
+	h.controller.checkpointFn = func(context.Context, CheckpointParams) error {
+		h.checkpointCalls.Add(1)
+		h.checkpointOnce.Do(func() { close(h.checkpointEntered) })
+		<-h.releaseCheckpoint
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.cancel = cancel
+	go func() { h.runDone <- h.controller.Run(ctx) }()
+	t.Cleanup(h.stop)
+	h.requireBarrier(h.watchStarted, "content informer watch did not start")
+	h.requireBarrier(h.podWatchesStarted, "pod informer watches did not start")
+	h.requireBarrier(h.controllerStarted, "node controller caches did not sync")
+	return h
+}
+
+type controllerStartedLogSink struct {
+	started chan struct{}
+	once    sync.Once
+	ready   *atomic.Bool
+}
+
+func (*controllerStartedLogSink) Init(logr.RuntimeInfo) {}
+func (*controllerStartedLogSink) Enabled(int) bool      { return true }
+func (s *controllerStartedLogSink) Info(_ int, message string, _ ...any) {
+	if message == "PodSnapshot node controller started and caches synced" {
+		s.once.Do(func() {
+			s.ready.Store(true)
+			close(s.started)
+		})
+	}
+}
+func (*controllerStartedLogSink) Error(error, string, ...any) {}
+func (s *controllerStartedLogSink) WithValues(...any) logr.LogSink {
+	return s
+}
+func (s *controllerStartedLogSink) WithName(string) logr.LogSink {
+	return s
+}
+
+func informerRaceContent(name, snapshotName string) *snapshotv1alpha1.PodSnapshotContent {
+	return &snapshotv1alpha1.PodSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			UID:    ktypes.UID(name + "-uid"),
+			Labels: map[string]string{snapshotv1alpha1.SnapshotNodeLabel: testNodeName},
+		},
+		Spec: snapshotv1alpha1.PodSnapshotContentSpec{
+			PodSnapshotRef: snapshotv1alpha1.PodSnapshotReference{
+				Namespace: "inference",
+				Name:      snapshotName,
+				UID:       ktypes.UID(snapshotName + "-uid"),
+			},
+			Source: snapshotv1alpha1.PodSnapshotContentSource{
+				PodRef: snapshotv1alpha1.PodReference{
+					Name:       "source-" + name,
+					UID:        ktypes.UID("source-" + name + "-uid"),
+					Containers: []string{"main"},
+				},
+				NodeName: testNodeName,
+			},
+		},
+	}
+}
+
+func informerRaceSourcePod(content *snapshotv1alpha1.PodSnapshotContent) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: content.Spec.PodSnapshotRef.Namespace,
+			Name:      content.Spec.Source.PodRef.Name,
+			UID:       content.Spec.Source.PodRef.UID,
+			Labels:    map[string]string{},
+		},
+		Spec: corev1.PodSpec{NodeName: testNodeName},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:        "main",
+				Ready:       true,
+				ContainerID: "containerd://content-b-container",
+				State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+}
+
+func (h *contentInformerBarrierHarness) deliver(content *snapshotv1alpha1.PodSnapshotContent) {
+	h.t.Helper()
+	_, err := h.dynamicClient.Resource(podSnapshotContentGVR).Create(
+		context.Background(), mustUnstructured(h.t, content), metav1.CreateOptions{},
+	)
+	require.NoError(h.t, err)
+}
+
+func (h *contentInformerBarrierHarness) requireBarrier(barrier <-chan struct{}, message string) {
+	h.t.Helper()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-barrier:
+		return
+	case <-timer.C:
+		require.FailNow(h.t, message)
+	}
+}
+
+func (h *contentInformerBarrierHarness) assertNoCaptureEvidence(contentName string) {
+	h.t.Helper()
+	assert.Zero(h.t, h.checkpointCalls.Load(), "checkpoint seam must not be called")
+	assert.Zero(h.t, h.contentStatusWrites.Load(), "agent must not publish Ready or Failed")
+	for _, action := range h.controller.clientset.(*fake.Clientset).Actions() {
+		assert.NotEqual(h.t, "leases", action.GetResource().Resource, "capture lease must not be accessed")
+	}
+	stored := &snapshotv1alpha1.PodSnapshotContent{}
+	err := h.controller.client.Get(context.Background(), client.ObjectKey{Name: contentName}, stored)
+	require.NoError(h.t, err)
+	assert.Nil(h.t, meta.FindStatusCondition(stored.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady), "content must have no Ready agent result")
+	assert.Nil(h.t, meta.FindStatusCondition(stored.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed), "content must have no Failed agent result")
+}
+
+func (h *contentInformerBarrierHarness) stop() {
+	closeBarrier(h.releaseContentB)
+	closeBarrier(h.releaseContentA)
+	closeBarrier(h.releaseCheckpoint)
+	h.cancel()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-h.runDone:
+		if h.controllerReady.Load() {
+			assert.NoError(h.t, err)
+		}
+	case <-timer.C:
+		h.t.Error("node controller did not stop")
+	}
+}
+
+func closeBarrier(barrier chan struct{}) {
+	select {
+	case <-barrier:
+	default:
+		close(barrier)
+	}
+}
+
+func TestNodeController_ContentInformerDoesNotBlockLaterWork(t *testing.T) {
+	t.Run("blocked reconciliation does not block later content", func(t *testing.T) {
+		h := newContentInformerBarrierHarness(t, false)
+		h.deliver(informerRaceContent("content-a", "snapshot-a"))
+		h.requireBarrier(h.contentAGet, "content A did not enter live reconciliation")
+
+		h.deliver(informerRaceContent("content-b", "snapshot-b"))
+		h.requireBarrier(h.contentBGet,
+			"content B did not reach the live Get boundary while content A reconciliation was blocked")
+		h.assertNoCaptureEvidence("content-b")
+	})
+
+	t.Run("released reconciliation allows later content", func(t *testing.T) {
+		h := newContentInformerBarrierHarness(t, false)
+		h.deliver(informerRaceContent("content-a", "snapshot-a"))
+		h.requireBarrier(h.contentAGet, "content A did not enter live reconciliation")
+		closeBarrier(h.releaseContentA)
+
+		h.deliver(informerRaceContent("content-b", "snapshot-b"))
+		h.requireBarrier(h.contentBGet,
+			"content B did not reach the live Get boundary after content A reconciliation was released")
+		h.assertNoCaptureEvidence("content-b")
+	})
+
+	t.Run("content reaches capture pipeline", func(t *testing.T) {
+		h := newContentInformerBarrierHarness(t, true)
+		h.deliver(informerRaceContent("content-b", "snapshot-b"))
+		h.requireBarrier(h.contentBGet, "content B did not reach the live Get boundary")
+		h.requireBarrier(h.leaseCreated, "content B did not acquire its capture lease")
+		h.requireBarrier(h.checkpointEntered, "content B did not reach the checkpoint seam")
+		closeBarrier(h.releaseCheckpoint)
+		h.requireBarrier(h.contentReady, "content B did not publish Ready after checkpoint success")
+		h.requireBarrier(h.leaseDeleted, "content B did not release its capture lease")
+
+		stored := &snapshotv1alpha1.PodSnapshotContent{}
+		require.NoError(t, h.controller.client.Get(context.Background(), client.ObjectKey{Name: "content-b"}, stored))
+		assert.Equal(t, int32(1), h.checkpointCalls.Load())
+		assert.NotNil(t, meta.FindStatusCondition(stored.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionReady))
+		assert.Nil(t, meta.FindStatusCondition(stored.Status.Conditions, snapshotv1alpha1.PodSnapshotConditionFailed))
+	})
 }
 
 func testScheme(t *testing.T) *runtime.Scheme {

--- a/agent/internal/controller/podsnapshotcontent.go
+++ b/agent/internal/controller/podsnapshotcontent.go
@@ -18,7 +18,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ai-dynamo/snapshot/agent/internal/executor"
@@ -49,9 +48,9 @@ type CheckpointParams struct {
 // reconcilePodSnapshotContent is the pre-bind gate for a PodSnapshotContent work order. It validates the
 // source pod (existence and provenance) and, when the pod is valid, promotes it by adding
 // CaptureEligibleLabel — it never runs the capture flow itself. The source-pod informer (keyed on that
-// label) then drives the capture path. Driven by the content informer (Add/Update) and its 10s resync;
-// the resync is the backstop that eventually writes a terminal failure for a work order whose source
-// pod is gone.
+// label) then drives the capture path. Driven by content workqueue workers fed from the content informer
+// (Add/Update) and its 10s resync; the resync is the backstop that eventually writes a terminal failure
+// for a work order whose source pod is gone.
 func (w *NodeController) reconcilePodSnapshotContent(ctx context.Context, name string) {
 	logger := logr.FromContextOrDiscard(ctx).WithValues("content", name)
 
@@ -67,10 +66,7 @@ func (w *NodeController) reconcilePodSnapshotContent(ctx context.Context, name s
 	if content.Spec.Source.NodeName != w.config.NodeName {
 		return
 	}
-	if !content.DeletionTimestamp.IsZero() {
-		return
-	}
-	if isContentTerminal(content) {
+	if !contentActionable(content) {
 		return
 	}
 
@@ -163,8 +159,8 @@ func (w *NodeController) captureLeaseHeldElsewhere(ctx context.Context, content 
 		*lease.Spec.HolderIdentity != w.holderID
 }
 
-// failContentFromGate records a terminal failure from the pre-bind gate, which has no workqueue
-// to surface errors to: a failed status write is logged and left to the informer resync.
+// failContentFromGate records a terminal failure from the pre-bind gate, which surfaces no errors
+// onto the content workqueue: a failed status write is logged and left to the informer resync.
 func (w *NodeController) failContentFromGate(ctx context.Context, content *snapshotv1alpha1.PodSnapshotContent, reason string, cause error) {
 	if err := w.setSnapshotContentFailed(ctx, content, reason, cause); err != nil {
 		logr.FromContextOrDiscard(ctx).Error(err, "Failed to write PodSnapshotContent failed status", "content", content.Name)
@@ -668,21 +664,4 @@ func artifactPresent(destination, contentUID, containerName string) bool {
 	return err == nil &&
 		manifest.Artifact.ContentUID == contentUID &&
 		manifest.Artifact.ContainerName == containerName
-}
-
-// contentNameFromInformerObj extracts the object name from a dynamic informer object,
-// handling the DeletedFinalStateUnknown tombstone.
-func contentNameFromInformerObj(obj interface{}) (string, bool) {
-	if accessor, err := meta.Accessor(obj); err == nil {
-		return accessor.GetName(), true
-	}
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-	if !ok {
-		return "", false
-	}
-	accessor, err := meta.Accessor(tombstone.Obj)
-	if err != nil {
-		return "", false
-	}
-	return accessor.GetName(), true
 }


### PR DESCRIPTION
## Summary

Fixes #302

This change deterministically reproduces node-agent PodSnapshotContent informer head-of-line blocking with a controlled live-Get barrier: before the fix, one stalled content reconciliation prevented later content from entering reconciliation and capture. The minimal production fix moves PodSnapshotContent informer events onto a deduplicating queue drained by two workers, while retaining live reads as the authoritative reconciliation state.

This also contributes to #245 (simplify the agent capture flow using a work queue): PodSnapshotContent event delivery now goes through a deduplicating work queue drained by two workers instead of synchronous informer handlers. The rest of #245's scope — replacing lease-based locking/sync and the synchronous source-pod informer — is untouched.

The local evidence proves the one-stall head-of-line blocking behavior and its correction. It does not prove that the vCluster object-modified conflict seen in the [failing Dynamo CI job](https://github.com/ai-dynamo/dynamo/actions/runs/34444478883/job/102771685192?pr=14105) was the exact production trigger. This work does not claim a full vCluster, GPU, or CRIU end-to-end reproduction.

[ai-dynamo/snapshot PR 178](https://github.com/ai-dynamo/snapshot/pull/178) was a closed draft measurement-infrastructure follow-up, not an already merged fix.

The fix has deliberately bounded scope:

- Two workers guarantee progress for the reproduced one-stall case.
- When all workers are stalled, later work orders wait in the queue until a worker frees.
- The typed client has no controller-specific request timeout.
- The separate source-pod informer remains synchronous and is outside this content-informer fix.

## Validation

Validated on the exact final tree using the running Colima Linux/aarch64 runtime, Go 1.26.6, a persistent build cache, and the host module cache mounted read-only:

- `gofmt` on all three changed files and `git diff --check`: passed with no formatting change or whitespace error.
- Native Linux/arm64 `go test -mod=readonly -count=1 ./internal/controller`: passed in 0.678s.
- `TestNodeController_ContentInformerDoesNotBlockLaterWork -count=100`: passed in 32.675s.
- The same focused test with `-race -count=10`: passed in 5.491s with no race.
- Linux/amd64 `go test -mod=readonly -c ./internal/controller` cross-compilation: passed; output was written outside the repository.
- no-mistakes AXI run `01M2606X3XM0WMMPY8MTN1JBEY`: reached `checks-passed`. Automated review reported only the two independently accepted informational no-op scope limitations above; test, documentation, and lint stages passed with zero findings and no pipeline-authored repository or commit change; all visible CI checks passed.


