### PR TITLE
refactor(agent): isolate cuinterpose host-carrier storage

### DIFF
--- a/agent/cmd/cuinterpose/Makefile
+++ b/agent/cmd/cuinterpose/Makefile
@@ -120,7 +120,7 @@ PRELOAD_TESTS := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/*_preload_
 COORDINATOR_TEST := $(patsubst tests/%.cc,$(TEST_DIR)/%,$(wildcard tests/coordinator_test.cc))
 # Shim sources that need no CUDA driver at run time. symbols.c and context.c
 # resolve driver symbols and are exercised through the preload tests.
-UNIT_SOURCES := $(filter-out coordinator.c interpose.c multicast.c symbols.c context.c,$(wildcard *.c)) $(UTIL_SOURCES)
+UNIT_SOURCES := $(filter-out coordinator.c interpose.c multicast.c symbols.c context.c host_carrier.c,$(wildcard *.c)) $(UTIL_SOURCES)
 UNIT_OBJECTS := $(patsubst %.c,$(TEST_DIR)/%.o,$(UNIT_SOURCES))
 # When the shim under test is ASan-instrumented, the ASan runtime must be the
 # first library in the process, ahead of the shim itself.

--- a/agent/cmd/cuinterpose/context.c
+++ b/agent/cmd/cuinterpose/context.c
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "context.h"
+
+#include <string.h>
+
+#include "symbols.h"
+
+typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+typedef CUresult(CUDAAPI* context_set_fn)(CUcontext);
+typedef CUresult(CUDAAPI* primary_retain_fn)(CUcontext*, CUdevice);
+typedef CUresult(CUDAAPI* primary_release_fn)(CUdevice);
+
+void
+cuinterpose_capture_context(CUcontext* context)
+{
+  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
+  CUcontext current = NULL;
+
+  *context = get_current != NULL && get_current(&current) == CUDA_SUCCESS ? current : NULL;
+}
+
+static void
+release_primary(struct cuinterpose_context_scope* scope)
+{
+  primary_release_fn release = (primary_release_fn)cuinterpose_lookup_real_symbol("cuDevicePrimaryCtxRelease_v2");
+
+  if (scope->retained_primary && release != NULL)
+    (void)release(scope->primary_device);
+  scope->retained_primary = false;
+}
+
+int
+cuinterpose_enter_context(CUcontext context, CUdevice fallback_device, struct cuinterpose_context_scope* scope)
+{
+  context_get_fn get_current = (context_get_fn)cuinterpose_lookup_real_symbol("cuCtxGetCurrent");
+  context_set_fn set_current = (context_set_fn)cuinterpose_lookup_real_symbol("cuCtxSetCurrent");
+
+  memset(scope, 0, sizeof(*scope));
+  if (get_current == NULL || set_current == NULL)
+    return -1;
+  if (context == NULL) {
+    primary_retain_fn retain = (primary_retain_fn)cuinterpose_lookup_real_symbol("cuDevicePrimaryCtxRetain");
+
+    if (retain == NULL || fallback_device == CUINTERPOSE_NO_DEVICE || retain(&context, fallback_device) != CUDA_SUCCESS ||
+        context == NULL)
+      return -1;
+    scope->retained_primary = true;
+    scope->primary_device = fallback_device;
+  }
+  if (get_current(&scope->previous) != CUDA_SUCCESS) {
+    release_primary(scope);
+    return -1;
+  }
+  if (scope->previous != context) {
+    if (set_current(context) != CUDA_SUCCESS) {
+      release_primary(scope);
+      return -1;
+    }
+    scope->changed = true;
+  }
+  return 0;
+}
+
+int
+cuinterpose_leave_context(struct cuinterpose_context_scope* scope)
+{
+  context_set_fn set_current = (context_set_fn)cuinterpose_lookup_real_symbol("cuCtxSetCurrent");
+  int result = !scope->changed || (set_current != NULL && set_current(scope->previous) == CUDA_SUCCESS) ? 0 : -1;
+
+  release_primary(scope);
+  return result;
+}

--- a/agent/cmd/cuinterpose/context.h
+++ b/agent/cmd/cuinterpose/context.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_CONTEXT_H
+#define CUINTERPOSE_CONTEXT_H
+
+#include <cuda.h>
+#include <stdbool.h>
+
+/*
+ * Driver calls that act on an allocation or a multicast object must run in the
+ * CUDA context it belongs to. The shim remembers that context when it can
+ * (create, import, first map or export) and switches to it for the duration
+ * of a scope during checkpoint and restore, switching back afterwards.
+ */
+
+#define CUINTERPOSE_NO_DEVICE ((CUdevice)-1)
+
+struct cuinterpose_context_scope {
+  CUcontext previous;
+  bool changed;
+  bool retained_primary; /* the device's primary context was retained for this scope */
+  CUdevice primary_device;
+};
+
+/* Remembers the current context, or NULL when there is none. */
+void cuinterpose_capture_context(CUcontext* context);
+
+/*
+ * Makes `context` current. When it is NULL (the object never had a context)
+ * and fallback_device is a real device, that device's primary context is
+ * retained for the scope and released on leave. Returns -1 on failure.
+ */
+int cuinterpose_enter_context(
+    CUcontext context, CUdevice fallback_device, struct cuinterpose_context_scope* scope);
+int cuinterpose_leave_context(struct cuinterpose_context_scope* scope);
+
+#endif

--- a/agent/cmd/cuinterpose/host_carrier.c
+++ b/agent/cmd/cuinterpose/host_carrier.c
@@ -1,0 +1,593 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "host_carrier.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+
+#include "context.h"
+#include "symbols.h"
+#include "util/cleanup.h"
+#include "util/time.h"
+
+typedef CUresult(CUDAAPI* create_fn)(
+    CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+typedef CUresult(CUDAAPI* release_fn)(CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* address_reserve_fn)(CUdeviceptr*, size_t, size_t, CUdeviceptr, unsigned long long);
+typedef CUresult(CUDAAPI* address_free_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* map_fn)(
+    CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+typedef CUresult(CUDAAPI* unmap_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* access_fn)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+typedef CUresult(CUDAAPI* host_register_fn)(void*, size_t, unsigned int);
+typedef CUresult(CUDAAPI* host_unregister_fn)(void*);
+typedef CUresult(CUDAAPI* host_get_flags_fn)(unsigned int*, void*);
+typedef CUresult(CUDAAPI* copy_dtoh_async_fn)(void*, CUdeviceptr, size_t, CUstream);
+typedef CUresult(CUDAAPI* copy_htod_async_fn)(CUdeviceptr, const void*, size_t, CUstream);
+typedef CUresult(CUDAAPI* stream_create_fn)(CUstream*, unsigned int);
+typedef CUresult(CUDAAPI* stream_synchronize_fn)(CUstream);
+typedef CUresult(CUDAAPI* stream_destroy_fn)(CUstream);
+
+/*
+ * One anonymous arena per process is registered once as portable pinned
+ * memory. CRIU captures it with the process image. Allocations sharing a CUDA
+ * context are staged into one contiguous device VA range and copied on one
+ * stream, avoiding per-allocation registration, mapping, and synchronization.
+ */
+struct carrier_arena {
+  void* base;
+  size_t size;
+  CUcontext context;
+  CUdevice device;
+};
+
+struct staging_range {
+  CUdeviceptr base;
+  size_t size;
+};
+
+static struct carrier_arena arena;
+
+static CUdevice
+fallback_device(const struct cuinterpose_host_carrier_allocation* allocation)
+{
+  return allocation->properties.location.type == CU_MEM_LOCATION_TYPE_DEVICE
+             ? (CUdevice)allocation->properties.location.id
+             : CUINTERPOSE_NO_DEVICE;
+}
+
+static int
+enter_context(
+    const struct cuinterpose_host_carrier_allocation* allocation,
+    struct cuinterpose_context_scope* scope)
+{
+  return cuinterpose_enter_context(allocation->context, fallback_device(allocation), scope);
+}
+
+static int
+compare_by_context(const void* left, const void* right)
+{
+  uintptr_t a =
+      (uintptr_t)((const struct cuinterpose_host_carrier_allocation*)left)->context;
+  uintptr_t b =
+      (uintptr_t)((const struct cuinterpose_host_carrier_allocation*)right)->context;
+
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+static int
+prepare_allocations(
+    struct cuinterpose_host_carrier_allocation* allocations, size_t count,
+    uint64_t* total, const char** error)
+{
+  size_t index;
+
+  *total = 0;
+  for (index = 0; index < count; index++) {
+    if (allocations[index].size == 0 || allocations[index].device_handle == NULL ||
+        allocations[index].host_address == NULL ||
+        UINT64_MAX - *total < allocations[index].size) {
+      *error = "invalid host carrier allocation";
+      return -1;
+    }
+    *total += allocations[index].size;
+  }
+  if (*total > SIZE_MAX) {
+    *error = "host carrier arena is too large";
+    return -1;
+  }
+  qsort(allocations, count, sizeof(*allocations), compare_by_context);
+  return 0;
+}
+
+static size_t
+context_batch_end(
+    const struct cuinterpose_host_carrier_allocation* allocations, size_t count,
+    size_t begin, size_t* bytes)
+{
+  size_t end = begin;
+
+  *bytes = 0;
+  while (end < count && allocations[end].context == allocations[begin].context) {
+    *bytes += allocations[end].size;
+    end++;
+  }
+  return end;
+}
+
+/*
+ * Map a context batch at consecutive offsets and grant access from each
+ * allocation's original location. Nothing remains mapped on failure.
+ */
+static CUresult
+map_staging_range(
+    const struct cuinterpose_host_carrier_allocation* allocations,
+    const CUmemGenericAllocationHandle* handles, size_t count, size_t total,
+    struct staging_range* range)
+{
+  address_reserve_fn reserve =
+      (address_reserve_fn)cuinterpose_lookup_real_symbol("cuMemAddressReserve");
+  address_free_fn free_address =
+      (address_free_fn)cuinterpose_lookup_real_symbol("cuMemAddressFree");
+  map_fn map = (map_fn)cuinterpose_lookup_real_symbol("cuMemMap");
+  unmap_fn unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  access_fn set_access =
+      (access_fn)cuinterpose_lookup_real_symbol("cuMemSetAccess");
+  size_t offset = 0;
+  size_t mapped = 0;
+  size_t index;
+  CUresult result;
+
+  memset(range, 0, sizeof(*range));
+  if (reserve == NULL || free_address == NULL || map == NULL || unmap == NULL ||
+      set_access == NULL)
+    return CUDA_ERROR_NOT_INITIALIZED;
+  result = reserve(&range->base, total, 0, 0, 0);
+  if (result != CUDA_SUCCESS) {
+    range->base = 0;
+    return result;
+  }
+  for (index = 0; index < count; index++) {
+    CUmemAccessDesc access;
+
+    result = map(range->base + offset, allocations[index].size, 0, handles[index], 0);
+    if (result != CUDA_SUCCESS)
+      break;
+    mapped = offset + allocations[index].size;
+    memset(&access, 0, sizeof(access));
+    access.location = allocations[index].properties.location;
+    access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    result = set_access(range->base + offset, allocations[index].size, &access, 1);
+    if (result != CUDA_SUCCESS)
+      break;
+    offset = mapped;
+  }
+  if (result != CUDA_SUCCESS) {
+    if (mapped != 0)
+      (void)unmap(range->base, mapped);
+    (void)free_address(range->base, total);
+    range->base = 0;
+    return result;
+  }
+  range->size = total;
+  return CUDA_SUCCESS;
+}
+
+static void
+unmap_staging_range(struct staging_range* range)
+{
+  unmap_fn unmap;
+  address_free_fn free_address;
+
+  if (range->base == 0)
+    return;
+  unmap = (unmap_fn)cuinterpose_lookup_real_symbol("cuMemUnmap");
+  free_address = (address_free_fn)cuinterpose_lookup_real_symbol("cuMemAddressFree");
+  if (unmap != NULL)
+    (void)unmap(range->base, range->size);
+  if (free_address != NULL)
+    (void)free_address(range->base, range->size);
+  memset(range, 0, sizeof(*range));
+}
+
+struct save_operation {
+  struct cuinterpose_host_carrier_allocation* allocations;
+  size_t count;
+  host_unregister_fn unregister_host;
+  stream_destroy_fn stream_destroy;
+  struct cuinterpose_context_scope scope;
+  struct staging_range range;
+  CUmemGenericAllocationHandle* handles;
+  CUstream stream;
+  void* base;
+  uint64_t total;
+  bool entered;
+  bool registered;
+  bool rollback;
+  bool committed;
+};
+
+static void
+save_operation_release(struct save_operation* operation)
+{
+  size_t index;
+
+  unmap_staging_range(&operation->range);
+  if (operation->stream != NULL && operation->stream_destroy != NULL)
+    (void)operation->stream_destroy(operation->stream);
+  if (operation->rollback && !operation->committed) {
+    if (operation->registered) {
+      if (!operation->entered && operation->count != 0 &&
+          enter_context(&operation->allocations[0], &operation->scope) == 0)
+        operation->entered = true;
+      (void)operation->unregister_host(operation->base);
+    }
+    if (operation->base != MAP_FAILED)
+      munmap(operation->base, (size_t)operation->total);
+    for (index = 0; index < operation->count; index++)
+      *operation->allocations[index].host_address = NULL;
+  }
+  if (operation->entered)
+    (void)cuinterpose_leave_context(&operation->scope);
+  free(operation->handles);
+}
+
+struct load_operation {
+  struct cuinterpose_host_carrier_allocation* allocations;
+  size_t count;
+  release_fn release;
+  stream_destroy_fn stream_destroy;
+  struct cuinterpose_context_scope scope;
+  struct staging_range range;
+  CUmemGenericAllocationHandle* fresh;
+  CUstream stream;
+  bool entered;
+  bool committed;
+};
+
+static void
+load_operation_release(struct load_operation* operation)
+{
+  size_t index;
+
+  unmap_staging_range(&operation->range);
+  if (operation->stream != NULL && operation->stream_destroy != NULL)
+    (void)operation->stream_destroy(operation->stream);
+  if (!operation->committed && operation->fresh != NULL) {
+    for (index = 0; index < operation->count; index++) {
+      if (operation->fresh[index] != 0)
+        (void)operation->release(operation->fresh[index]);
+    }
+  }
+  if (operation->entered)
+    (void)cuinterpose_leave_context(&operation->scope);
+  free(operation->fresh);
+}
+
+int
+cuinterpose_host_carrier_save(
+    struct cuinterpose_host_carrier_allocation* allocations, size_t count,
+    uint64_t* bytes, uint32_t* copy_us, const char** error)
+{
+  host_register_fn register_host =
+      (host_register_fn)cuinterpose_lookup_real_symbol("cuMemHostRegister_v2");
+  host_unregister_fn unregister_host =
+      (host_unregister_fn)cuinterpose_lookup_real_symbol("cuMemHostUnregister");
+  copy_dtoh_async_fn copy =
+      (copy_dtoh_async_fn)cuinterpose_lookup_real_symbol("cuMemcpyDtoHAsync_v2");
+  stream_create_fn stream_create =
+      (stream_create_fn)cuinterpose_lookup_real_symbol("cuStreamCreate");
+  stream_synchronize_fn stream_synchronize =
+      (stream_synchronize_fn)cuinterpose_lookup_real_symbol("cuStreamSynchronize");
+  stream_destroy_fn stream_destroy =
+      (stream_destroy_fn)cuinterpose_lookup_real_symbol("cuStreamDestroy_v2");
+  CUINTERPOSE_CLEANUP(save_operation_release) struct save_operation operation = {
+      .allocations = allocations,
+      .count = count,
+      .unregister_host = unregister_host,
+      .stream_destroy = stream_destroy,
+      .base = MAP_FAILED,
+  };
+  size_t placed = 0;
+  size_t begin;
+  size_t end;
+  size_t index;
+  double copy_time = 0.0;
+
+  *bytes = 0;
+  *copy_us = 0;
+  *error = "host carrier symbols are unavailable";
+  if (register_host == NULL || unregister_host == NULL || copy == NULL ||
+      stream_create == NULL || stream_synchronize == NULL || stream_destroy == NULL)
+    return -1;
+  if (count == 0) {
+    *error = NULL;
+    return 0;
+  }
+  if (arena.base != NULL) {
+    *error = "a host carrier arena already exists";
+    return -1;
+  }
+  if (prepare_allocations(allocations, count, &operation.total, error) != 0)
+    return -1;
+  for (index = 0; index < count; index++) {
+    if (*allocations[index].device_handle == 0) {
+      *error = "creator allocation has no device handle";
+      return -1;
+    }
+  }
+  operation.handles = calloc(count, sizeof(*operation.handles));
+  if (operation.handles == NULL) {
+    *error = "cannot allocate host carrier handles";
+    return -1;
+  }
+  operation.rollback = true;
+  operation.base = mmap(
+      NULL, (size_t)operation.total, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
+  if (operation.base == MAP_FAILED) {
+    *error = "cannot allocate host carrier memory";
+    return -1;
+  }
+
+  for (begin = 0; begin < count; begin = end) {
+    struct timespec started;
+    struct timespec finished;
+    size_t batch_bytes;
+    size_t offset = 0;
+
+    end = context_batch_end(allocations, count, begin, &batch_bytes);
+    if (enter_context(&allocations[begin], &operation.scope) != 0) {
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    operation.entered = true;
+    if (!operation.registered) {
+      if (register_host(operation.base, (size_t)operation.total, CU_MEMHOSTREGISTER_PORTABLE) !=
+          CUDA_SUCCESS) {
+        *error = "cannot pin host carrier memory";
+        return -1;
+      }
+      operation.registered = true;
+    }
+    for (index = begin; index < end; index++)
+      operation.handles[index] = *allocations[index].device_handle;
+    if (map_staging_range(
+            &allocations[begin], &operation.handles[begin], end - begin, batch_bytes,
+            &operation.range) != CUDA_SUCCESS) {
+      *error = "cannot map creator allocations for the host copy";
+      return -1;
+    }
+    if (stream_create(&operation.stream, CU_STREAM_NON_BLOCKING) != CUDA_SUCCESS) {
+      operation.stream = NULL;
+      *error = "cannot create the host carrier stream";
+      return -1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &started);
+    for (index = begin; index < end; index++) {
+      void* host = (char*)operation.base + placed;
+
+      if (copy(host, operation.range.base + offset, allocations[index].size, operation.stream) !=
+          CUDA_SUCCESS) {
+        *error = "device-to-host copy failed";
+        return -1;
+      }
+      *allocations[index].host_address = host;
+      placed += allocations[index].size;
+      offset += allocations[index].size;
+    }
+    if (stream_synchronize(operation.stream) != CUDA_SUCCESS) {
+      *error = "device-to-host copies did not complete";
+      return -1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &finished);
+    copy_time += elapsed_milliseconds(&started, &finished);
+    *bytes += batch_bytes;
+    unmap_staging_range(&operation.range);
+    (void)stream_destroy(operation.stream);
+    operation.stream = NULL;
+    operation.entered = false;
+    if (cuinterpose_leave_context(&operation.scope) != 0) {
+      *error = "cannot leave the allocation's CUDA context";
+      return -1;
+    }
+  }
+  arena.base = operation.base;
+  arena.size = (size_t)operation.total;
+  arena.context = allocations[0].context;
+  arena.device = fallback_device(&allocations[0]);
+  operation.committed = true;
+  *copy_us = (uint32_t)(copy_time * 1e3 + 0.5);
+  *error = NULL;
+  return 0;
+}
+
+int
+cuinterpose_host_carrier_load(
+    struct cuinterpose_host_carrier_allocation* allocations, size_t count,
+    uint64_t* bytes, uint32_t* copy_us, const char** error)
+{
+  create_fn create = (create_fn)cuinterpose_lookup_real_symbol("cuMemCreate");
+  release_fn release =
+      (release_fn)cuinterpose_lookup_real_symbol("cuMemRelease");
+  host_register_fn register_host =
+      (host_register_fn)cuinterpose_lookup_real_symbol("cuMemHostRegister_v2");
+  host_get_flags_fn host_flags =
+      (host_get_flags_fn)cuinterpose_lookup_real_symbol("cuMemHostGetFlags");
+  copy_htod_async_fn copy =
+      (copy_htod_async_fn)cuinterpose_lookup_real_symbol("cuMemcpyHtoDAsync_v2");
+  stream_create_fn stream_create =
+      (stream_create_fn)cuinterpose_lookup_real_symbol("cuStreamCreate");
+  stream_synchronize_fn stream_synchronize =
+      (stream_synchronize_fn)cuinterpose_lookup_real_symbol("cuStreamSynchronize");
+  stream_destroy_fn stream_destroy =
+      (stream_destroy_fn)cuinterpose_lookup_real_symbol("cuStreamDestroy_v2");
+  CUINTERPOSE_CLEANUP(load_operation_release) struct load_operation operation = {
+      .allocations = allocations,
+      .count = count,
+      .release = release,
+      .stream_destroy = stream_destroy,
+  };
+  uint64_t total = 0;
+  size_t begin;
+  size_t end;
+  size_t index;
+  double copy_time = 0.0;
+  bool registration_checked = false;
+
+  *bytes = 0;
+  *copy_us = 0;
+  *error = "host carrier symbols are unavailable";
+  if (create == NULL || release == NULL || register_host == NULL || copy == NULL ||
+      stream_create == NULL || stream_synchronize == NULL || stream_destroy == NULL)
+    return -1;
+  if (count == 0) {
+    *error = NULL;
+    return 0;
+  }
+  if (prepare_allocations(allocations, count, &total, error) != 0)
+    return -1;
+  if (arena.base == NULL || arena.size != total) {
+    *error = "host carrier arena is missing";
+    return -1;
+  }
+  for (index = 0; index < count; index++) {
+    if (*allocations[index].host_address == NULL) {
+      *error = "host carrier allocation is missing";
+      return -1;
+    }
+  }
+  operation.fresh = calloc(count, sizeof(*operation.fresh));
+  if (operation.fresh == NULL) {
+    *error = "cannot allocate fresh handles";
+    return -1;
+  }
+
+  for (begin = 0; begin < count; begin = end) {
+    struct timespec started;
+    struct timespec finished;
+    size_t batch_bytes;
+    size_t offset = 0;
+
+    end = context_batch_end(allocations, count, begin, &batch_bytes);
+    if (enter_context(&allocations[begin], &operation.scope) != 0) {
+      *error = "cannot enter the allocation's CUDA context";
+      return -1;
+    }
+    operation.entered = true;
+    if (!registration_checked) {
+      unsigned int flags = 0;
+
+      if (host_flags == NULL ||
+          host_flags(&flags, arena.base) != CUDA_SUCCESS) {
+        if (register_host(
+                arena.base, arena.size, CU_MEMHOSTREGISTER_PORTABLE) !=
+            CUDA_SUCCESS) {
+          *error = "cannot pin host carrier memory for the copy back";
+          return -1;
+        }
+        fprintf(
+            stderr,
+            "cuinterpose: host carrier registration did not survive restore; "
+            "re-registered\n");
+      }
+      registration_checked = true;
+      arena.context = allocations[begin].context;
+      arena.device = fallback_device(&allocations[begin]);
+    }
+    for (index = begin; index < end; index++) {
+      if (create(
+              &operation.fresh[index], allocations[index].size,
+              &allocations[index].properties, 0) != CUDA_SUCCESS) {
+        operation.fresh[index] = 0;
+        *error = "cannot create fresh device memory for a creator allocation";
+        return -1;
+      }
+    }
+    if (map_staging_range(
+            &allocations[begin], &operation.fresh[begin], end - begin, batch_bytes,
+            &operation.range) != CUDA_SUCCESS) {
+      *error = "cannot map fresh device memory for the copy back";
+      return -1;
+    }
+    if (stream_create(&operation.stream, CU_STREAM_NON_BLOCKING) != CUDA_SUCCESS) {
+      operation.stream = NULL;
+      *error = "cannot create the host carrier stream";
+      return -1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &started);
+    for (index = begin; index < end; index++) {
+      if (copy(
+              operation.range.base + offset, *allocations[index].host_address,
+              allocations[index].size, operation.stream) != CUDA_SUCCESS) {
+        *error = "host-to-device copy failed";
+        return -1;
+      }
+      offset += allocations[index].size;
+    }
+    if (stream_synchronize(operation.stream) != CUDA_SUCCESS) {
+      *error = "host-to-device copies did not complete";
+      return -1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &finished);
+    copy_time += elapsed_milliseconds(&started, &finished);
+    *bytes += batch_bytes;
+    unmap_staging_range(&operation.range);
+    (void)stream_destroy(operation.stream);
+    operation.stream = NULL;
+    operation.entered = false;
+    if (cuinterpose_leave_context(&operation.scope) != 0) {
+      *error = "cannot leave the allocation's CUDA context";
+      return -1;
+    }
+  }
+
+  /* Publish fresh handles only after every copy completed. */
+  for (index = 0; index < count; index++) {
+    *allocations[index].device_handle = operation.fresh[index];
+    operation.fresh[index] = 0;
+    *allocations[index].host_address = NULL;
+  }
+  operation.committed = true;
+  *copy_us = (uint32_t)(copy_time * 1e3 + 0.5);
+  *error = NULL;
+  return 0;
+}
+
+void
+cuinterpose_host_carrier_release(void)
+{
+  host_unregister_fn unregister_host =
+      (host_unregister_fn)cuinterpose_lookup_real_symbol("cuMemHostUnregister");
+  struct cuinterpose_context_scope scope;
+  struct carrier_arena local = arena;
+
+  memset(&arena, 0, sizeof(arena));
+  if (local.base == NULL)
+    return;
+  if (unregister_host != NULL &&
+      cuinterpose_enter_context(local.context, local.device, &scope) == 0) {
+    (void)unregister_host(local.base);
+    (void)cuinterpose_leave_context(&scope);
+  }
+  munmap(local.base, local.size);
+}
+
+void
+cuinterpose_host_carrier_fork_child(void)
+{
+  if (arena.base != NULL)
+    munmap(arena.base, arena.size);
+  memset(&arena, 0, sizeof(arena));
+}

--- a/agent/cmd/cuinterpose/host_carrier.h
+++ b/agent/cmd/cuinterpose/host_carrier.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUINTERPOSE_HOST_CARRIER_H
+#define CUINTERPOSE_HOST_CARRIER_H
+
+#include <cuda.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * The host-carrier module owns the temporary storage and CUDA copy mechanics
+ * used to preserve exportable allocation contents. The caller owns allocation
+ * eligibility and lifecycle; pointers let the module publish host addresses
+ * and fresh device handles only after a complete batch succeeds.
+ */
+struct cuinterpose_host_carrier_allocation {
+  CUcontext context;
+  CUmemAllocationProp properties;
+  size_t size;
+  CUmemGenericAllocationHandle* device_handle;
+  void** host_address;
+};
+
+int cuinterpose_host_carrier_save(
+    struct cuinterpose_host_carrier_allocation* allocations, size_t count, uint64_t* bytes,
+    uint32_t* copy_us, const char** error);
+int cuinterpose_host_carrier_load(
+    struct cuinterpose_host_carrier_allocation* allocations, size_t count, uint64_t* bytes,
+    uint32_t* copy_us, const char** error);
+
+/* Release the restored arena after LOAD_ALLOCATIONS has replied. */
+void cuinterpose_host_carrier_release(void);
+/* A fork child cannot use inherited CUDA registration; discard CPU state only. */
+void cuinterpose_host_carrier_fork_child(void);
+
+#endif


### PR DESCRIPTION
## Summary

Layer 8 of the eleven-PR [cuinterpose stack #293](https://github.com/ai-dynamo/snapshot/stack/293). Closed PR #214 is intentionally not in the active stack.

This PR isolates the current allocation-content transport in `host_carrier.c`/`.h`, with CUDA context scoping in `context.c`/`.h`. It does not add lifecycle operations, change allocation eligibility, introduce a backend registry, or add a save-all flag. #218 calls this concrete module from the generic `SAVE_ALLOCATIONS` and `LOAD_ALLOCATIONS` operations.

The public surface is deliberately small: save a batch, load a batch, release restored storage, and discard inherited CPU-side state after `fork`. The lifecycle caller supplies each allocation's context, properties, size, device-handle pointer, and host-address pointer; it remains responsible for eligibility, mappings, access grants, export caches, and importer topology.

On save, the module creates one anonymous host arena per shim process and registers it as portable pinned memory. It groups allocations by CUDA context, maps each group into a contiguous temporary device VA range, and copies D2H on one nonblocking stream with one synchronization per group. CRIU captures the arena as ordinary process memory.

On load, the module verifies or recreates host registration, creates fresh physical allocations with the original properties, stages each context group, copies H2D, and publishes fresh handles only after the complete batch succeeds. Save and load each use an explicit operation-state object with scoped cleanup and direct returns, so partial failures release fresh handles and partial host state without `goto`. The adjacent context helper restores the caller's prior context and can retain a device primary context when tracking never observed one.

## PageBroker boundary

This is a replacement seam, not a speculative pluggable framework. PageBroker currently implements only `TransferEngineType::POSIX_COPY` and registers only `PosixCopyEngine`; its protobuf reserves `DirectRestoreRequest` for a future GPU engine. There is no GPU engine to integrate with today.

When PageBroker defines a GPU/direct engine and a transaction contract for allocation IDs, content, and completion barriers, the two host-carrier lifecycle calls are the intended replacement point. Tickets, participant identity, topology records, and coordinator ordering should not need to become PageBroker-aware.

## Stack boundary

Based on #217. #218 owns which supported exportable allocations preserve content and composes this module with unicast teardown, creator publication, and importer reconstruction.

## Validation

The pinned CUDA 13.1 builder compiles `host_carrier.c` into the production shim with `-Werror`. The #218 lifecycle suite exercises successful save/load, context grouping, missing registration recovery, failure cleanup, and fork behavior through the fake CUDA driver; the final stack passes all 4 lifecycle tests under ASan/UBSan. `make test` passes in all Go modules. The final published stack head `0eae9c4f9b66093332f00a332afaf56048e1e64a` passed the full `make check` gate, the CUDA 13.1 production build, and all 73 sanitizer-backed native cuinterpose tests. Its physical-GPU suite passed all 3 tests with no skips on two DRA-assigned NVIDIA B200 GPUs. The unicast test kept an explicit allocation-ID ticket-backed peer mapping per worker live across capture and restore; the multicast test required a nonzero multicast VA and shim-logical handle, exercised `BindAddr`, and passed its collective and captured-graph replay. Detailed hardware evidence and measurements are in #220.



